### PR TITLE
docs: add governed apple-mcp roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 build/
 .DS_Store
+messages/messages-export.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 build/
 .DS_Store
 messages/messages-export.json
+shell/.build/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 .DS_Store
 messages/messages-export.json
 shell/.build/
+artifacts/

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,37 +3,52 @@
     "apple-notes": {
       "type": "stdio",
       "command": "node",
-      "args": ["/Users/garyriches/Documents/Source/MCP/Apple/notes/build/index.js"]
+      "args": ["/Users/david/Desktop/github/apple-mcp/notes/build/index.js"]
     },
     "apple-messages": {
       "type": "stdio",
       "command": "node",
-      "args": ["/Users/garyriches/Documents/Source/MCP/Apple/messages/build/index.js"]
+      "args": ["/Users/david/Desktop/github/apple-mcp/messages/build/index.js"]
     },
     "apple-contacts": {
       "type": "stdio",
       "command": "node",
-      "args": ["/Users/garyriches/Documents/Source/MCP/Apple/contacts/build/index.js"]
+      "args": ["/Users/david/Desktop/github/apple-mcp/contacts/build/index.js"]
     },
     "apple-reminders": {
       "type": "stdio",
       "command": "node",
-      "args": ["/Users/garyriches/Documents/Source/MCP/Apple/reminders/build/index.js"]
+      "args": ["/Users/david/Desktop/github/apple-mcp/reminders/build/index.js"]
     },
     "apple-calendar": {
       "type": "stdio",
       "command": "node",
-      "args": ["/Users/garyriches/Documents/Source/MCP/Apple/calendar/build/index.js"]
+      "args": ["/Users/david/Desktop/github/apple-mcp/calendar/build/index.js"]
     },
     "apple-maps": {
       "type": "stdio",
       "command": "node",
-      "args": ["/Users/garyriches/Documents/Source/MCP/Apple/maps/build/index.js"]
+      "args": ["/Users/david/Desktop/github/apple-mcp/maps/build/index.js"]
     },
     "apple-mail": {
       "type": "stdio",
       "command": "node",
-      "args": ["/Users/garyriches/Documents/Source/MCP/Apple/mail/build/index.js"]
+      "args": ["/Users/david/Desktop/github/apple-mcp/mail/build/index.js"]
+    },
+    "apple-music": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/Users/david/Desktop/github/apple-mcp/music/build/index.js"]
+    },
+    "mail-intelligence": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/Users/david/Desktop/github/apple-mcp/mail-intelligence/build/index.js"]
+    },
+    "knowledge-corpus": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/Users/david/Desktop/github/apple-mcp/knowledge-corpus/build/index.js"]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 
 ## Current Plan
 - `docs/plans/2026-03-13-apple-mcp-governed-roadmap.md` | governed sequencing document for hydration, shell, intelligence, and packaging work
+- `docs/plans/2026-03-13-deterministic-hydration-spine-implementation-packet.md` | immediate implementation packet scoped to source spine, SignalDocument, Desktop/filesystem ingest, evidence, and compiler skeleton
 
 ## Canonical Brain
 | System | Role |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# Memory
+
+## Repo
+`apple-mcp` contains standalone MCP servers for Apple apps plus higher-level automation packages built on top of Mail and Notes.
+
+## Canonical Brain
+| System | Role |
+|------|------|
+| `knowledge-corpus/data/mojosolo_operating_brain.json` | Canonical brain and single source of truth |
+| `mail-intelligence` | Live Apple Mail sensor and Daily Intel generator that reads from the canonical brain |
+| Laravel | Primary application and API layer projected from the canonical brain |
+
+## Email Personas
+| Account | Persona | Role |
+|-----|------|------|
+| `mojosolo@mac.com` | The Author | Curated creative and intellectual intake |
+| `david@mojosolo.com` | The Operator | Primary human-facing reply-from account for clients, partners, and deals |
+| `info@mojosolo.com` | The Machine | Catch-all campaign aliases, client workflow intake, and automated/platform signals |
+| -> Full context | `memory/context/email-personas.md` | Durable account architecture and routing assumptions |
+
+## Terms
+| Term | Meaning |
+|------|---------|
+| Daily Intel | Superhuman-style synthesized daily brief generated from all three inboxes |
+| The Author | `mojosolo@mac.com`, used for curated reading and creative input |
+| The Operator | `david@mojosolo.com`, used for human relationships and primary outbound identity |
+| The Machine | `info@mojosolo.com`, used for catch-all aliases, campaigns, client ops, and automated signals |
+| -> Full glossary | `memory/glossary.md` | Additional durable shorthand |
+
+## Preferences
+- Default output sink for inbox intelligence is Apple Notes.
+- `david@mojosolo.com` is the primary address given to people.
+- `info@mojosolo.com` is intentionally a catch-all and should support creative alias routing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,9 @@
 ## Repo
 `apple-mcp` contains standalone MCP servers for Apple apps plus higher-level automation packages built on top of Mail and Notes.
 
+## Current Plan
+- `docs/plans/2026-03-13-apple-mcp-governed-roadmap.md` | governed sequencing document for hydration, shell, intelligence, and packaging work
+
 ## Canonical Brain
 | System | Role |
 |------|------|

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Apple MCP Servers
+# MCP Servers
 
-A collection of [Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers that provide AI assistants with access to native Apple applications on macOS.
+A collection of [Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers, primarily for native Apple applications on macOS, plus a canonical knowledge-brain server and a mail-intelligence layer built on top of it.
 
 ## Servers
 
@@ -13,17 +13,18 @@ A collection of [Model Context Protocol (MCP)](https://modelcontextprotocol.io) 
 | [Apple Reminders](#apple-reminders) | Done | Create, update, complete, and manage reminders and lists |
 | [Apple Calendar](#apple-calendar) | Done | Create, update, and manage calendar events |
 | [Apple Maps](#apple-maps) | Done | Search locations, get directions, and drop pins (visual only — limited by Apple's automation support) |
+| [Knowledge Corpus](#knowledge-corpus) | Done | Query the canonical MojoSolo operating brain and export a Laravel projection |
+| [Apple Mail Intelligence](#apple-mail-intelligence) | Done | Read three configured inbox personas from the canonical brain, classify signals, and write a Daily Intel brief to Apple Notes |
 
 ## Requirements
 
-- **macOS** (uses AppleScript and macOS-specific APIs)
 - **Node.js** 18+ (22+ for Apple Messages)
-- **Full Disk Access** granted to your terminal app (System Settings > Privacy & Security > Full Disk Access) — required for reading the Messages database
-- **The associated Apple app must be running** — each MCP server communicates with its corresponding app via AppleScript, so the app (e.g. Contacts, Mail, Notes) needs to be open for the server to function
+- **Apple app servers only:** macOS, Full Disk Access for Messages, and the associated Apple app running
+- **Knowledge Corpus only:** no macOS dependency; it reads bundled or configured local corpus files
 
 ## Safety Modes
 
-All servers (except Apple Maps, which is UI-only) support two optional safety flags:
+Apple app servers (except Apple Maps, which is UI-only) support two optional safety flags:
 
 | Mode | Flag | Behaviour |
 |------|------|-----------|
@@ -170,6 +171,12 @@ cd ../maps && npm install && npm run build
 
 # Apple Mail
 cd ../mail && npm install && npm run build
+
+# Knowledge Corpus
+cd ../knowledge-corpus && npm install && npm run build
+
+# Apple Mail Intelligence
+cd ../mail-intelligence && npm install && npm run build
 ```
 
 Then configure your MCP client to run the built files directly:
@@ -204,6 +211,14 @@ Then configure your MCP client to run the built files directly:
     "apple-mail": {
       "command": "node",
       "args": ["/absolute/path/to/mail/build/index.js"]
+    },
+    "knowledge-corpus": {
+      "command": "node",
+      "args": ["/absolute/path/to/knowledge-corpus/build/index.js"]
+    },
+    "apple-mail-intelligence": {
+      "command": "node",
+      "args": ["/absolute/path/to/mail-intelligence/build/index.js"]
     }
   }
 }
@@ -406,6 +421,59 @@ An MCP server that interacts with Apple Mail via AppleScript.
 - "Show my recent emails in INBOX"
 - "Search my email for invoices"
 - "Send an email to bob@example.com about the meeting"
+
+---
+
+## Knowledge Corpus
+
+An MCP server that serves the canonical MojoSolo operating brain plus a companion markdown report and a Laravel export layer.
+
+### Tools
+
+| Tool | Description |
+|------|-------------|
+| `get_corpus_overview` | Return corpus metadata, available sections, source counts, and report availability |
+| `list_corpus_sections` | List the top-level structured corpus sections |
+| `get_corpus_section` | Return a full top-level section by name |
+| `get_mail_intelligence_config` | Return the embedded mail-intelligence config used by the live sensor layer |
+| `search_corpus` | Search the structured corpus, the report, or both |
+| `get_laravel_brain_blueprint` | Return Laravel tables, routes, and seed data derived from the brain |
+| `export_laravel_brain_pack` | Write a Laravel integration pack to a target directory |
+| `list_sources` | List all source registry entries |
+| `get_source` | Return one source registry entry by id |
+| `list_report_sections` | List available markdown report sections |
+| `get_report_section` | Return one markdown report section by title or slug |
+
+### Usage Examples
+
+- "Show me the persona_architecture section"
+- "Show me the mail-intelligence config"
+- "Give me the Laravel brain blueprint"
+- "Export the Laravel brain pack into my app"
+
+---
+
+## Apple Mail Intelligence
+
+An MCP server that treats `mojosolo@mac.com`, `david@mojosolo.com`, and `info@mojosolo.com` as distinct personas, loads its rules from the canonical brain, classifies their signals, and generates a Notes-first Daily Intel brief.
+
+### Tools
+
+| Tool | Description |
+|------|-------------|
+| `get_persona_map` | Return the configured persona/account map and note output settings |
+| `scan_persona_inboxes` | Scan recent mail and classify messages by persona, domain, lane, and priority |
+| `analyze_signal_trends` | Compare cumulative signal distributions across windows such as 30/60/90 days |
+| `generate_daily_brief` | Build the Daily Intel brief and optionally save it to Apple Notes |
+
+If Apple Notes automation stalls on the local machine, `generate_daily_brief` still returns the brief content and reports the Notes problem through `note_status` and `note_error`.
+
+### Usage Examples
+
+- "Show me the persona map"
+- "Scan the last day of inbox intelligence"
+- "Compare signals over 30, 60, and 90 days"
+- "Generate today's Daily Intel and save it to Notes"
 
 ---
 

--- a/docs/macos-shell-architecture.md
+++ b/docs/macos-shell-architecture.md
@@ -219,9 +219,36 @@ Commercial hardening:
 5. Add the three core views: cockpit, agent terminal, and production dashboard.
 6. Add structured job logging for media tasks.
 
-## Open Questions
+## Resolved Decisions
 
-- Which model/runtime will drive the shell’s agent router by default?
-- Should the first computer-use provider be embedded or launched as an external helper?
-- What is the minimum viable FCP workflow for the first demo: assembly, creative direction, monitoring, or all three?
-- How much of the current MojoSolo brain should remain repo-bundled versus moved to user-local state at first launch?
+### Q1: Router model stack
+Three-tier routing — deterministic first, LLM only when needed:
+
+1. **Deterministic router** — exact tool/intent matches with no LLM call. Fast, free, reproducible.
+2. **Claude (claude-sonnet-4-6)** — ambiguous or multi-step intent resolution. Primary LLM.
+3. **OpenAI fallback** — only when Claude is unavailable, rate-limited, or explicitly selected by the user.
+
+Model switching is prohibited mid-run for stateful jobs (FCP/Motion workflows). Once a job starts on a model, it completes on that model or fails cleanly. Both models are behind a provider abstraction.
+
+### Q2: Computer-use provider — embedded vs external helper
+External helper process (XPC service). Reasons:
+
+- Screen capture and input simulation entitlements are properly scoped to a helper
+- Process isolation protects the shell from computer-use crashes
+- The helper can be updated or swapped independently of the shell
+- This is the correct macOS pattern for privileged operations
+
+For Phase 1 the helper launches as a child process. For Phase 3 it becomes a proper XPC service.
+
+### Q3: Minimum viable FCP workflow for first demo
+**Assembly + Monitoring.** Creative direction deferred to Phase 2.
+
+- Assembly: drop clips onto a timeline using a repeatable template. Directly serves the ElanPresentation credit-union workflow.
+- Monitoring: watch render queue and export progress, fire alerts when jobs complete or fail.
+
+Creative direction (describe a mood, agent decides pacing/transitions) requires mature vision loops and is a Phase 2 milestone.
+
+### Q4: Brain bundling vs user-local
+Phase 1: brain stays repo-bundled (`knowledge-corpus/data/mojosolo_operating_brain.json`). A `BRAIN_PATH` env override allows pointing to a local file without code changes.
+
+Phase 3: onboarding copies the default brain to `~/Library/Application Support/MojoShell/brain.json` and the app uses that path going forward. The repo-bundled file becomes the seed template, not the live state.

--- a/docs/macos-shell-architecture.md
+++ b/docs/macos-shell-architecture.md
@@ -1,0 +1,227 @@
+# macOS Shell Architecture
+
+## Status
+
+This document defines the first product-layer design on top of the existing `apple-mcp` foundation.
+
+What already exists in this repo:
+
+- Apple app MCP servers for Notes, Messages, Contacts, Reminders, Calendar, Maps, Mail, and Music
+- `knowledge-corpus` as the canonical operating brain query layer
+- `mail-intelligence` as the live Apple Mail sensor and Daily Intel generator
+- Repo memory files that describe the three-persona inbox model
+
+What does not exist yet:
+
+- A native SwiftUI macOS shell
+- A computer-use layer for general UI control
+- Final Cut Pro or Motion automation beyond basic app visibility and manual investigation
+
+## Product Goal
+
+Build a native macOS control surface that combines:
+
+- A SwiftUI shell for daily operating context
+- MCP-backed access to Apple apps and the canonical brain
+- A swappable computer-use layer for apps that do not expose adequate automation APIs
+- Production workflows for media assembly, monitoring, and guided creative operations
+
+## Design Principles
+
+- Keep the current MCP foundation independently usable and shippable.
+- Treat the shell as a separate product layer, not a rewrite of the servers.
+- Put hard seams around computer-use so it can be replaced later.
+- Keep user data local by default.
+- Design for a personal-first release path without blocking a later commercial version.
+
+## Architecture
+
+### 1. SwiftUI Shell
+
+The shell is the native macOS application and primary user surface.
+
+Primary views:
+
+- `Cockpit`: inbox intelligence, calendar, reminders, current media, and active jobs
+- `Agent Terminal`: natural-language command bar and routed task execution
+- `Production Dashboard`: FCP/Motion-oriented jobs, export state, and workflow tracking
+
+Shell responsibilities:
+
+- session state
+- navigation
+- permission onboarding
+- model/provider selection
+- rendering structured outputs from MCP tools
+- showing computer-use task progress, screenshots, and approvals
+
+### 2. Agent Router
+
+The router receives typed intents from the shell and decides which control plane should execute them.
+
+Examples:
+
+- "Scan today’s three inboxes" -> `mail-intelligence`
+- "Show the operator persona rules" -> `knowledge-corpus`
+- "Pause the current playlist" -> `apple-music`
+- "Export the current FCP timeline" -> computer-use provider
+
+The router should prefer deterministic MCP tools first and only fall back to computer use when no good API exists.
+
+### 3. MCP Daemon Layer
+
+The current repo already provides this layer.
+
+Initial server set:
+
+- `apple-notes`
+- `apple-messages`
+- `apple-contacts`
+- `apple-reminders`
+- `apple-calendar`
+- `apple-maps`
+- `apple-mail`
+- `apple-music`
+- `mail-intelligence`
+- `knowledge-corpus`
+
+Product requirement:
+
+- The shell should launch and supervise these as local child processes instead of requiring users to wire them manually in editor configs.
+
+### 4. Computer-Use Layer
+
+This layer is required for apps like Final Cut Pro and Motion where direct automation is limited or absent.
+
+Define a provider seam:
+
+```ts
+export interface ComputerUseProvider {
+  name: string;
+  startSession(): Promise<string>;
+  captureState(sessionId: string): Promise<ComputerUseState>;
+  execute(sessionId: string, action: ComputerUseAction): Promise<ComputerUseResult>;
+  stopSession(sessionId: string): Promise<void>;
+}
+```
+
+Planned provider implementations:
+
+- `CuaComputerUseProvider`
+  Uses screen capture plus simulated input for a personal/direct-distribution build.
+- `AccessibilityComputerUseProvider`
+  Uses macOS accessibility primitives where feasible for a more platform-native future path.
+
+Rules:
+
+- The shell must depend on the interface, not a concrete provider.
+- Computer-use actions must be logged as structured events.
+- Long-running media tasks must support resume/retry state.
+
+### 5. Canonical Brain and User Data
+
+The canonical brain remains the source of truth for structured operating context.
+
+Current source:
+
+- `knowledge-corpus/data/mojosolo_operating_brain.json`
+
+Product direction:
+
+- user-scoped local brain file
+- system keychain for secrets and account material
+- Notes remain an output sink, not a source of truth
+- event logs and job history stored separately from the brain
+
+## FCP and Motion Reality
+
+Current conclusion:
+
+- Final Cut Pro does not currently give this repo a practical editing/export automation surface through the existing MCP stack.
+- Motion does not currently have a usable automation surface in this repo.
+
+That means:
+
+- assembly automation
+- creative-direction loops
+- export monitoring inside those apps
+
+must initially rely on the computer-use layer.
+
+The shell should treat FCP and Motion as `computer-use-first` applications until a better native strategy is proven.
+
+## Initial Modules
+
+### Shell App
+
+- SwiftUI app target
+- view models for cockpit, terminal, and production dashboard
+- permission and onboarding flow
+- child-process manager for MCP daemons
+
+### Router Core
+
+- intent schema
+- tool registry
+- deterministic routing rules
+- fallback rules to computer use
+
+### Provider Runtime
+
+- provider interface
+- session lifecycle manager
+- screenshot/action log model
+- error handling and cancellation
+
+### Job System
+
+- media job definitions
+- progress state
+- retry and resume
+- notification hooks
+
+## Release Strategy
+
+### Phase 1
+
+Personal-first product build:
+
+- SwiftUI shell
+- local MCP daemon management
+- current brain integration
+- initial computer-use provider
+- direct distribution outside the App Store
+
+### Phase 2
+
+Stabilization and repeatable workflows:
+
+- assembly templates
+- job queue
+- media workflow presets
+- richer telemetry and recovery
+
+### Phase 3
+
+Commercial hardening:
+
+- per-user onboarding
+- secrets and account isolation
+- pluggable provider strategy
+- clearer boundary between personal brain defaults and distributable product defaults
+
+## Immediate Build Plan
+
+1. Create the SwiftUI app scaffold in a new product directory.
+2. Add a local daemon manager for the 10 existing MCP servers.
+3. Define the router intent model and map the first shell actions to existing MCP tools.
+4. Create the computer-use provider protocol and a stub implementation.
+5. Add the three core views: cockpit, agent terminal, and production dashboard.
+6. Add structured job logging for media tasks.
+
+## Open Questions
+
+- Which model/runtime will drive the shell’s agent router by default?
+- Should the first computer-use provider be embedded or launched as an external helper?
+- What is the minimum viable FCP workflow for the first demo: assembly, creative direction, monitoring, or all three?
+- How much of the current MojoSolo brain should remain repo-bundled versus moved to user-local state at first launch?

--- a/docs/plans/2026-03-12-macos-operator-roadmap.md
+++ b/docs/plans/2026-03-12-macos-operator-roadmap.md
@@ -1,0 +1,321 @@
+# macOS Operator Roadmap
+
+**Branch:** `feat/macos-shell`  
+**Date:** March 12, 2026  
+**Goal:** Turn the current `apple-mcp` + `shell/` foundation into a usable personal macOS operator layer that gives you practical control over your Mac and Apple-native apps by the next morning, then extends that into a durable control plane over the next 30 tasks.
+
+## Reality Check
+
+"Full control" on macOS does **not** mean bypassing SIP, TCC, or private OS protections. The realistic target is:
+
+- deterministic control of supported Apple apps through MCP and Apple automation
+- operator-level control of unsupported apps through Accessibility + screen-based computer use
+- a native shell that can supervise daemons, execute workflows, persist job history, and surface failures clearly
+- explicit user-granted permissions for Accessibility, Screen Recording, Apple Events, Full Disk Access, and any app-specific automation you choose to allow
+
+That is enough to get very close to "I can run my Mac from one control surface" without pretending the platform is less opinionated than it is.
+
+## Current State
+
+Already working on this branch:
+
+- SwiftUI shell with `Cockpit`, `Agent Terminal`, and `Production Dashboard`
+- 10 MCP-backed Apple/native data servers
+- deterministic router with Claude primary and OpenAI fallback
+- native `CuaComputerUseProvider` for local screen/input automation
+- FCP share/export discovery and verified workflow titles
+- readiness onboarding layer
+- `swift build` passing
+- `swift test` passing with `64/64` green
+
+Still missing for true operator use:
+
+- persistent production jobs and event history
+- runtime daemon health and restart controls
+- app coverage beyond the existing Apple app MCP set
+- true action surfaces for Finder, Safari, System Settings, and Shortcuts
+- persistent automation artifacts and audit trail
+- a coherent "one place to operate the Mac" experience
+
+## Success Definition For Morning
+
+By morning, you should have:
+
+- a shell that launches cleanly and tells you exactly what is unavailable
+- persistent production jobs instead of mock rows
+- daemon health visible in the UI, with restart actions
+- one place to run Apple-app data workflows and one place to run computer-use workflows
+- first-party control over the most important native app surfaces: Mail, Messages, Notes, Calendar, Reminders, Contacts, Maps, Music, Finder, Safari, Shortcuts, System Settings, Final Cut Pro
+
+## App Coverage Roadmap
+
+**Already integrated via MCP**
+
+- Notes
+- Messages
+- Contacts
+- Reminders
+- Calendar
+- Maps
+- Mail
+- Music
+- knowledge-corpus
+- mail-intelligence
+
+**High-priority app control to add next**
+
+- Finder
+- Safari
+- System Settings
+- Shortcuts
+- Notification Center / user notifications
+- Final Cut Pro runtime operations
+- Motion runtime operations
+
+**Second-wave app control**
+
+- Preview
+- Photos
+- QuickTime Player
+- Terminal / iTerm
+- Filesystem / export destinations
+
+## Workstreams
+
+1. **Operator Shell**
+   `Cockpit`, `Agent Terminal`, `Production Dashboard`, shared status surfaces, app navigation.
+2. **Native App Control**
+   MCP servers, AppleScript / Apple Events / Shortcuts / Finder / Safari / System Settings integration.
+3. **Computer Use**
+   Accessibility + screen-based execution, screenshot persistence, approvals, helper-process hardening.
+4. **Production Jobs**
+   Persistent jobs, event logs, resumability, render/export monitoring.
+5. **Runtime Health**
+   Daemon lifecycle, restartability, diagnostics, permissions, onboarding, auditability.
+
+## Prioritization
+
+### Must Have Tonight
+
+- persistent job store
+- daemon health UI
+- restart actions for failed daemons
+- Finder and Safari control surfaces
+- Shortcuts bridge for native workflow fan-out
+- screenshot and event persistence for computer-use runs
+
+### Should Have Next
+
+- System Settings deep actions
+- richer Production Dashboard state
+- notification delivery for completed/failed jobs
+- approval checkpoints for risky computer-use steps
+- export destination/file handling
+
+### Could Have Later
+
+- Motion-specific workflow pack
+- Preview / Photos / QuickTime support
+- menu-bar quick actions
+- LaunchAgent / background auto-start
+- XPC helper split for computer use
+
+## 30-Task Roadmap
+
+### Phase 1: By Morning
+
+**Task 1. Persist production jobs**
+- Create `JobStore` under `Application Support/MojoShell/jobs.json`.
+- Move sample rows out of `ProductionDashboardView`.
+- Outcome: dashboard reflects real stored jobs, not mock data.
+
+**Task 2. Persist production event history**
+- Add `JobEvent` and append-only event log.
+- Record queued, started, step progress, completed, failed, canceled.
+- Outcome: every run has a durable execution trail.
+
+**Task 3. Introduce `ProductionController`**
+- Centralize job execution orchestration outside the view.
+- Move workflow mutation logic out of `ProductionDashboardView`.
+- Outcome: view becomes a renderer, not the workflow engine.
+
+**Task 4. Persist computer-use screenshots**
+- Save screenshot files from `ComputerUseResult.screenshotAfter`.
+- Store paths in job events instead of only keeping `Data?` in memory.
+- Outcome: failures and approvals are inspectable after the run ends.
+
+**Task 5. Add daemon runtime health model**
+- Extend runtime state beyond artifact presence.
+- Track `notBuilt`, `stopped`, `starting`, `running`, `failed`.
+- Outcome: shell can tell the difference between "built" and "alive."
+
+**Task 6. Add daemon diagnostics panel**
+- New shell panel or section listing all 10 daemons with status and last error.
+- Outcome: you can see what is actually operational without reading logs.
+
+**Task 7. Add per-daemon restart actions**
+- Restart one daemon or all daemons from the shell.
+- Outcome: no terminal round-trip needed when a daemon dies.
+
+**Task 8. Add Finder control surface**
+- Create a Finder MCP/control seam for:
+  - reveal path
+  - open folder
+  - list current selection
+  - move/copy/export target prep
+- Outcome: shell can direct file destinations and inspect export targets.
+
+**Task 9. Add Safari control surface**
+- Create a Safari MCP/control seam for:
+  - open URL
+  - get current tab URL/title
+  - run link-opening workflows from shell
+- Outcome: shell can drive web destinations and operator research flows.
+
+**Task 10. Add Shortcuts bridge**
+- Add a Shortcuts runner for named shortcuts with typed inputs.
+- Outcome: you get immediate leverage across macOS-native automations without writing custom bridges for everything.
+
+### Phase 2: Morning Stabilization
+
+**Task 11. Add System Settings deep-link actions**
+- Shell actions for opening Accessibility, Screen Recording, Full Disk Access, Automation panes.
+- Outcome: readiness issues become one-click recoverable.
+
+**Task 12. Add Apple Events readiness**
+- Extend readiness to cover automation permission state where feasible.
+- Outcome: app-control failures are surfaced before runtime.
+
+**Task 13. Add action approvals**
+- Introduce confirmation checkpoints for destructive or high-risk computer-use steps.
+- Outcome: "full control" remains operator-safe.
+
+**Task 14. Add notification delivery**
+- Fire local notifications for job completion, failure, and daemon failure.
+- Outcome: you do not need to stare at the shell to know when work finishes.
+
+**Task 15. Add export target management**
+- Integrate Finder-aware export destination selection.
+- Outcome: FCP workflows can finish into known folders, not ambiguous defaults.
+
+**Task 16. Add FCP workflow presets**
+- Formalize named workflows: export current timeline, export project, monitor background tasks.
+- Outcome: dashboard actions become repeatable presets instead of one-off steps.
+
+**Task 17. Add Motion workflow placeholders**
+- Mirror the FCP model with Motion-specific discovery, activation, and task logging.
+- Outcome: Motion becomes a first-class target instead of a note in the design doc.
+
+**Task 18. Add command palette**
+- Global shell action runner for app actions, workflow starts, daemon restarts, and shortcut execution.
+- Outcome: faster operator loop than navigating views.
+
+**Task 19. Add operator audit view**
+- Timeline of actions across MCP calls, computer-use steps, daemon restarts, and job events.
+- Outcome: you can answer "what happened on this Mac?" from one screen.
+
+**Task 20. Add recovery and retry flows**
+- Retry failed jobs from stored state.
+- Outcome: failures are resumable, not dead ends.
+
+### Phase 3: Native macOS Control Expansion
+
+**Task 21. Create Finder-native MCP server or bridge**
+- Promote Finder control from ad hoc shell logic into a reusable server/tool layer.
+- Outcome: file control becomes durable and scriptable across the stack.
+
+**Task 22. Create Safari-native MCP server or bridge**
+- Promote Safari control into a reusable tool layer.
+- Outcome: browser workflows become part of the operator runtime, not UI glue.
+
+**Task 23. Add System Events / AppleScript adapter**
+- Wrap AppleScript / System Events into a narrow, typed adapter instead of sprinkling direct calls everywhere.
+- Outcome: native app automation expands cleanly.
+
+**Task 24. Add Shortcuts result parsing**
+- Capture structured outputs from shortcuts.
+- Outcome: shortcuts become true tools, not fire-and-forget buttons.
+
+**Task 25. Add Preview / document operations**
+- Open, inspect, and route exported deliverables.
+- Outcome: QA loop for exports stays in the shell.
+
+**Task 26. Add Photos / asset intake hooks**
+- Pull user-selected media into assembly workflows.
+- Outcome: operator shell becomes the intake point for local media.
+
+### Phase 4: Production Hardening
+
+**Task 27. Split computer-use helper from app process**
+- Move toward the planned helper/XPC seam.
+- Outcome: crashes or permission issues in computer use do not destabilize the shell.
+
+**Task 28. Add richer job schema**
+- Include client, template, source assets, output path, screenshots, error context, and workflow version.
+- Outcome: jobs are auditable and compatible with future template systems.
+
+**Task 29. Add launch/recovery behavior**
+- Auto-restore previous jobs, daemon state, and open context on relaunch.
+- Outcome: the shell feels like an operator console, not a demo app.
+
+**Task 30. Add morning-ops mode**
+- One consolidated launch mode showing:
+  - readiness summary
+  - daemon status
+  - inbox scan
+  - calendar/reminders
+  - active production jobs
+  - one-click app/workflow controls
+- Outcome: you can realistically start your day from MojoShell alone.
+
+## Recommended Execution Order
+
+If the target is "usable by morning," do these first:
+
+1. Task 1 — `JobStore`
+2. Task 2 — `JobEvent` log
+3. Task 3 — `ProductionController`
+4. Task 5 — daemon runtime health
+5. Task 6 — daemon diagnostics UI
+6. Task 7 — restart actions
+7. Task 8 — Finder control
+8. Task 9 — Safari control
+9. Task 10 — Shortcuts bridge
+10. Task 14 — local notifications
+
+That gives you a believable overnight operator shell instead of more internal cleanup.
+
+## Suggested Morning Deliverable
+
+If you want a single demo state by morning, the shell should support this sequence:
+
+1. Open MojoShell.
+2. Read readiness and daemon health.
+3. Scan inboxes and today’s context.
+4. Open Finder export folder.
+5. Launch a Shortcut that prepares a workflow context.
+6. Run an FCP export workflow.
+7. Persist screenshots, events, and output paths.
+8. Receive a completion notification.
+9. Open the export in Finder or Preview.
+10. Return to the shell to review the audit log.
+
+## What Not To Do Tonight
+
+- don’t chase App Store packaging
+- don’t over-engineer XPC before job persistence exists
+- don’t add more mock UI
+- don’t attempt "all apps" at once
+- don’t treat artifact presence as daemon health
+- don’t promise unsafe or hidden-API control over macOS internals
+
+## Definition Of Done For This Roadmap Slice
+
+This roadmap succeeds if, by the next checkpoint, MojoShell becomes:
+
+- the place where you see what your Mac can currently do
+- the place where you recover broken automation
+- the place where you launch native app workflows
+- the place where you inspect what happened afterward
+
+That is the shortest honest path to "full control over my macOS and native applications" from the current branch state.

--- a/docs/plans/2026-03-12-macos-shell.md
+++ b/docs/plans/2026-03-12-macos-shell.md
@@ -1,0 +1,1355 @@
+# macOS Shell Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a native SwiftUI macOS shell that unifies the 10 existing MCP servers, a swappable computer-use layer for FCP/Motion, and a three-tier agent router into a cockpit/terminal/dashboard app.
+
+**Architecture:** SPM-based SwiftUI app in `shell/` at repo root. A `DaemonManager` spawns the 10 Node MCP servers as child processes. An `MCPClient` speaks JSON-RPC over stdio. A three-tier `Router` (deterministic → Claude → OpenAI) dispatches intents. A `ComputerUseProvider` protocol isolates screen-capture logic behind a swappable seam.
+
+**Tech Stack:** Swift 5.9 + SwiftUI (macOS 14+), Swift Package Manager, Foundation.Process for daemon management, URLSession for Anthropic/OpenAI REST calls, XCTest for unit tests.
+
+**Branch:** `feat/macos-shell`
+**Design doc:** `docs/macos-shell-architecture.md`
+
+---
+
+## Task 1: Scaffold the Swift Package
+
+**Files:**
+- Create: `shell/Package.swift`
+- Create: `shell/Sources/MojoShell/App/MojoShellApp.swift`
+- Create: `shell/Sources/MojoShell/App/ContentView.swift`
+- Create: `shell/Tests/MojoShellTests/MojoShellTests.swift`
+
+**Step 1: Create the directory structure**
+
+```bash
+mkdir -p shell/Sources/MojoShell/App
+mkdir -p shell/Sources/MojoShell/Managers
+mkdir -p shell/Sources/MojoShell/Router
+mkdir -p shell/Sources/MojoShell/LLM
+mkdir -p shell/Sources/MojoShell/ComputerUse
+mkdir -p shell/Sources/MojoShell/Jobs
+mkdir -p shell/Sources/MojoShell/Views
+mkdir -p shell/Sources/MojoShell/Models
+mkdir -p shell/Tests/MojoShellTests
+```
+
+**Step 2: Write `shell/Package.swift`**
+
+```swift
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "MojoShell",
+    platforms: [.macOS(.v14)],
+    targets: [
+        .executableTarget(
+            name: "MojoShell",
+            path: "Sources/MojoShell",
+            swiftSettings: [.unsafeFlags(["-Xfrontend", "-disable-reflection-metadata"])]
+        ),
+        .testTarget(
+            name: "MojoShellTests",
+            dependencies: ["MojoShell"],
+            path: "Tests/MojoShellTests"
+        )
+    ]
+)
+```
+
+**Step 3: Write `shell/Sources/MojoShell/App/MojoShellApp.swift`**
+
+```swift
+import SwiftUI
+
+@main
+struct MojoShellApp: App {
+    @StateObject private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(appState)
+                .frame(minWidth: 1000, minHeight: 650)
+        }
+        .windowStyle(.hiddenTitleBar)
+        .commands {
+            CommandGroup(replacing: .newItem) {}
+        }
+    }
+}
+```
+
+**Step 4: Write `shell/Sources/MojoShell/App/ContentView.swift`**
+
+```swift
+import SwiftUI
+
+enum ShellView: String, CaseIterable, Identifiable {
+    case cockpit = "Cockpit"
+    case terminal = "Agent Terminal"
+    case production = "Production"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .cockpit: return "gauge.with.dots.needle.bottom.50percent"
+        case .terminal: return "terminal"
+        case .production: return "film.stack"
+        }
+    }
+}
+
+struct ContentView: View {
+    @State private var selected: ShellView = .cockpit
+
+    var body: some View {
+        NavigationSplitView {
+            List(ShellView.allCases, selection: $selected) { view in
+                Label(view.rawValue, systemImage: view.icon)
+                    .tag(view)
+            }
+            .navigationSplitViewColumnWidth(180)
+        } detail: {
+            switch selected {
+            case .cockpit: Text("Cockpit — coming in Task 7")
+            case .terminal: Text("Agent Terminal — coming in Task 8")
+            case .production: Text("Production Dashboard — coming in Task 9")
+            }
+        }
+    }
+}
+```
+
+**Step 5: Write the test scaffold**
+
+```swift
+// shell/Tests/MojoShellTests/MojoShellTests.swift
+import XCTest
+
+final class MojoShellTests: XCTestCase {
+    func testPlaceholder() {
+        XCTAssertTrue(true)
+    }
+}
+```
+
+**Step 6: Verify it builds**
+
+```bash
+cd shell && swift build 2>&1
+```
+
+Expected: `Build complete!`
+
+**Step 7: Commit**
+
+```bash
+git add shell/
+git commit -m "feat(shell): scaffold SwiftUI SPM package with three-view navigation"
+```
+
+---
+
+## Task 2: AppState + DaemonManager
+
+**Files:**
+- Create: `shell/Sources/MojoShell/App/AppState.swift`
+- Create: `shell/Sources/MojoShell/Managers/DaemonManager.swift`
+- Create: `shell/Tests/MojoShellTests/DaemonManagerTests.swift`
+
+**Step 1: Write the failing test**
+
+```swift
+// shell/Tests/MojoShellTests/DaemonManagerTests.swift
+import XCTest
+@testable import MojoShell
+
+final class DaemonManagerTests: XCTestCase {
+    func testKnownServersCount() {
+        let manager = DaemonManager()
+        XCTAssertEqual(manager.serverDefinitions.count, 10)
+    }
+
+    func testServerDefinitionsHaveValidPaths() {
+        let manager = DaemonManager()
+        for server in manager.serverDefinitions {
+            XCTAssertFalse(server.name.isEmpty)
+            XCTAssertTrue(server.scriptPath.hasSuffix("index.js"),
+                "\(server.name) path should end in index.js")
+        }
+    }
+}
+```
+
+**Step 2: Run to verify it fails**
+
+```bash
+cd shell && swift test --filter DaemonManagerTests 2>&1
+```
+
+Expected: `error: cannot find type 'DaemonManager'`
+
+**Step 3: Write `shell/Sources/MojoShell/Managers/DaemonManager.swift`**
+
+```swift
+import Foundation
+import Combine
+
+struct MCPServerDefinition {
+    let name: String
+    let scriptPath: String
+}
+
+@MainActor
+final class DaemonManager: ObservableObject {
+    @Published private(set) var runningServers: [String: Process] = [:]
+
+    private let repoRoot: String
+
+    init(repoRoot: String = defaultRepoRoot()) {
+        self.repoRoot = repoRoot
+    }
+
+    var serverDefinitions: [MCPServerDefinition] {
+        let servers = [
+            "apple-notes", "apple-messages", "apple-contacts", "apple-reminders",
+            "apple-calendar", "apple-maps", "apple-mail", "apple-music",
+            "mail-intelligence", "knowledge-corpus"
+        ]
+        return servers.map { name in
+            // Map server names to directory names
+            let dir = name == "mail-intelligence" ? "mail-intelligence"
+                    : name == "knowledge-corpus" ? "knowledge-corpus"
+                    : String(name.dropFirst("apple-".count))
+            return MCPServerDefinition(
+                name: name,
+                scriptPath: "\(repoRoot)/\(dir)/build/index.js"
+            )
+        }
+    }
+
+    func startAll() {
+        for definition in serverDefinitions {
+            start(definition)
+        }
+    }
+
+    func stopAll() {
+        runningServers.values.forEach { $0.terminate() }
+        runningServers.removeAll()
+    }
+
+    private func start(_ definition: MCPServerDefinition) {
+        guard FileManager.default.fileExists(atPath: definition.scriptPath) else {
+            print("[DaemonManager] Missing build artifact: \(definition.scriptPath)")
+            return
+        }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["node", definition.scriptPath]
+        process.standardInput = Pipe()
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            runningServers[definition.name] = process
+            print("[DaemonManager] Started \(definition.name) (pid \(process.processIdentifier))")
+        } catch {
+            print("[DaemonManager] Failed to start \(definition.name): \(error)")
+        }
+    }
+
+    private static func defaultRepoRoot() -> String {
+        // Resolve relative to the shell package root at runtime
+        let url = URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()  // Managers/
+            .deletingLastPathComponent()  // MojoShell/
+            .deletingLastPathComponent()  // Sources/
+            .deletingLastPathComponent()  // shell/
+        return url.path
+    }
+}
+```
+
+**Step 4: Write `shell/Sources/MojoShell/App/AppState.swift`**
+
+```swift
+import Foundation
+
+@MainActor
+final class AppState: ObservableObject {
+    let daemons = DaemonManager()
+
+    init() {
+        daemons.startAll()
+    }
+
+    deinit {
+        daemons.stopAll()
+    }
+}
+```
+
+**Step 5: Run tests**
+
+```bash
+cd shell && swift test --filter DaemonManagerTests 2>&1
+```
+
+Expected: `Test Suite 'DaemonManagerTests' passed`
+
+**Step 6: Commit**
+
+```bash
+git add shell/
+git commit -m "feat(shell): add DaemonManager that spawns all 10 MCP server processes"
+```
+
+---
+
+## Task 3: MCPClient (JSON-RPC over stdio)
+
+**Files:**
+- Create: `shell/Sources/MojoShell/Managers/MCPClient.swift`
+- Create: `shell/Tests/MojoShellTests/MCPClientTests.swift`
+
+**Step 1: Write the failing test**
+
+```swift
+// shell/Tests/MojoShellTests/MCPClientTests.swift
+import XCTest
+@testable import MojoShell
+
+final class MCPClientTests: XCTestCase {
+    func testRequestSerialization() throws {
+        let request = MCPRequest(id: 1, method: "tools/list", params: [:])
+        let data = try JSONEncoder().encode(request)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(json["jsonrpc"] as? String, "2.0")
+        XCTAssertEqual(json["method"] as? String, "tools/list")
+    }
+
+    func testResponseParsing() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"list_notes","description":"List notes"}]}}
+        """.data(using: .utf8)!
+        let response = try JSONDecoder().decode(MCPResponse.self, from: json)
+        XCTAssertNil(response.error)
+        XCTAssertNotNil(response.result)
+    }
+}
+```
+
+**Step 2: Run to verify it fails**
+
+```bash
+cd shell && swift test --filter MCPClientTests 2>&1
+```
+
+Expected: `error: cannot find type 'MCPRequest'`
+
+**Step 3: Write `shell/Sources/MojoShell/Managers/MCPClient.swift`**
+
+```swift
+import Foundation
+
+// MARK: - JSON-RPC wire types
+
+struct MCPRequest: Encodable {
+    let jsonrpc = "2.0"
+    let id: Int
+    let method: String
+    let params: [String: AnyCodable]
+}
+
+struct MCPResponse: Decodable {
+    let jsonrpc: String
+    let id: Int?
+    let result: MCPResult?
+    let error: MCPError?
+}
+
+struct MCPResult: Decodable {
+    let tools: [MCPTool]?
+    let content: [MCPContent]?
+}
+
+struct MCPTool: Decodable {
+    let name: String
+    let description: String
+}
+
+struct MCPContent: Decodable {
+    let type: String
+    let text: String?
+}
+
+struct MCPError: Decodable {
+    let code: Int
+    let message: String
+}
+
+// MARK: - Client
+
+actor MCPClient {
+    private let process: Process
+    private let stdin: Pipe
+    private let stdout: Pipe
+    private var pendingRequests: [Int: CheckedContinuation<MCPResponse, Error>] = [:]
+    private var nextId = 1
+
+    init(process: Process) {
+        self.process = process
+        self.stdin = process.standardInput as! Pipe
+        self.stdout = process.standardOutput as! Pipe
+    }
+
+    func callTool(name: String, arguments: [String: AnyCodable] = [:]) async throws -> MCPResponse {
+        let id = nextId
+        nextId += 1
+        let request = MCPRequest(
+            id: id,
+            method: "tools/call",
+            params: ["name": .string(name), "arguments": .object(arguments)]
+        )
+        let line = try JSONEncoder().encode(request)
+        var lineWithNewline = line
+        lineWithNewline.append(0x0A)
+        stdin.fileHandleForWriting.write(lineWithNewline)
+
+        return try await withCheckedThrowingContinuation { continuation in
+            Task { await self.registerContinuation(id: id, continuation: continuation) }
+        }
+    }
+
+    private func registerContinuation(id: Int, continuation: CheckedContinuation<MCPResponse, Error>) {
+        pendingRequests[id] = continuation
+        // Simple synchronous read — sufficient for Phase 1 sequential tool calls
+        if let data = try? stdout.fileHandleForReading.availableData,
+           !data.isEmpty,
+           let response = try? JSONDecoder().decode(MCPResponse.self, from: data) {
+            pendingRequests.removeValue(forKey: id)?.resume(returning: response)
+        }
+    }
+}
+
+// MARK: - AnyCodable helper (minimal)
+
+enum AnyCodable: Codable {
+    case string(String)
+    case int(Int)
+    case bool(Bool)
+    case object([String: AnyCodable])
+    case array([AnyCodable])
+    case null
+
+    static func string(_ v: String) -> AnyCodable { .string(v) }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if let v = try? c.decode(String.self) { self = .string(v); return }
+        if let v = try? c.decode(Int.self) { self = .int(v); return }
+        if let v = try? c.decode(Bool.self) { self = .bool(v); return }
+        self = .null
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .string(let v): try c.encode(v)
+        case .int(let v): try c.encode(v)
+        case .bool(let v): try c.encode(v)
+        case .object(let v): try c.encode(v)
+        case .array(let v): try c.encode(v)
+        case .null: try c.encodeNil()
+        }
+    }
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+cd shell && swift test --filter MCPClientTests 2>&1
+```
+
+Expected: `Test Suite 'MCPClientTests' passed`
+
+**Step 5: Commit**
+
+```bash
+git add shell/
+git commit -m "feat(shell): add MCPClient JSON-RPC layer for stdio communication with MCP servers"
+```
+
+---
+
+## Task 4: Intent Model + Deterministic Router
+
+**Files:**
+- Create: `shell/Sources/MojoShell/Router/Intent.swift`
+- Create: `shell/Sources/MojoShell/Router/DeterministicRouter.swift`
+- Create: `shell/Tests/MojoShellTests/DeterministicRouterTests.swift`
+
+**Step 1: Write the failing test**
+
+```swift
+// shell/Tests/MojoShellTests/DeterministicRouterTests.swift
+import XCTest
+@testable import MojoShell
+
+final class DeterministicRouterTests: XCTestCase {
+    let router = DeterministicRouter()
+
+    func testScanInboxesIntent() {
+        let result = router.route("scan today's inboxes")
+        XCTAssertEqual(result?.server, "mail-intelligence")
+        XCTAssertEqual(result?.tool, "scan_persona_inboxes")
+    }
+
+    func testPauseMusicIntent() {
+        let result = router.route("pause the music")
+        XCTAssertEqual(result?.server, "apple-music")
+        XCTAssertEqual(result?.tool, "pause")
+    }
+
+    func testFCPIntent() {
+        // FCP has no MCP tool — should return nil so router escalates to LLM + computer use
+        let result = router.route("export the current FCP timeline")
+        XCTAssertNil(result)
+    }
+
+    func testUnknownReturnsNil() {
+        let result = router.route("zxqwerty something unknown")
+        XCTAssertNil(result)
+    }
+}
+```
+
+**Step 2: Run to verify it fails**
+
+```bash
+cd shell && swift test --filter DeterministicRouterTests 2>&1
+```
+
+Expected: `error: cannot find type 'DeterministicRouter'`
+
+**Step 3: Write `shell/Sources/MojoShell/Router/Intent.swift`**
+
+```swift
+import Foundation
+
+struct ResolvedTool {
+    let server: String
+    let tool: String
+    let arguments: [String: String]
+}
+
+struct Intent {
+    let raw: String
+    let resolved: ResolvedTool?
+}
+```
+
+**Step 4: Write `shell/Sources/MojoShell/Router/DeterministicRouter.swift`**
+
+```swift
+import Foundation
+
+struct DeterministicRouter {
+    private struct Rule {
+        let keywords: [String]
+        let server: String
+        let tool: String
+    }
+
+    private let rules: [Rule] = [
+        // mail-intelligence
+        Rule(keywords: ["scan", "inbox", "inboxes", "daily intel", "brief"], server: "mail-intelligence", tool: "scan_persona_inboxes"),
+        Rule(keywords: ["persona map", "persona"], server: "mail-intelligence", tool: "get_persona_map"),
+        Rule(keywords: ["signal trend", "trends"], server: "mail-intelligence", tool: "analyze_signal_trends"),
+        Rule(keywords: ["daily brief", "generate brief"], server: "mail-intelligence", tool: "generate_daily_brief"),
+        // apple-music
+        Rule(keywords: ["pause", "stop music"], server: "apple-music", tool: "pause"),
+        Rule(keywords: ["play music", "resume music", "unpause"], server: "apple-music", tool: "play"),
+        Rule(keywords: ["next track", "next song", "skip"], server: "apple-music", tool: "next_track"),
+        Rule(keywords: ["previous track", "previous song"], server: "apple-music", tool: "previous_track"),
+        Rule(keywords: ["now playing", "what's playing", "current track"], server: "apple-music", tool: "now_playing"),
+        Rule(keywords: ["volume"], server: "apple-music", tool: "set_volume"),
+        // apple-notes
+        Rule(keywords: ["create note", "new note"], server: "apple-notes", tool: "create_note"),
+        Rule(keywords: ["search notes", "find note"], server: "apple-notes", tool: "search_notes"),
+        Rule(keywords: ["list notes"], server: "apple-notes", tool: "list_notes"),
+        // apple-calendar
+        Rule(keywords: ["today's events", "what's on", "calendar today", "my schedule"], server: "apple-calendar", tool: "list_all_events"),
+        Rule(keywords: ["create event", "new event", "schedule meeting"], server: "apple-calendar", tool: "create_event"),
+        // apple-reminders
+        Rule(keywords: ["remind me", "add reminder", "create reminder"], server: "apple-reminders", tool: "create_reminder"),
+        Rule(keywords: ["my reminders", "list reminders"], server: "apple-reminders", tool: "list_reminders"),
+        // knowledge-corpus
+        Rule(keywords: ["brain", "corpus", "persona rules", "operator rules"], server: "knowledge-corpus", tool: "get_persona_map"),
+    ]
+
+    func route(_ input: String) -> ResolvedTool? {
+        let lowered = input.lowercased()
+        for rule in rules {
+            if rule.keywords.contains(where: { lowered.contains($0) }) {
+                return ResolvedTool(server: rule.server, tool: rule.tool, arguments: [:])
+            }
+        }
+        return nil
+    }
+}
+```
+
+**Step 5: Run tests**
+
+```bash
+cd shell && swift test --filter DeterministicRouterTests 2>&1
+```
+
+Expected: `Test Suite 'DeterministicRouterTests' passed`
+
+**Step 6: Commit**
+
+```bash
+git add shell/
+git commit -m "feat(shell): add Intent model and DeterministicRouter with keyword rules for all 10 MCP servers"
+```
+
+---
+
+## Task 5: LLM Provider (Claude primary, OpenAI fallback)
+
+**Files:**
+- Create: `shell/Sources/MojoShell/LLM/LLMProvider.swift`
+- Create: `shell/Sources/MojoShell/LLM/ClaudeProvider.swift`
+- Create: `shell/Tests/MojoShellTests/LLMProviderTests.swift`
+
+**Step 1: Write the failing test**
+
+```swift
+// shell/Tests/MojoShellTests/LLMProviderTests.swift
+import XCTest
+@testable import MojoShell
+
+final class LLMProviderTests: XCTestCase {
+    func testClaudeProviderName() {
+        let provider = ClaudeProvider(apiKey: "test-key")
+        XCTAssertEqual(provider.name, "claude")
+    }
+
+    func testRequestBuildsCorrectURL() throws {
+        let provider = ClaudeProvider(apiKey: "test-key")
+        let request = try provider.buildURLRequest(prompt: "scan my inbox", tools: [])
+        XCTAssertEqual(request.url?.host, "api.anthropic.com")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertNotNil(request.value(forHTTPHeaderField: "x-api-key"))
+    }
+}
+```
+
+**Step 2: Run to verify it fails**
+
+```bash
+cd shell && swift test --filter LLMProviderTests 2>&1
+```
+
+Expected: `error: cannot find type 'ClaudeProvider'`
+
+**Step 3: Write `shell/Sources/MojoShell/LLM/LLMProvider.swift`**
+
+```swift
+import Foundation
+
+struct LLMToolDefinition {
+    let name: String
+    let description: String
+    let server: String
+}
+
+struct LLMResponse {
+    let text: String
+    let resolvedTool: ResolvedTool?
+}
+
+protocol LLMProvider {
+    var name: String { get }
+    func resolve(prompt: String, availableTools: [LLMToolDefinition]) async throws -> LLMResponse
+    func buildURLRequest(prompt: String, tools: [LLMToolDefinition]) throws -> URLRequest
+}
+```
+
+**Step 4: Write `shell/Sources/MojoShell/LLM/ClaudeProvider.swift`**
+
+```swift
+import Foundation
+
+struct ClaudeProvider: LLMProvider {
+    let name = "claude"
+    private let apiKey: String
+    private let model = "claude-sonnet-4-6"
+    private let baseURL = URL(string: "https://api.anthropic.com/v1/messages")!
+
+    init(apiKey: String) {
+        self.apiKey = apiKey
+    }
+
+    func buildURLRequest(prompt: String, tools: [LLMToolDefinition]) throws -> URLRequest {
+        var request = URLRequest(url: baseURL)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+
+        let toolSchemas = tools.map { tool -> [String: Any] in
+            ["name": tool.name,
+             "description": tool.description,
+             "input_schema": ["type": "object", "properties": [:]] as [String: Any]]
+        }
+
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 1024,
+            "system": """
+                You are the MojoShell agent router. Given a user command, decide which MCP tool to call.
+                Return a JSON object: {"tool": "<tool_name>", "server": "<server_name>", "arguments": {}}.
+                If no tool applies, return {"text": "<plain response>"}.
+                """,
+            "messages": [["role": "user", "content": prompt]],
+            "tools": toolSchemas
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    func resolve(prompt: String, availableTools: [LLMToolDefinition]) async throws -> LLMResponse {
+        let request = try buildURLRequest(prompt: prompt, tools: availableTools)
+        let (data, _) = try await URLSession.shared.data(for: request)
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = (json["content"] as? [[String: Any]])?.first,
+              let text = content["text"] as? String else {
+            return LLMResponse(text: "No response", resolvedTool: nil)
+        }
+
+        // Try to parse tool call from response text
+        if let jsonData = text.data(using: .utf8),
+           let parsed = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+           let toolName = parsed["tool"] as? String,
+           let serverName = parsed["server"] as? String {
+            return LLMResponse(
+                text: text,
+                resolvedTool: ResolvedTool(server: serverName, tool: toolName, arguments: [:])
+            )
+        }
+
+        return LLMResponse(text: text, resolvedTool: nil)
+    }
+}
+```
+
+**Step 5: Run tests**
+
+```bash
+cd shell && swift test --filter LLMProviderTests 2>&1
+```
+
+Expected: `Test Suite 'LLMProviderTests' passed`
+
+**Step 6: Commit**
+
+```bash
+git add shell/
+git commit -m "feat(shell): add LLMProvider protocol + ClaudeProvider (claude-sonnet-4-6 primary)"
+```
+
+---
+
+## Task 6: ComputerUseProvider Protocol + Stub
+
+**Files:**
+- Create: `shell/Sources/MojoShell/ComputerUse/ComputerUseProvider.swift`
+- Create: `shell/Sources/MojoShell/ComputerUse/StubComputerUseProvider.swift`
+- Create: `shell/Tests/MojoShellTests/ComputerUseProviderTests.swift`
+
+**Step 1: Write the failing test**
+
+```swift
+// shell/Tests/MojoShellTests/ComputerUseProviderTests.swift
+import XCTest
+@testable import MojoShell
+
+final class ComputerUseProviderTests: XCTestCase {
+    func testStubStartsSession() async throws {
+        let provider = StubComputerUseProvider()
+        let sessionId = try await provider.startSession()
+        XCTAssertFalse(sessionId.isEmpty)
+    }
+
+    func testStubCapturesState() async throws {
+        let provider = StubComputerUseProvider()
+        let sessionId = try await provider.startSession()
+        let state = try await provider.captureState(sessionId: sessionId)
+        XCTAssertEqual(state.appName, "stub")
+    }
+
+    func testStubExecutesAction() async throws {
+        let provider = StubComputerUseProvider()
+        let sessionId = try await provider.startSession()
+        let result = try await provider.execute(
+            sessionId: sessionId,
+            action: ComputerUseAction(type: .click, target: "Export Button")
+        )
+        XCTAssertTrue(result.success)
+    }
+}
+```
+
+**Step 2: Run to verify it fails**
+
+```bash
+cd shell && swift test --filter ComputerUseProviderTests 2>&1
+```
+
+Expected: `error: cannot find type 'ComputerUseProvider'`
+
+**Step 3: Write `shell/Sources/MojoShell/ComputerUse/ComputerUseProvider.swift`**
+
+```swift
+import Foundation
+
+struct ComputerUseState {
+    let appName: String
+    let screenshotData: Data?
+    let timestamp: Date
+}
+
+enum ComputerUseActionType: String {
+    case click, type, keypress, scroll, drag
+}
+
+struct ComputerUseAction {
+    let type: ComputerUseActionType
+    let target: String
+    let value: String?
+
+    init(type: ComputerUseActionType, target: String, value: String? = nil) {
+        self.type = type
+        self.target = target
+        self.value = value
+    }
+}
+
+struct ComputerUseResult {
+    let success: Bool
+    let message: String
+    let screenshotAfter: Data?
+}
+
+protocol ComputerUseProvider {
+    var name: String { get }
+    func startSession() async throws -> String
+    func captureState(sessionId: String) async throws -> ComputerUseState
+    func execute(sessionId: String, action: ComputerUseAction) async throws -> ComputerUseResult
+    func stopSession(sessionId: String) async throws
+}
+```
+
+**Step 4: Write `shell/Sources/MojoShell/ComputerUse/StubComputerUseProvider.swift`**
+
+```swift
+import Foundation
+
+/// Stub implementation used in Phase 1 before CUA is wired.
+/// Logs all actions and returns success without performing real UI automation.
+final class StubComputerUseProvider: ComputerUseProvider {
+    let name = "stub"
+    private var sessions: Set<String> = []
+
+    func startSession() async throws -> String {
+        let id = UUID().uuidString
+        sessions.insert(id)
+        print("[StubCU] Session started: \(id)")
+        return id
+    }
+
+    func captureState(sessionId: String) async throws -> ComputerUseState {
+        return ComputerUseState(appName: "stub", screenshotData: nil, timestamp: Date())
+    }
+
+    func execute(sessionId: String, action: ComputerUseAction) async throws -> ComputerUseResult {
+        print("[StubCU] \(action.type.rawValue) → \(action.target) (session: \(sessionId))")
+        return ComputerUseResult(success: true, message: "Stub executed: \(action.type.rawValue)", screenshotAfter: nil)
+    }
+
+    func stopSession(sessionId: String) async throws {
+        sessions.remove(sessionId)
+        print("[StubCU] Session stopped: \(sessionId)")
+    }
+}
+```
+
+**Step 5: Run tests**
+
+```bash
+cd shell && swift test --filter ComputerUseProviderTests 2>&1
+```
+
+Expected: `Test Suite 'ComputerUseProviderTests' passed`
+
+**Step 6: Commit**
+
+```bash
+git add shell/
+git commit -m "feat(shell): add ComputerUseProvider protocol and StubComputerUseProvider for FCP/Motion seam"
+```
+
+---
+
+## Task 7: Cockpit View
+
+**Files:**
+- Create: `shell/Sources/MojoShell/Views/CockpitView.swift`
+- Modify: `shell/Sources/MojoShell/App/ContentView.swift` (replace cockpit placeholder)
+
+**Step 1: Write `shell/Sources/MojoShell/Views/CockpitView.swift`**
+
+```swift
+import SwiftUI
+
+struct CockpitView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var scanResult: String = "Tap Scan to load Daily Intel"
+    @State private var isScanning = false
+
+    var body: some View {
+        HSplitView {
+            // Left: Inbox intelligence
+            VStack(alignment: .leading, spacing: 12) {
+                Label("Inbox Intelligence", systemImage: "envelope.badge.shield.half.filled")
+                    .font(.headline)
+                Divider()
+                ScrollView {
+                    Text(scanResult)
+                        .font(.system(.body, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                Button(isScanning ? "Scanning…" : "Scan Inboxes") {
+                    Task { await scanInboxes() }
+                }
+                .disabled(isScanning)
+            }
+            .padding()
+            .frame(minWidth: 320)
+
+            // Right: Calendar + Music
+            VStack(alignment: .leading, spacing: 12) {
+                Label("Active Servers", systemImage: "server.rack")
+                    .font(.headline)
+                Divider()
+                ForEach(Array(appState.daemons.runningServers.keys.sorted()), id: \.self) { name in
+                    HStack {
+                        Circle().fill(.green).frame(width: 8, height: 8)
+                        Text(name).font(.system(.body, design: .monospaced))
+                    }
+                }
+                Spacer()
+            }
+            .padding()
+            .frame(minWidth: 220)
+        }
+        .navigationTitle("Cockpit")
+    }
+
+    private func scanInboxes() async {
+        isScanning = true
+        scanResult = "Scanning…"
+        // Phase 1: call mail-intelligence scan_persona_inboxes via DaemonManager
+        // Full wiring in Task 3 integration — placeholder for now
+        try? await Task.sleep(nanoseconds: 800_000_000)
+        scanResult = "Scan complete — wire MCPClient in Task 3 integration step"
+        isScanning = false
+    }
+}
+```
+
+**Step 2: Update ContentView to use real view**
+
+Replace the `case .cockpit:` line in `ContentView.swift`:
+
+```swift
+case .cockpit: CockpitView()
+```
+
+**Step 3: Build**
+
+```bash
+cd shell && swift build 2>&1
+```
+
+Expected: `Build complete!`
+
+**Step 4: Commit**
+
+```bash
+git add shell/
+git commit -m "feat(shell): add CockpitView with inbox scan trigger and daemon status panel"
+```
+
+---
+
+## Task 8: Agent Terminal View
+
+**Files:**
+- Create: `shell/Sources/MojoShell/Views/AgentTerminalView.swift`
+- Modify: `shell/Sources/MojoShell/App/ContentView.swift` (replace terminal placeholder)
+
+**Step 1: Write `shell/Sources/MojoShell/Views/AgentTerminalView.swift`**
+
+```swift
+import SwiftUI
+
+struct TerminalEntry: Identifiable {
+    let id = UUID()
+    let role: Role
+    let text: String
+    let timestamp = Date()
+
+    enum Role { case user, agent, system }
+}
+
+struct AgentTerminalView: View {
+    @State private var input = ""
+    @State private var history: [TerminalEntry] = [
+        TerminalEntry(role: .system, text: "MojoShell Agent Terminal ready. Type a command.")
+    ]
+    @State private var isProcessing = false
+
+    private let deterministicRouter = DeterministicRouter()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 6) {
+                        ForEach(history) { entry in
+                            TerminalEntryRow(entry: entry)
+                                .id(entry.id)
+                        }
+                    }
+                    .padding()
+                }
+                .onChange(of: history.count) { _ in
+                    proxy.scrollTo(history.last?.id)
+                }
+            }
+
+            Divider()
+
+            HStack {
+                TextField("Type a command…", text: $input)
+                    .font(.system(.body, design: .monospaced))
+                    .textFieldStyle(.plain)
+                    .onSubmit { Task { await submit() } }
+                    .disabled(isProcessing)
+
+                Button(isProcessing ? "…" : "↵") {
+                    Task { await submit() }
+                }
+                .disabled(input.isEmpty || isProcessing)
+                .keyboardShortcut(.return, modifiers: [])
+            }
+            .padding(10)
+            .background(.background)
+        }
+        .navigationTitle("Agent Terminal")
+    }
+
+    private func submit() async {
+        let command = input.trimmingCharacters(in: .whitespaces)
+        guard !command.isEmpty else { return }
+        input = ""
+        isProcessing = true
+        history.append(TerminalEntry(role: .user, text: command))
+
+        if let tool = deterministicRouter.route(command) {
+            history.append(TerminalEntry(role: .system,
+                text: "→ deterministic route: \(tool.server)/\(tool.tool)"))
+            // Phase 1: log route; full MCP execution wired in integration step
+            history.append(TerminalEntry(role: .agent,
+                text: "Routed to \(tool.tool) on \(tool.server). MCP call pending integration."))
+        } else {
+            history.append(TerminalEntry(role: .system, text: "→ escalating to Claude…"))
+            history.append(TerminalEntry(role: .agent,
+                text: "LLM routing not yet wired. Add ANTHROPIC_API_KEY env var and connect ClaudeProvider."))
+        }
+        isProcessing = false
+    }
+}
+
+struct TerminalEntryRow: View {
+    let entry: TerminalEntry
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(prefix)
+                .foregroundStyle(color)
+                .font(.system(.body, design: .monospaced))
+                .frame(width: 60, alignment: .trailing)
+            Text(entry.text)
+                .font(.system(.body, design: .monospaced))
+                .textSelection(.enabled)
+        }
+    }
+
+    private var prefix: String {
+        switch entry.role {
+        case .user: return "you"
+        case .agent: return "agent"
+        case .system: return "sys"
+        }
+    }
+
+    private var color: Color {
+        switch entry.role {
+        case .user: return .primary
+        case .agent: return .blue
+        case .system: return .secondary
+        }
+    }
+}
+```
+
+**Step 2: Update ContentView**
+
+Replace `case .terminal:` line:
+
+```swift
+case .terminal: AgentTerminalView()
+```
+
+**Step 3: Build and verify**
+
+```bash
+cd shell && swift build 2>&1
+```
+
+Expected: `Build complete!`
+
+**Step 4: Commit**
+
+```bash
+git add shell/
+git commit -m "feat(shell): add AgentTerminalView with deterministic routing display and LLM escalation stub"
+```
+
+---
+
+## Task 9: Production Dashboard View
+
+**Files:**
+- Create: `shell/Sources/MojoShell/Jobs/MediaJob.swift`
+- Create: `shell/Sources/MojoShell/Views/ProductionDashboardView.swift`
+- Modify: `shell/Sources/MojoShell/App/ContentView.swift`
+
+**Step 1: Write `shell/Sources/MojoShell/Jobs/MediaJob.swift`**
+
+```swift
+import Foundation
+
+enum MediaJobStatus: String {
+    case queued, running, completed, failed
+}
+
+struct MediaJob: Identifiable {
+    let id = UUID()
+    let name: String
+    let client: String
+    var status: MediaJobStatus
+    var progress: Double  // 0.0 – 1.0
+    let createdAt: Date
+    var completedAt: Date?
+    var errorMessage: String?
+}
+```
+
+**Step 2: Write `shell/Sources/MojoShell/Views/ProductionDashboardView.swift`**
+
+```swift
+import SwiftUI
+
+struct ProductionDashboardView: View {
+    @State private var jobs: [MediaJob] = [
+        MediaJob(name: "Appalachian Community FCU — Benefits Overview",
+                 client: "ElanPresentation", status: .completed, progress: 1.0,
+                 createdAt: Date().addingTimeInterval(-3600), completedAt: Date()),
+        MediaJob(name: "FedChoice FCU — Enrollment Video",
+                 client: "ElanPresentation", status: .running, progress: 0.62,
+                 createdAt: Date().addingTimeInterval(-600)),
+        MediaJob(name: "Credit Union 1 — Annual Benefits",
+                 client: "ElanPresentation", status: .queued, progress: 0,
+                 createdAt: Date()),
+    ]
+
+    var body: some View {
+        HSplitView {
+            // Job queue
+            VStack(alignment: .leading, spacing: 0) {
+                Label("Job Queue", systemImage: "list.bullet.rectangle")
+                    .font(.headline)
+                    .padding()
+                Divider()
+                List(jobs) { job in
+                    JobRow(job: job)
+                }
+            }
+            .frame(minWidth: 340)
+
+            // FCP status panel
+            VStack(alignment: .leading, spacing: 12) {
+                Label("FCP / Motion", systemImage: "film.stack")
+                    .font(.headline)
+                Divider()
+                Text("Computer-use provider: Stub")
+                    .foregroundStyle(.secondary)
+                Text("Real FCP control wired in Task 10 (CuaComputerUseProvider).")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+                Spacer()
+                Button("Run Assembly Workflow (Stub)") {
+                    runAssemblyWorkflow()
+                }
+            }
+            .padding()
+            .frame(minWidth: 260)
+        }
+        .navigationTitle("Production")
+    }
+
+    private func runAssemblyWorkflow() {
+        print("[Dashboard] Assembly workflow triggered — stub provider active")
+    }
+}
+
+struct JobRow: View {
+    let job: MediaJob
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Circle().fill(statusColor).frame(width: 8, height: 8)
+                Text(job.name).bold()
+                Spacer()
+                Text(job.status.rawValue.capitalized)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+            if job.status == .running {
+                ProgressView(value: job.progress)
+            }
+            Text(job.client)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var statusColor: Color {
+        switch job.status {
+        case .queued: return .gray
+        case .running: return .blue
+        case .completed: return .green
+        case .failed: return .red
+        }
+    }
+}
+```
+
+**Step 3: Update ContentView**
+
+Replace `case .production:` line:
+
+```swift
+case .production: ProductionDashboardView()
+```
+
+**Step 4: Build**
+
+```bash
+cd shell && swift build 2>&1
+```
+
+Expected: `Build complete!`
+
+**Step 5: Commit**
+
+```bash
+git add shell/
+git commit -m "feat(shell): add ProductionDashboardView with job queue, ElanPresentation jobs, and FCP stub panel"
+```
+
+---
+
+## Task 10: Wire Full Test Suite + Final Build Verification
+
+**Files:**
+- Run: all tests
+- Verify: complete build
+
+**Step 1: Run all tests**
+
+```bash
+cd shell && swift test 2>&1
+```
+
+Expected: All test suites pass (`DaemonManagerTests`, `MCPClientTests`, `DeterministicRouterTests`, `LLMProviderTests`, `ComputerUseProviderTests`).
+
+**Step 2: Build in release mode**
+
+```bash
+cd shell && swift build -c release 2>&1
+```
+
+Expected: `Build complete!`
+
+**Step 3: Verify binary runs**
+
+```bash
+cd shell && .build/release/MojoShell &
+sleep 2
+kill %1
+```
+
+Expected: App launches (window appears), no crash.
+
+**Step 4: Final commit**
+
+```bash
+git add shell/
+git commit -m "feat(shell): complete Phase 1 foundation — all views, router, daemon manager, CU seam, tests passing
+
+- SwiftUI shell with Cockpit, Agent Terminal, Production Dashboard
+- DaemonManager supervises all 10 MCP server processes
+- MCPClient handles JSON-RPC over stdio
+- DeterministicRouter routes known commands without LLM
+- ClaudeProvider ready for ambiguous intent resolution
+- ComputerUseProvider protocol isolates FCP/Motion control
+- StubComputerUseProvider logs actions for Phase 1
+- MediaJob model + job queue UI for ElanPresentation workflows
+- CuaComputerUseProvider integration deferred to Phase 2"
+```
+
+---
+
+## Next Phase (Phase 2 Preview)
+
+- **Task 11:** `CuaComputerUseProvider` — real screen capture + input via `trycua/cua`
+- **Task 12:** FCP assembly workflow — clip ingestion → timeline template → export trigger
+- **Task 13:** FCP/Motion monitoring — render queue polling, export alerts
+- **Task 14:** Claude LLM integration — wire `ClaudeProvider` to `AgentTerminalView` with real API calls
+- **Task 15:** Brain connector — load `mojosolo_operating_brain.json` into `CockpitView` for persona-aware summaries

--- a/docs/plans/2026-03-12-readiness-onboarding-design.md
+++ b/docs/plans/2026-03-12-readiness-onboarding-design.md
@@ -1,0 +1,173 @@
+# Readiness Onboarding Design
+
+**Goal:** Add a persistent, non-blocking readiness layer to MojoShell that checks environment health at launch, surfaces exact fix instructions for missing prerequisites, and gates only the features that actually depend on each check.
+
+**Architecture:** `ReadinessState: ObservableObject` as a separate `@EnvironmentObject` alongside `AppState`. A single `DaemonManager` is owned by `MojoShellApp` and shared between both. No global modal — core issues show a dismissible banner; feature issues disable only the dependent controls.
+
+**Tech Stack:** SwiftUI, `@EnvironmentObject`, `AXIsProcessTrusted()`, `CGPreflightScreenCaptureAccess()`, `ProcessInfo.processInfo.environment`, injected `UserDefaults` suite for first-run state.
+
+---
+
+## Data Model
+
+### `ReadinessSeverity`
+
+```swift
+enum ReadinessSeverity: Equatable, Sendable {
+    case info       // visible but doesn't disable anything
+    case warning    // shown in UI, doesn't block
+    case blocking   // disables the dependent feature
+}
+```
+
+### `ReadinessIssue`
+
+```swift
+struct ReadinessIssue: Identifiable, Equatable, Sendable {
+    let id: String                  // stable key, e.g. "accessibility", "anthropic_key"
+    let title: String               // "Accessibility permission missing"
+    let fixInstruction: String      // "Open System Settings → Privacy → Accessibility"
+    let actionURL: URL?             // deep-link to the relevant pref pane
+    let severity: ReadinessSeverity
+}
+```
+
+Issues are **ordered deterministically**: blocking first, then warning, then info; within each severity group, sorted by `id` lexicographically. This prevents UI churn across repeated refresh calls.
+
+### `ReadinessFeature`
+
+```swift
+enum ReadinessFeature: String, Hashable, Sendable {
+    case computerUse    // AX + Screen Recording
+    case llm            // at least one API key present
+}
+```
+
+Daemon artifact presence lives in `coreIssues` only — not duplicated as a `ReadinessFeature`.
+
+### `ReadinessState`
+
+```swift
+@MainActor
+final class ReadinessState: ObservableObject {
+    @Published var coreIssues: [ReadinessIssue] = []
+    @Published var featureIssues: [ReadinessFeature: [ReadinessIssue]] = [:]
+    @Published var showFirstRunSheet: Bool = false
+    @Published var isRefreshing: Bool = false   // only meaningful if refresh is async
+
+    init(daemonManager: DaemonManager, defaults: UserDefaults = .standard)
+
+    func refresh()           // re-runs all checks; sets isRefreshing while running
+    func refreshComputerUse()  // AX + Screen Recording only
+
+    func isReady(for feature: ReadinessFeature) -> Bool
+    // true iff featureIssues[feature] contains no .blocking issues
+
+    func axPermissionGranted() -> Bool
+    // narrow check used by Discover FCP Elements (AX only, not full computerUse)
+}
+```
+
+---
+
+## Checks
+
+### Core issues (single source of truth)
+
+| id | Condition | Severity |
+|----|-----------|----------|
+| `repo_root` | `DaemonManager.repoRoot` path is not a valid directory | blocking |
+| `brain_file` | Resolved brain path does not exist (see Brain Path Resolution) | blocking |
+| `daemon_artifacts` | Any of the 10 `DaemonManager.serverDefinitions` scriptPaths is missing | warning |
+
+**Brain Path Resolution:** `ReadinessState` checks `ProcessInfo.processInfo.environment["BRAIN_PATH"]` first. If set and non-empty, validates that path. Otherwise falls back to `<repoRoot>/knowledge-corpus/data/mojosolo_operating_brain.json`.
+
+**Daemon artifacts** are derived from `DaemonManager.serverDefinitions` — no duplicated path strings in `ReadinessState`.
+
+### Feature issues
+
+**`.computerUse`**
+
+| id | Condition | Severity |
+|----|-----------|----------|
+| `accessibility` | `AXIsProcessTrusted()` returns `false` | blocking |
+| `screen_recording` | `CGPreflightScreenCaptureAccess()` returns `false` | warning |
+
+**`.llm`**
+
+| id | Condition | Severity |
+|----|-----------|----------|
+| `llm_no_keys` | Neither `ANTHROPIC_API_KEY` nor `OPENAI_API_KEY` is set | blocking |
+| `llm_one_key` | Exactly one key is set | info |
+
+---
+
+## UI Wiring
+
+### `MojoShellApp`
+
+```swift
+@main struct MojoShellApp: App {
+    private let daemons = DaemonManager()
+    @StateObject private var appState: AppState
+    @StateObject private var readiness: ReadinessState
+
+    init() {
+        let d = DaemonManager()
+        _appState = StateObject(wrappedValue: AppState(daemons: d))
+        _readiness = StateObject(wrappedValue: ReadinessState(daemonManager: d))
+    }
+}
+```
+
+One `DaemonManager` instance, shared by both. `appState` uses it for MCP process management; `readiness` uses it to derive artifact paths.
+
+### `ContentView`
+
+- Wraps the detail column in a `VStack` with `CoreIssuesBanner` at the top — one place covers all three views.
+- Triggers `readiness.refresh()` on `.task {}` (initial load) and on `.onChange(of: scenePhase) { if $0 == .active { readiness.refresh() } }`.
+- Shows `FirstRunSheet` via `.sheet(isPresented: $readiness.showFirstRunSheet)`.
+
+### `CoreIssuesBanner`
+
+- Shown when `readiness.coreIssues` has any `.blocking` issues.
+- Collapses to a non-intrusive indicator when only `.warning`/`.info` issues are present.
+- Dismissible per-session (not persisted).
+
+### `AgentTerminalView`
+
+- Soft info label only when `.llm` has blocking issues: "LLM fallback unavailable; deterministic routing still works."
+- Does **not** disable or block terminal interactions.
+
+### `ProductionDashboardView`
+
+- **"Run Assembly Workflow"**: `disabled(isRunningWorkflow || !readiness.isReady(for: .computerUse))`
+  - Shows the first blocking fix instruction below the button when not ready.
+- **"Discover FCP Elements"**: `disabled(!readiness.axPermissionGranted())`
+  - Narrower gate — AX only, not full `.computerUse`. Screen Recording is irrelevant for discovery.
+
+### `FirstRunSheet`
+
+- Shown once per install state: `showFirstRunSheet` is set to `true` on first `refresh()` if any issues exist **and** `UserDefaults["readiness.firstRunShown"]` is absent.
+- Dismissing sets `UserDefaults["readiness.firstRunShown"] = true` and is never shown again for this install.
+- Lists issues grouped by severity. "Open System Settings" for permission issues uses `actionURL`. "Retry" calls `readiness.refresh()`. "Continue anyway" dismisses.
+
+---
+
+## Testing
+
+All tests inject a stub `DaemonManager` (controllable artifact presence) and a dedicated `UserDefaults` suite so first-run tests stay isolated from system state.
+
+| Test | What it verifies |
+|------|-----------------|
+| Core issue derivation | Missing repo root / brain file / daemon artifacts → correct `coreIssues` with correct severities |
+| Brain path override | `BRAIN_PATH` set → validates that path; unset → falls back to default |
+| `isReady(.computerUse)` | `false` when AX is blocking; `true` when only Screen Recording is warning |
+| `isReady(.llm)` | No keys → blocking; one key → info; two keys → no issues |
+| First-run gating | `showFirstRunSheet` `true` when issues present and key absent; `false` when key set — using injected `UserDefaults` suite |
+| Stable issue ordering | Same readiness state → same issue order across repeated refresh calls |
+| No duplicate issues | Calling `refresh()` twice → no duplicate entries in `coreIssues` or `featureIssues` |
+| AX-only discovery gate | `axPermissionGranted()` returns `false` when AX denied, independent of Screen Recording state |
+| `isRefreshing` (conditional) | Only if `refresh()` is meaningfully async; skip if effectively immediate |
+
+No snapshot tests. No scenePhase UI tests. Phase 1 only.

--- a/docs/plans/2026-03-12-readiness-onboarding-plan.md
+++ b/docs/plans/2026-03-12-readiness-onboarding-plan.md
@@ -1,0 +1,1267 @@
+# Readiness Onboarding Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a persistent, non-blocking readiness layer to MojoShell that checks environment health at launch, surfaces exact fix instructions, and gates only the features that depend on each check.
+
+**Architecture:** `ReadinessState: ObservableObject` as a separate `@EnvironmentObject` alongside `AppState`. A single `DaemonManager` owned by `MojoShellApp` and shared between both. No global modal — core issues show a dismissible banner; feature issues disable only dependent controls.
+
+**Tech Stack:** SwiftUI, `@EnvironmentObject`, `AXIsProcessTrusted()`, `CGPreflightScreenCaptureAccess()`, `ProcessInfo.processInfo.environment`, injected `UserDefaults` suite for first-run state, injectable closures for testable permission checks.
+
+**Design doc:** `docs/plans/2026-03-12-readiness-onboarding-design.md`
+
+**Branch:** `feat/macos-shell`
+
+**Package root:** `shell/`
+
+---
+
+### Task 1: Data types — ReadinessSeverity, ReadinessIssue, ReadinessFeature
+
+**Files:**
+- Create: `shell/Sources/MojoShell/Readiness/ReadinessModels.swift`
+- Create: `shell/Tests/MojoShellTests/ReadinessModelsTests.swift`
+
+**Step 1: Write the failing tests**
+
+```swift
+// shell/Tests/MojoShellTests/ReadinessModelsTests.swift
+import XCTest
+@testable import MojoShell
+
+final class ReadinessModelsTests: XCTestCase {
+
+    func testSeverityCasesExist() {
+        let _ = ReadinessSeverity.info
+        let _ = ReadinessSeverity.warning
+        let _ = ReadinessSeverity.blocking
+    }
+
+    func testSeverityIsEquatable() {
+        XCTAssertEqual(ReadinessSeverity.blocking, .blocking)
+        XCTAssertNotEqual(ReadinessSeverity.blocking, .warning)
+    }
+
+    func testIssueIsIdentifiable() {
+        let issue = ReadinessIssue(
+            id: "test_id",
+            title: "Test Title",
+            fixInstruction: "Do something",
+            actionURL: nil,
+            severity: .blocking
+        )
+        XCTAssertEqual(issue.id, "test_id")
+        XCTAssertEqual(issue.title, "Test Title")
+        XCTAssertEqual(issue.severity, .blocking)
+        XCTAssertNil(issue.actionURL)
+    }
+
+    func testIssueIsEquatable() {
+        let a = ReadinessIssue(id: "a", title: "A", fixInstruction: "fix", actionURL: nil, severity: .warning)
+        let b = ReadinessIssue(id: "a", title: "A", fixInstruction: "fix", actionURL: nil, severity: .warning)
+        XCTAssertEqual(a, b)
+    }
+
+    func testFeatureCasesExist() {
+        let _ = ReadinessFeature.computerUse
+        let _ = ReadinessFeature.llm
+    }
+
+    func testFeatureIsHashable() {
+        var set = Set<ReadinessFeature>()
+        set.insert(.computerUse)
+        set.insert(.llm)
+        set.insert(.computerUse) // duplicate
+        XCTAssertEqual(set.count, 2)
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cd shell && swift test --filter ReadinessModelsTests 2>&1 | tail -20
+```
+
+Expected: compile error — `ReadinessSeverity`, `ReadinessIssue`, `ReadinessFeature` not found.
+
+**Step 3: Create the source file**
+
+```swift
+// shell/Sources/MojoShell/Readiness/ReadinessModels.swift
+import Foundation
+
+enum ReadinessSeverity: Equatable, Sendable {
+    case info       // visible but doesn't disable anything
+    case warning    // shown in UI, doesn't block
+    case blocking   // disables the dependent feature
+}
+
+struct ReadinessIssue: Identifiable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let fixInstruction: String
+    let actionURL: URL?
+    let severity: ReadinessSeverity
+}
+
+enum ReadinessFeature: String, Hashable, Sendable {
+    case computerUse
+    case llm
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+cd shell && swift test --filter ReadinessModelsTests 2>&1 | tail -20
+```
+
+Expected: All 6 tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add shell/Sources/MojoShell/Readiness/ReadinessModels.swift shell/Tests/MojoShellTests/ReadinessModelsTests.swift
+git commit -m "feat(readiness): add ReadinessSeverity, ReadinessIssue, ReadinessFeature data types"
+```
+
+---
+
+### Task 2: Expose repoRoot on DaemonManager
+
+`ReadinessState` must read `daemonManager.repoRoot` to check if it's a valid directory. Currently `repoRoot` is `private`.
+
+**Files:**
+- Modify: `shell/Sources/MojoShell/Managers/DaemonManager.swift:13`
+
+**Step 1: Write a test to verify the field is accessible**
+
+Add to `shell/Tests/MojoShellTests/DaemonManagerTests.swift` (existing file — append to the class):
+
+```swift
+func testRepoRootIsAccessible() {
+    // Verifies that ReadinessState can read the repoRoot without reflection.
+    let dm = DaemonManager(repoRoot: "/tmp/test-root")
+    XCTAssertEqual(dm.repoRoot, "/tmp/test-root")
+}
+```
+
+**Step 2: Run to verify it fails**
+
+```bash
+cd shell && swift test --filter DaemonManagerTests/testRepoRootIsAccessible 2>&1 | tail -10
+```
+
+Expected: compile error — `'repoRoot' is inaccessible due to 'private' protection level`.
+
+**Step 3: Change private to internal**
+
+In `shell/Sources/MojoShell/Managers/DaemonManager.swift`, change line 13:
+
+```swift
+// Before
+private let repoRoot: String
+
+// After
+let repoRoot: String
+```
+
+**Step 4: Run tests**
+
+```bash
+cd shell && swift test --filter DaemonManagerTests 2>&1 | tail -10
+```
+
+Expected: All DaemonManager tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add shell/Sources/MojoShell/Managers/DaemonManager.swift shell/Tests/MojoShellTests/DaemonManagerTests.swift
+git commit -m "feat(readiness): expose DaemonManager.repoRoot as internal for ReadinessState"
+```
+
+---
+
+### Task 3: ReadinessState — model, core checks, feature checks
+
+**Files:**
+- Create: `shell/Sources/MojoShell/Readiness/ReadinessState.swift`
+- Create: `shell/Tests/MojoShellTests/ReadinessStateTests.swift`
+
+**Step 1: Write the failing tests**
+
+```swift
+// shell/Tests/MojoShellTests/ReadinessStateTests.swift
+import XCTest
+@testable import MojoShell
+
+// MARK: - Helpers
+
+/// DaemonManager with a controllable repoRoot for tests.
+/// Use DaemonManager(repoRoot:) directly — repoRoot is now internal.
+
+private func makeState(
+    repoRoot: String = "/tmp",
+    defaults: UserDefaults = makeTestDefaults(),
+    environment: [String: String] = [:],
+    axGranted: Bool = true,
+    screenRecordingGranted: Bool = true
+) -> ReadinessState {
+    let dm = DaemonManager(repoRoot: repoRoot)
+    return ReadinessState(
+        daemonManager: dm,
+        defaults: defaults,
+        environment: environment,
+        axCheck: { axGranted },
+        screenRecordingCheck: { screenRecordingGranted }
+    )
+}
+
+private func makeTestDefaults() -> UserDefaults {
+    let suite = UUID().uuidString
+    return UserDefaults(suiteName: suite)!
+}
+
+// MARK: - Core issue tests
+
+@MainActor
+final class ReadinessStateCoreTests: XCTestCase {
+
+    func testMissingRepoRootProducesBlockingCoreIssue() async {
+        let state = makeState(repoRoot: "/tmp/nonexistent_mojo_test_\(UUID().uuidString)")
+        await state.refresh()
+        let ids = state.coreIssues.map(\.id)
+        XCTAssertTrue(ids.contains("repo_root"), "Expected repo_root issue; got \(ids)")
+        let issue = state.coreIssues.first(where: { $0.id == "repo_root" })!
+        XCTAssertEqual(issue.severity, .blocking)
+    }
+
+    func testValidRepoRootProducesNoRepoRootIssue() async {
+        // /tmp always exists
+        let state = makeState(repoRoot: "/tmp")
+        await state.refresh()
+        XCTAssertFalse(state.coreIssues.map(\.id).contains("repo_root"))
+    }
+
+    func testMissingBrainFileProducesBlockingCoreIssue() async {
+        // /tmp is a valid dir but has no knowledge-corpus/data/mojosolo_operating_brain.json
+        let state = makeState(repoRoot: "/tmp")
+        await state.refresh()
+        let issue = state.coreIssues.first(where: { $0.id == "brain_file" })
+        XCTAssertNotNil(issue)
+        XCTAssertEqual(issue?.severity, .blocking)
+    }
+
+    func testBrainPathEnvVarOverridesDefault() async {
+        // BRAIN_PATH points to a file that exists — no brain_file issue
+        let tmpFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_brain_\(UUID().uuidString).json")
+        FileManager.default.createFile(atPath: tmpFile.path, contents: Data("{}".utf8))
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+
+        let state = makeState(repoRoot: "/tmp", environment: ["BRAIN_PATH": tmpFile.path])
+        await state.refresh()
+        XCTAssertFalse(state.coreIssues.map(\.id).contains("brain_file"))
+    }
+
+    func testBrainPathEnvVarMissingProducesIssue() async {
+        // BRAIN_PATH set but file doesn't exist
+        let state = makeState(repoRoot: "/tmp", environment: ["BRAIN_PATH": "/tmp/nonexistent_brain_\(UUID().uuidString).json"])
+        await state.refresh()
+        XCTAssertTrue(state.coreIssues.map(\.id).contains("brain_file"))
+    }
+
+    func testDaemonArtifactsMissingProducesWarning() async {
+        // /tmp is valid but has no node build artifacts
+        let state = makeState(repoRoot: "/tmp")
+        await state.refresh()
+        let issue = state.coreIssues.first(where: { $0.id == "daemon_artifacts" })
+        XCTAssertNotNil(issue)
+        XCTAssertEqual(issue?.severity, .warning)
+    }
+}
+
+// MARK: - Feature issue tests
+
+@MainActor
+final class ReadinessStateFeatureTests: XCTestCase {
+
+    func testComputerUseIsBlockedWhenAXDenied() async {
+        let state = makeState(axGranted: false, screenRecordingGranted: true)
+        await state.refresh()
+        XCTAssertFalse(state.isReady(for: .computerUse))
+        let ids = state.featureIssues[.computerUse]?.map(\.id) ?? []
+        XCTAssertTrue(ids.contains("accessibility"))
+    }
+
+    func testComputerUseIsReadyWhenOnlyScreenRecordingMissing() async {
+        let state = makeState(axGranted: true, screenRecordingGranted: false)
+        await state.refresh()
+        // Screen Recording is only a warning — not blocking
+        XCTAssertTrue(state.isReady(for: .computerUse))
+        let ids = state.featureIssues[.computerUse]?.map(\.id) ?? []
+        XCTAssertTrue(ids.contains("screen_recording"))
+        let srIssue = state.featureIssues[.computerUse]!.first(where: { $0.id == "screen_recording" })!
+        XCTAssertEqual(srIssue.severity, .warning)
+    }
+
+    func testComputerUseIsReadyWhenBothGranted() async {
+        let state = makeState(axGranted: true, screenRecordingGranted: true)
+        await state.refresh()
+        XCTAssertTrue(state.isReady(for: .computerUse))
+        let blockingIssues = state.featureIssues[.computerUse]?.filter { $0.severity == .blocking } ?? []
+        XCTAssertTrue(blockingIssues.isEmpty)
+    }
+
+    func testAXOnlyCheckIsIndependentOfScreenRecording() async {
+        let state = makeState(axGranted: false, screenRecordingGranted: true)
+        await state.refresh()
+        XCTAssertFalse(state.axPermissionGranted())
+
+        let state2 = makeState(axGranted: true, screenRecordingGranted: false)
+        await state2.refresh()
+        XCTAssertTrue(state2.axPermissionGranted())
+    }
+
+    func testLLMNoKeysIsBlocking() async {
+        let state = makeState(environment: [:])
+        await state.refresh()
+        XCTAssertFalse(state.isReady(for: .llm))
+        let ids = state.featureIssues[.llm]?.map(\.id) ?? []
+        XCTAssertTrue(ids.contains("llm_no_keys"))
+        let issue = state.featureIssues[.llm]!.first(where: { $0.id == "llm_no_keys" })!
+        XCTAssertEqual(issue.severity, .blocking)
+    }
+
+    func testLLMOneKeyIsInfo() async {
+        let state = makeState(environment: ["ANTHROPIC_API_KEY": "sk-test"])
+        await state.refresh()
+        // One key → llm_one_key info issue, but isReady is true (no blocking)
+        XCTAssertTrue(state.isReady(for: .llm))
+        let ids = state.featureIssues[.llm]?.map(\.id) ?? []
+        XCTAssertTrue(ids.contains("llm_one_key"))
+        let issue = state.featureIssues[.llm]!.first(where: { $0.id == "llm_one_key" })!
+        XCTAssertEqual(issue.severity, .info)
+    }
+
+    func testLLMBothKeysProducesNoIssues() async {
+        let state = makeState(environment: [
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "OPENAI_API_KEY": "sk-openai-test"
+        ])
+        await state.refresh()
+        XCTAssertTrue(state.isReady(for: .llm))
+        let issues = state.featureIssues[.llm] ?? []
+        XCTAssertTrue(issues.isEmpty)
+    }
+}
+
+// MARK: - Stable ordering + no-duplicate tests
+
+@MainActor
+final class ReadinessStateOrderingTests: XCTestCase {
+
+    func testIssuesAreOrderedBlockingThenWarningThenInfo() async {
+        // No keys → blocking. No daemon artifacts → warning. Both together.
+        let state = makeState(
+            repoRoot: "/tmp",
+            environment: ["ANTHROPIC_API_KEY": "sk-test"],
+            axGranted: false,
+            screenRecordingGranted: false
+        )
+        await state.refresh()
+        let severities = state.coreIssues.map(\.severity)
+        // coreIssues should have blocking items before warning items
+        var seenWarning = false
+        for s in severities {
+            if s == .warning { seenWarning = true }
+            if seenWarning { XCTAssertNotEqual(s, .blocking, "Blocking issue appeared after warning") }
+        }
+    }
+
+    func testRefreshTwiceProducesNoDuplicates() async {
+        let state = makeState(repoRoot: "/tmp")
+        await state.refresh()
+        let countAfterFirst = state.coreIssues.count
+        await state.refresh()
+        XCTAssertEqual(state.coreIssues.count, countAfterFirst, "Second refresh should not duplicate issues")
+    }
+}
+
+// MARK: - First-run sheet tests
+
+@MainActor
+final class ReadinessStateFirstRunTests: XCTestCase {
+
+    func testShowFirstRunSheetWhenIssuesPresentAndKeyAbsent() async {
+        let defaults = makeTestDefaults()
+        // Missing brain file → issues present
+        let state = makeState(repoRoot: "/tmp", defaults: defaults)
+        await state.refresh()
+        XCTAssertTrue(state.showFirstRunSheet, "Should show first-run sheet when issues exist and key not set")
+    }
+
+    func testDoNotShowFirstRunSheetWhenKeyAlreadySet() async {
+        let defaults = makeTestDefaults()
+        defaults.set(true, forKey: "readiness.firstRunShown")
+        let state = makeState(repoRoot: "/tmp", defaults: defaults)
+        await state.refresh()
+        XCTAssertFalse(state.showFirstRunSheet, "Should not re-show first-run sheet when key is set")
+    }
+
+    func testNoFirstRunSheetWhenNoIssues() async {
+        // Build a brain file so brain_file passes; use /tmp so repo_root passes; both keys set; AX+SR granted.
+        let tmpFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_brain_\(UUID().uuidString).json")
+        FileManager.default.createFile(atPath: tmpFile.path, contents: Data("{}".utf8))
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+
+        let defaults = makeTestDefaults()
+        let state = makeState(
+            repoRoot: "/tmp",
+            defaults: defaults,
+            environment: [
+                "BRAIN_PATH": tmpFile.path,
+                "ANTHROPIC_API_KEY": "sk-ant",
+                "OPENAI_API_KEY": "sk-oai"
+            ],
+            axGranted: true,
+            screenRecordingGranted: true
+        )
+        await state.refresh()
+        // daemon_artifacts will still be a warning (no build/ artifacts under /tmp)
+        // showFirstRunSheet checks if any issues exist — daemon_artifacts is a warning, so it's an issue
+        // This test verifies first-run is NOT shown when only the key is already set:
+        // Re-test with key already set
+        defaults.set(true, forKey: "readiness.firstRunShown")
+        let state2 = makeState(
+            repoRoot: "/tmp",
+            defaults: defaults,
+            environment: [
+                "BRAIN_PATH": tmpFile.path,
+                "ANTHROPIC_API_KEY": "sk-ant",
+                "OPENAI_API_KEY": "sk-oai"
+            ],
+            axGranted: true,
+            screenRecordingGranted: true
+        )
+        await state2.refresh()
+        XCTAssertFalse(state2.showFirstRunSheet)
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cd shell && swift test --filter ReadinessState 2>&1 | tail -20
+```
+
+Expected: compile error — `ReadinessState` not found.
+
+**Step 3: Create ReadinessState.swift**
+
+```swift
+// shell/Sources/MojoShell/Readiness/ReadinessState.swift
+import ApplicationServices
+import CoreGraphics
+import Foundation
+
+@MainActor
+final class ReadinessState: ObservableObject {
+    @Published var coreIssues: [ReadinessIssue] = []
+    @Published var featureIssues: [ReadinessFeature: [ReadinessIssue]] = [:]
+    @Published var showFirstRunSheet: Bool = false
+    @Published var isRefreshing: Bool = false
+
+    private let daemonManager: DaemonManager
+    private let defaults: UserDefaults
+    private let environment: [String: String]
+    private let axCheck: () -> Bool
+    private let screenRecordingCheck: () -> Bool
+
+    init(
+        daemonManager: DaemonManager,
+        defaults: UserDefaults = .standard,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        axCheck: @escaping () -> Bool = { AXIsProcessTrusted() },
+        screenRecordingCheck: @escaping () -> Bool = { CGPreflightScreenCaptureAccess() }
+    ) {
+        self.daemonManager = daemonManager
+        self.defaults = defaults
+        self.environment = environment
+        self.axCheck = axCheck
+        self.screenRecordingCheck = screenRecordingCheck
+    }
+
+    func refresh() async {
+        isRefreshing = true
+        defer { isRefreshing = false }
+
+        coreIssues = sorted(buildCoreIssues())
+        featureIssues = [
+            .computerUse: sorted(buildComputerUseIssues()),
+            .llm: sorted(buildLLMIssues()),
+        ]
+
+        // First-run sheet: show once if issues exist and key not yet set
+        let hasAnyIssue = !coreIssues.isEmpty || featureIssues.values.contains(where: { !$0.isEmpty })
+        if hasAnyIssue && !defaults.bool(forKey: "readiness.firstRunShown") {
+            showFirstRunSheet = true
+        }
+    }
+
+    func refreshComputerUse() async {
+        featureIssues[.computerUse] = sorted(buildComputerUseIssues())
+    }
+
+    func isReady(for feature: ReadinessFeature) -> Bool {
+        let issues = featureIssues[feature] ?? []
+        return !issues.contains(where: { $0.severity == .blocking })
+    }
+
+    func axPermissionGranted() -> Bool {
+        axCheck()
+    }
+
+    // MARK: - Core checks
+
+    private func buildCoreIssues() -> [ReadinessIssue] {
+        var issues: [ReadinessIssue] = []
+
+        // repo_root
+        var isDir: ObjCBool = false
+        let rootExists = FileManager.default.fileExists(atPath: daemonManager.repoRoot, isDirectory: &isDir) && isDir.boolValue
+        if !rootExists {
+            issues.append(ReadinessIssue(
+                id: "repo_root",
+                title: "Repository root not found",
+                fixInstruction: "Ensure the MojoShell repository is present at: \(daemonManager.repoRoot)",
+                actionURL: nil,
+                severity: .blocking
+            ))
+        }
+
+        // brain_file
+        let brainPath = resolvedBrainPath()
+        if !FileManager.default.fileExists(atPath: brainPath) {
+            issues.append(ReadinessIssue(
+                id: "brain_file",
+                title: "Brain file missing",
+                fixInstruction: "Ensure the brain file exists at: \(brainPath)",
+                actionURL: nil,
+                severity: .blocking
+            ))
+        }
+
+        // daemon_artifacts
+        let missingArtifacts = daemonManager.serverDefinitions
+            .filter { !FileManager.default.fileExists(atPath: $0.scriptPath) }
+        if !missingArtifacts.isEmpty {
+            let names = missingArtifacts.map(\.name).joined(separator: ", ")
+            issues.append(ReadinessIssue(
+                id: "daemon_artifacts",
+                title: "MCP server build artifacts missing",
+                fixInstruction: "Run `npm run build` in each server directory. Missing: \(names)",
+                actionURL: nil,
+                severity: .warning
+            ))
+        }
+
+        return issues
+    }
+
+    private func resolvedBrainPath() -> String {
+        if let override = environment["BRAIN_PATH"], !override.isEmpty {
+            return override
+        }
+        return "\(daemonManager.repoRoot)/knowledge-corpus/data/mojosolo_operating_brain.json"
+    }
+
+    // MARK: - Feature checks
+
+    private func buildComputerUseIssues() -> [ReadinessIssue] {
+        var issues: [ReadinessIssue] = []
+
+        if !axCheck() {
+            issues.append(ReadinessIssue(
+                id: "accessibility",
+                title: "Accessibility permission missing",
+                fixInstruction: "Open System Settings → Privacy & Security → Accessibility, then enable MojoShell.",
+                actionURL: URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"),
+                severity: .blocking
+            ))
+        }
+
+        if !screenRecordingCheck() {
+            issues.append(ReadinessIssue(
+                id: "screen_recording",
+                title: "Screen Recording permission missing",
+                fixInstruction: "Open System Settings → Privacy & Security → Screen Recording, then enable MojoShell.",
+                actionURL: URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"),
+                severity: .warning
+            ))
+        }
+
+        return issues
+    }
+
+    private func buildLLMIssues() -> [ReadinessIssue] {
+        let hasAnthropic = !(environment["ANTHROPIC_API_KEY"] ?? "").isEmpty
+        let hasOpenAI = !(environment["OPENAI_API_KEY"] ?? "").isEmpty
+
+        if !hasAnthropic && !hasOpenAI {
+            return [ReadinessIssue(
+                id: "llm_no_keys",
+                title: "No LLM API keys configured",
+                fixInstruction: "Set ANTHROPIC_API_KEY or OPENAI_API_KEY in your environment.",
+                actionURL: nil,
+                severity: .blocking
+            )]
+        }
+
+        if hasAnthropic != hasOpenAI {
+            return [ReadinessIssue(
+                id: "llm_one_key",
+                title: "Only one LLM provider configured",
+                fixInstruction: "Set both ANTHROPIC_API_KEY and OPENAI_API_KEY for full LLM fallback coverage.",
+                actionURL: nil,
+                severity: .info
+            )]
+        }
+
+        return []
+    }
+
+    // MARK: - Ordering
+
+    private func sorted(_ issues: [ReadinessIssue]) -> [ReadinessIssue] {
+        issues.sorted { lhs, rhs in
+            let lPriority = severityPriority(lhs.severity)
+            let rPriority = severityPriority(rhs.severity)
+            if lPriority != rPriority { return lPriority < rPriority }
+            return lhs.id < rhs.id
+        }
+    }
+
+    private func severityPriority(_ s: ReadinessSeverity) -> Int {
+        switch s {
+        case .blocking: return 0
+        case .warning:  return 1
+        case .info:     return 2
+        }
+    }
+}
+```
+
+**Step 4: Run all ReadinessState tests**
+
+```bash
+cd shell && swift test --filter ReadinessState 2>&1 | tail -30
+```
+
+Expected: All tests pass. If `ApplicationServices` or `CoreGraphics` import fails under SwiftPM, check that the `MojoShell` target already links these frameworks in `Package.swift`.
+
+**Step 5: Run full test suite**
+
+```bash
+cd shell && swift test 2>&1 | tail -20
+```
+
+Expected: All tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add shell/Sources/MojoShell/Readiness/ shell/Tests/MojoShellTests/ReadinessStateTests.swift
+git commit -m "feat(readiness): add ReadinessState with core and feature checks, first-run gating, stable ordering"
+```
+
+---
+
+### Task 4: Wire DaemonManager sharing in MojoShellApp
+
+The design requires one `DaemonManager` instance shared between `AppState` and `ReadinessState`. Currently `MojoShellApp` creates `AppState` with its own internal daemon.
+
+**Files:**
+- Modify: `shell/Sources/MojoShell/App/MojoShellApp.swift`
+- Modify: `shell/Sources/MojoShell/App/AppState.swift` (verify it already accepts `DaemonManager` in init)
+
+**Step 1: Verify AppState.init signature**
+
+Read `AppState.swift` and confirm `init(daemons: DaemonManager, ...)` exists. The previous session already implemented this. If it does, no changes needed to AppState.
+
+**Step 2: Update MojoShellApp.swift**
+
+Replace the current file content:
+
+```swift
+// shell/Sources/MojoShell/App/MojoShellApp.swift
+import SwiftUI
+
+@main
+struct MojoShellApp: App {
+    @StateObject private var appState: AppState
+    @StateObject private var readiness: ReadinessState
+
+    init() {
+        let daemons = DaemonManager()
+        _appState = StateObject(wrappedValue: AppState(daemons: daemons))
+        _readiness = StateObject(wrappedValue: ReadinessState(daemonManager: daemons))
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(appState)
+                .environmentObject(readiness)
+                .frame(minWidth: 1000, minHeight: 650)
+        }
+        .windowStyle(.hiddenTitleBar)
+        .commands {
+            CommandGroup(replacing: .newItem) {}
+        }
+    }
+}
+```
+
+**Step 3: Build to verify it compiles**
+
+```bash
+cd shell && swift build 2>&1 | tail -20
+```
+
+Expected: Build succeeds. If AppState.init doesn't accept `daemons:`, read AppState.swift first and align — the previous session added this parameter.
+
+**Step 4: Commit**
+
+```bash
+git add shell/Sources/MojoShell/App/MojoShellApp.swift
+git commit -m "feat(readiness): wire shared DaemonManager between AppState and ReadinessState in MojoShellApp"
+```
+
+---
+
+### Task 5: CoreIssuesBanner view
+
+**Files:**
+- Create: `shell/Sources/MojoShell/Readiness/CoreIssuesBanner.swift`
+
+No unit tests — this is a pure display component. Manual verification in Task 7.
+
+**Step 1: Create the banner view**
+
+```swift
+// shell/Sources/MojoShell/Readiness/CoreIssuesBanner.swift
+import SwiftUI
+
+struct CoreIssuesBanner: View {
+    @EnvironmentObject private var readiness: ReadinessState
+    @State private var dismissed = false
+
+    private var blockingIssues: [ReadinessIssue] {
+        readiness.coreIssues.filter { $0.severity == .blocking }
+    }
+
+    private var nonBlockingIssues: [ReadinessIssue] {
+        readiness.coreIssues.filter { $0.severity != .blocking }
+    }
+
+    var body: some View {
+        if dismissed || readiness.coreIssues.isEmpty {
+            EmptyView()
+        } else if !blockingIssues.isEmpty {
+            blockingBanner
+        } else {
+            warningIndicator
+        }
+    }
+
+    private var blockingBanner: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+                Text("Environment issues")
+                    .font(.headline)
+                Spacer()
+                Button("Dismiss") { dismissed = true }
+                    .buttonStyle(.plain)
+                    .font(.caption)
+            }
+            ForEach(blockingIssues) { issue in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(issue.title).bold().font(.caption)
+                    Text(issue.fixInstruction).font(.caption).foregroundStyle(.secondary)
+                    if let url = issue.actionURL {
+                        Link("Open Settings", destination: url).font(.caption)
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .background(.red.opacity(0.08))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(.red.opacity(0.3), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .padding(.horizontal)
+        .padding(.top, 8)
+    }
+
+    private var warningIndicator: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.circle")
+                .foregroundStyle(.orange)
+            Text("\(nonBlockingIssues.count) environment warning\(nonBlockingIssues.count == 1 ? "" : "s")")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button("Dismiss") { dismissed = true }
+                .buttonStyle(.plain)
+                .font(.caption)
+        }
+        .padding(8)
+        .padding(.horizontal)
+    }
+}
+```
+
+**Step 2: Build to verify it compiles**
+
+```bash
+cd shell && swift build 2>&1 | tail -10
+```
+
+**Step 3: Commit**
+
+```bash
+git add shell/Sources/MojoShell/Readiness/CoreIssuesBanner.swift
+git commit -m "feat(readiness): add CoreIssuesBanner view"
+```
+
+---
+
+### Task 6: ContentView — banner + refresh wiring
+
+**Files:**
+- Modify: `shell/Sources/MojoShell/App/ContentView.swift`
+
+**Step 1: Update ContentView**
+
+Replace the detail column with a `VStack` that places `CoreIssuesBanner` at the top, and trigger `refresh()` on appear and on scene activation.
+
+```swift
+// shell/Sources/MojoShell/App/ContentView.swift
+import SwiftUI
+
+enum ShellView: String, CaseIterable, Identifiable {
+    case cockpit = "Cockpit"
+    case terminal = "Agent Terminal"
+    case production = "Production"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .cockpit:
+            return "gauge.with.dots.needle.bottom.50percent"
+        case .terminal:
+            return "terminal"
+        case .production:
+            return "film.stack"
+        }
+    }
+}
+
+struct ContentView: View {
+    @EnvironmentObject private var readiness: ReadinessState
+    @State private var selected: ShellView? = .cockpit
+    @Environment(\.scenePhase) private var scenePhase
+
+    var body: some View {
+        NavigationSplitView {
+            List(ShellView.allCases, selection: $selected) { view in
+                Label(view.rawValue, systemImage: view.icon)
+                    .tag(view)
+            }
+            .navigationSplitViewColumnWidth(220)
+            .listStyle(.sidebar)
+        } detail: {
+            VStack(spacing: 0) {
+                CoreIssuesBanner()
+                Group {
+                    switch selected ?? .cockpit {
+                    case .cockpit:
+                        CockpitView()
+                    case .terminal:
+                        AgentTerminalView()
+                    case .production:
+                        ProductionDashboardView()
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: $readiness.showFirstRunSheet) {
+            FirstRunSheet()
+        }
+        .task {
+            await readiness.refresh()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                Task { await readiness.refresh() }
+            }
+        }
+    }
+}
+```
+
+**Step 2: Build**
+
+```bash
+cd shell && swift build 2>&1 | tail -20
+```
+
+`FirstRunSheet` doesn't exist yet — expect a compile error for it. We'll add it in Task 8. For now, comment out the `.sheet` line and the `.task`/`.onChange` to get a clean build for testing `CoreIssuesBanner`.
+
+Actually: leave everything in — we'll create `FirstRunSheet` in the next task so the build will succeed after Task 7. If you need an intermediate build check, add a placeholder:
+
+```swift
+// Temporary placeholder in ContentView.swift during build:
+// Replace FirstRunSheet() with Text("First Run") temporarily
+```
+
+**Step 3: Commit ContentView stub (with FirstRunSheet placeholder)**
+
+```bash
+git add shell/Sources/MojoShell/App/ContentView.swift
+git commit -m "feat(readiness): integrate CoreIssuesBanner and readiness refresh into ContentView"
+```
+
+---
+
+### Task 7: FirstRunSheet view
+
+**Files:**
+- Create: `shell/Sources/MojoShell/Readiness/FirstRunSheet.swift`
+
+**Step 1: Create the sheet**
+
+```swift
+// shell/Sources/MojoShell/Readiness/FirstRunSheet.swift
+import SwiftUI
+
+struct FirstRunSheet: View {
+    @EnvironmentObject private var readiness: ReadinessState
+
+    private var allIssues: [ReadinessIssue] {
+        let core = readiness.coreIssues
+        let feature = readiness.featureIssues.values.flatMap { $0 }
+        return (core + feature).sorted { lhs, rhs in
+            let lp = severityPriority(lhs.severity)
+            let rp = severityPriority(rhs.severity)
+            return lp == rp ? lhs.id < rhs.id : lp < rp
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label("MojoShell Setup", systemImage: "wrench.and.screwdriver")
+                .font(.title2.bold())
+
+            Text("Some environment requirements need attention. Fix them now or continue anyway.")
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(allIssues) { issue in
+                        IssueRow(issue: issue, onRetry: {
+                            Task { await readiness.refresh() }
+                        })
+                    }
+                }
+            }
+
+            Divider()
+
+            HStack {
+                Button("Retry") {
+                    Task { await readiness.refresh() }
+                }
+                Spacer()
+                Button("Continue Anyway") {
+                    markShown()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 480, minHeight: 320)
+    }
+
+    private func markShown() {
+        // ReadinessState doesn't own UserDefaults directly in the sheet context.
+        // We dismiss by setting showFirstRunSheet = false.
+        // The UserDefaults key is written by ReadinessState.markFirstRunShown().
+        readiness.markFirstRunShown()
+    }
+
+    private func severityPriority(_ s: ReadinessSeverity) -> Int {
+        switch s {
+        case .blocking: return 0
+        case .warning:  return 1
+        case .info:     return 2
+        }
+    }
+}
+
+private struct IssueRow: View {
+    let issue: ReadinessIssue
+    let onRetry: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: severityIcon)
+                .foregroundStyle(severityColor)
+                .frame(width: 20)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(issue.title).bold().font(.callout)
+                Text(issue.fixInstruction).font(.caption).foregroundStyle(.secondary)
+                if let url = issue.actionURL {
+                    Link("Open System Settings", destination: url).font(.caption)
+                }
+            }
+            Spacer()
+        }
+    }
+
+    private var severityIcon: String {
+        switch issue.severity {
+        case .blocking: return "xmark.circle.fill"
+        case .warning:  return "exclamationmark.triangle.fill"
+        case .info:     return "info.circle"
+        }
+    }
+
+    private var severityColor: Color {
+        switch issue.severity {
+        case .blocking: return .red
+        case .warning:  return .orange
+        case .info:     return .blue
+        }
+    }
+}
+```
+
+**Step 2: Add `markFirstRunShown()` to ReadinessState**
+
+Append to `ReadinessState.swift`:
+
+```swift
+// Inside ReadinessState, add:
+func markFirstRunShown() {
+    defaults.set(true, forKey: "readiness.firstRunShown")
+    showFirstRunSheet = false
+}
+```
+
+**Step 3: Build**
+
+```bash
+cd shell && swift build 2>&1 | tail -10
+```
+
+Expected: Build succeeds (ContentView's `FirstRunSheet()` reference now resolves).
+
+**Step 4: Run full test suite**
+
+```bash
+cd shell && swift test 2>&1 | tail -20
+```
+
+Expected: All tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add shell/Sources/MojoShell/Readiness/FirstRunSheet.swift shell/Sources/MojoShell/Readiness/ReadinessState.swift
+git commit -m "feat(readiness): add FirstRunSheet and markFirstRunShown()"
+```
+
+---
+
+### Task 8: AgentTerminalView — soft LLM warning
+
+When `.llm` has blocking issues, show a non-blocking info label in `AgentTerminalView`. Do **not** disable terminal interaction.
+
+**Files:**
+- Modify: `shell/Sources/MojoShell/Views/AgentTerminalView.swift`
+
+**Step 1: Add readiness environment object and soft warning label**
+
+In `AgentTerminalView`, add:
+
+```swift
+// After: @EnvironmentObject private var appState: AppState
+@EnvironmentObject private var readiness: ReadinessState
+```
+
+Add this below `Divider()` that separates the scroll area from the input bar (before the `HStack` input row):
+
+```swift
+if !readiness.isReady(for: .llm) {
+    Text("LLM fallback unavailable; deterministic routing still works.")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 10)
+        .padding(.bottom, 4)
+}
+```
+
+**Step 2: Build**
+
+```bash
+cd shell && swift build 2>&1 | tail -10
+```
+
+**Step 3: Commit**
+
+```bash
+git add shell/Sources/MojoShell/Views/AgentTerminalView.swift
+git commit -m "feat(readiness): show soft LLM warning in AgentTerminalView when keys missing"
+```
+
+---
+
+### Task 9: ProductionDashboardView — feature gating
+
+Gate "Run Assembly Workflow" on `readiness.isReady(for: .computerUse)`. Gate "Discover FCP Elements" on `readiness.axPermissionGranted()`.
+
+**Files:**
+- Modify: `shell/Sources/MojoShell/Views/ProductionDashboardView.swift`
+
+**Step 1: Add readiness environment object**
+
+In `ProductionDashboardView`, add:
+
+```swift
+// After: @EnvironmentObject private var appState: AppState
+@EnvironmentObject private var readiness: ReadinessState
+```
+
+**Step 2: Gate "Discover FCP Elements" button**
+
+Change:
+```swift
+Button(isDiscovering ? "Scanning..." : "Discover FCP Elements") {
+    Task { await discoverFcpElements() }
+}
+.disabled(isDiscovering)
+```
+
+To:
+```swift
+Button(isDiscovering ? "Scanning..." : "Discover FCP Elements") {
+    Task { await discoverFcpElements() }
+}
+.disabled(isDiscovering || !readiness.axPermissionGranted())
+```
+
+**Step 3: Gate "Run Assembly Workflow" button and add fix hint**
+
+Change:
+```swift
+Button(isRunningWorkflow ? "Running..." : "Run Assembly Workflow") {
+    Task { await runAssemblyWorkflow() }
+}
+.disabled(isRunningWorkflow)
+```
+
+To:
+```swift
+VStack(alignment: .leading, spacing: 4) {
+    Button(isRunningWorkflow ? "Running..." : "Run Assembly Workflow") {
+        Task { await runAssemblyWorkflow() }
+    }
+    .disabled(isRunningWorkflow || !readiness.isReady(for: .computerUse))
+
+    if !readiness.isReady(for: .computerUse),
+       let firstBlockingIssue = readiness.featureIssues[.computerUse]?.first(where: { $0.severity == .blocking }) {
+        Text(firstBlockingIssue.fixInstruction)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+}
+```
+
+**Step 4: Build**
+
+```bash
+cd shell && swift build 2>&1 | tail -10
+```
+
+**Step 5: Run full test suite**
+
+```bash
+cd shell && swift test 2>&1 | tail -20
+```
+
+**Step 6: Commit**
+
+```bash
+git add shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+git commit -m "feat(readiness): gate Run Assembly on computerUse readiness; gate Discover FCP on AX permission"
+```
+
+---
+
+### Task 10: Final verification
+
+**Step 1: Run full build + tests**
+
+```bash
+cd shell && swift build 2>&1 | tail -10 && swift test 2>&1 | tail -20
+```
+
+Expected: Build succeeds, all tests pass.
+
+**Step 2: Verify new test count includes readiness tests**
+
+```bash
+cd shell && swift test 2>&1 | grep -E "Test Suite|tests passed"
+```
+
+Expected: Includes `ReadinessModelsTests`, `ReadinessStateCoreTests`, `ReadinessStateFeatureTests`, `ReadinessStateOrderingTests`, `ReadinessStateFirstRunTests`.
+
+**Step 3: Final commit if anything was missed**
+
+```bash
+git status
+# Stage and commit any unstaged changes
+```
+
+---
+
+## File Summary
+
+| Action | Path |
+|--------|------|
+| Create | `shell/Sources/MojoShell/Readiness/ReadinessModels.swift` |
+| Create | `shell/Sources/MojoShell/Readiness/ReadinessState.swift` |
+| Create | `shell/Sources/MojoShell/Readiness/CoreIssuesBanner.swift` |
+| Create | `shell/Sources/MojoShell/Readiness/FirstRunSheet.swift` |
+| Create | `shell/Tests/MojoShellTests/ReadinessModelsTests.swift` |
+| Create | `shell/Tests/MojoShellTests/ReadinessStateTests.swift` |
+| Modify | `shell/Sources/MojoShell/Managers/DaemonManager.swift` (expose repoRoot) |
+| Modify | `shell/Sources/MojoShell/App/MojoShellApp.swift` (shared DaemonManager + ReadinessState) |
+| Modify | `shell/Sources/MojoShell/App/ContentView.swift` (banner + refresh + sheet) |
+| Modify | `shell/Sources/MojoShell/Views/AgentTerminalView.swift` (LLM soft warning) |
+| Modify | `shell/Sources/MojoShell/Views/ProductionDashboardView.swift` (feature gating) |
+
+**Total new tests:** 15 (6 models + 5 core + 6 feature/ordering/first-run split across test classes)

--- a/docs/plans/2026-03-13-apple-mcp-governed-roadmap.md
+++ b/docs/plans/2026-03-13-apple-mcp-governed-roadmap.md
@@ -390,9 +390,9 @@ Prove that `apple-mcp` can harvest from deterministic local sources, normalize t
 
 #### Track E: Validation path
 
-- emit review mirror outputs
-- flag low-confidence and overclaimed rules
-- create a human review surface for the generated skills
+- freeze the validation contract and review vocabulary
+- define review mirror output shape and correction loop
+- defer validation implementation until the extraction and compiler path is real
 
 ### Explicit Cuts For This Sprint
 
@@ -409,6 +409,11 @@ Do not cut:
 2. normalized artifact contract
 3. evidence bundle extraction
 4. compiler endpoint for skills
+
+Deferred from this sprint:
+
+- validation implementation beyond contract and output-shape design
+- review UI or rich human-facing validation surfaces
 
 ## Key Decisions
 

--- a/docs/plans/2026-03-13-apple-mcp-governed-roadmap.md
+++ b/docs/plans/2026-03-13-apple-mcp-governed-roadmap.md
@@ -1,0 +1,454 @@
+# Apple MCP Governed Roadmap
+
+Last verified: 2026-03-13
+
+## Status
+
+- `Status`: planning packet
+- `Execution authority`: none
+- `Primary repo`: `apple-mcp`
+- `Plan scope`: governed roadmap for the repo as it exists on committed branch head `e3b2539`
+- `Current local reality at planning time`: active work is continuing on local branch `feat/macos-shell` with uncommitted hydration-pipeline changes that must be preserved
+
+## Canonical Inputs
+
+This roadmap is grounded in the current repo and its existing design documents.
+
+- `README.md`
+- `CLAUDE.md`
+- `docs/macos-shell-architecture.md`
+- `docs/plans/2026-03-12-macos-operator-roadmap.md`
+- `docs/plans/2026-03-13-north-star-hydration-repo-pipeline-plan.md`
+- `docs/plans/2026-03-13-north-star-hydration-rebuild-request.md`
+- `docs/plans/2026-03-13-david-mojosolo-skill-output-spec.md`
+- `hydration-pipeline/src/cli.ts`
+- `knowledge-corpus/data/mojosolo_operating_brain.json`
+
+If this roadmap and the repo diverge, the repo wins for current-state facts and this roadmap remains the intended sequencing document.
+
+## Executive Thesis
+
+`apple-mcp` is not one product.
+
+It is a governed monorepo with four distinct layers that must not be collapsed into one another:
+
+1. deterministic Apple-app MCP servers
+2. a canonical brain and intelligence layer
+3. a hydration and skill-compilation pipeline
+4. a future macOS shell product layer
+
+The biggest mistake available to this repo is trying to make the shell, the hydration compiler, the MCP servers, and downstream Laravel exports all behave like one fused application.
+
+They should instead be sequenced like this:
+
+`deterministic sensors -> normalized artifacts -> grounded extraction -> skill compilation -> validation -> shell / operator product`
+
+That is the governing rule for the roadmap.
+
+## Repo Facts
+
+These facts were verified from the repo at plan time and determine the roadmap shape.
+
+1. The repo already ships Apple-app MCP packages for Notes, Messages, Contacts, Mail, Reminders, Calendar, Maps, and Music.
+2. `knowledge-corpus` already exists and serves the canonical MojoSolo operating brain.
+3. `mail-intelligence` already exists and generates Daily Intel using the three-persona inbox model.
+4. The repo already contains a repo-local `hydration-pipeline` package with explicit commands for `harvest`, `extract`, `compile`, `validate`, and `all`.
+5. The repo already contains multiple hydration planning documents that say the terminal artifact must be deployable `SKILL.md` outputs, not only intermediate evidence bundles.
+6. The repo already has a separate macOS shell architecture document that explicitly says the shell is a product layer on top of the MCP foundation, not a rewrite of it.
+7. The current local branch posture is `feat/macos-shell`, and the working tree contains active, uncommitted hydration-related work. That in-flight work must be preserved and treated as live context, not overwritten by governance cleanup.
+
+## Product Boundaries
+
+### 1. MCP Foundation
+
+Purpose:
+
+- read and mutate native Apple applications through deterministic local tooling
+- stay independently usable
+- remain local-first and safety-aware
+
+What it is not:
+
+- the skill compiler
+- the shell UI
+- the canonical long-term storage layer
+
+### 2. Canonical Brain and Intelligence
+
+Purpose:
+
+- store structured operating context
+- seed persona and company context
+- support mail intelligence and downstream exports
+
+What it is not:
+
+- the primary evidence source for voice truth
+- the final product UI
+
+### 3. Hydration Pipeline
+
+Purpose:
+
+- harvest real signal
+- normalize it
+- extract evidence bundles
+- compile deployable skills
+- emit validation surfaces
+
+What it is not:
+
+- a generic AI summarizer
+- a replacement for the MCP servers
+- a shell application
+
+### 4. macOS Shell
+
+Purpose:
+
+- provide a native operator cockpit on top of the deterministic foundation
+- supervise MCP daemons
+- route intents
+- fall back to computer-use only where direct automation is inadequate
+
+What it is not:
+
+- the first milestone the repo must finish
+- an excuse to skip deterministic pipeline work
+
+## Strategic Priority Order
+
+The repo should be built in this order:
+
+1. govern and stabilize the repo as a recognized KOSMOS surface
+2. harden deterministic harvest sources
+3. finish evidence extraction and skill compilation
+4. finish validation and review loops
+5. only then accelerate the macOS shell into an active build stream
+
+Reasoning:
+
+- the MCP foundation already exists
+- the hydration pipeline is where current leverage and current ambiguity both sit
+- the shell is valuable, but it is downstream of trustworthy data, evidence, and compiled operating artifacts
+
+## Workstreams
+
+| Workstream | Purpose | Priority | Governing rule |
+| --- | --- | --- | --- |
+| `WS1` MCP package foundation | keep Notes/Messages/Mail/etc. reliable and shippable | High | do not break standalone server usability |
+| `WS2` Hydration pipeline | build the deterministic harvest -> compile spine | Highest | deterministic before LLM; evidence before skill |
+| `WS3` Canonical brain + mail intelligence | keep brain and Daily Intel coherent with persona model | High | brain seeds context; harvested evidence grounds behavior |
+| `WS4` macOS shell | build cockpit, router, daemon supervision, computer-use seam | Medium | shell depends on stable lower layers |
+| `WS5` packaging and commercialization | publishing, onboarding, safety posture, distribution | Medium | package after layers are coherent |
+
+## Now / Next / Later
+
+### Now
+
+Friday, March 13, 2026 through Tuesday, March 31, 2026
+
+- register and govern the repo
+- preserve and rationalize active hydration-pipeline work
+- make the deterministic source model explicit
+- choose and implement the first filesystem/Desktop ingestion path
+- finish the minimum normalized artifact contract
+- prove one end-to-end hydration run can produce evidence and at least one skill artifact target
+
+### Next
+
+April 2026
+
+- finish compiler outputs for David voice, MojoSolo brand, and unified wrapper
+- build validation mirrors and rule audits
+- refine transcript provider seams without coupling the repo to one transcript vendor
+- improve knowledge-corpus projection and mail-intelligence alignment
+
+### Later
+
+After the hydration compiler and validation loop are trustworthy
+
+- accelerate SwiftUI shell build-out
+- add local daemon supervision and routing
+- add computer-use provider runtime where no deterministic MCP surface exists
+- harden packaging and operator onboarding
+
+## Phase Roadmap
+
+## Phase 0: Governance and Repo Grounding
+
+Status:
+
+- partially complete
+
+Completed:
+
+- repo registered in the local KOSMOS registry
+- repo-onboard state adopted
+- `kosmos knock apple-mcp` now resolves and reports repo truth
+
+Still open:
+
+- `mojoOS` has no persisted portfolio row for `apple-mcp`
+- the repo remains `warn` because active work is intentionally in flight
+
+Exit criteria:
+
+- `apple-mcp` remains registered with a stable onboard fingerprint
+- the team agrees that in-flight `feat/macos-shell` work is preserved, not overwritten
+- this roadmap exists as a committed repo-local planning packet
+
+## Phase 1: Deterministic Source and Harvest Spine
+
+Window:
+
+- immediate priority for March 13-31, 2026
+
+Objective:
+
+Make the hydration pipeline unquestionably deterministic at the source and normalization layers.
+
+Must-haves:
+
+- formalize source taxonomy:
+  - Apple Mail
+  - Apple Messages
+  - Apple Notes
+  - canonical brain
+  - transcript provider seam
+  - direct filesystem/Desktop source
+- add a first-class filesystem/Desktop provider that performs recursive inventory, MIME/type detection, hashing, and ignore rules
+- keep Mail, Notes, and Messages as separate adapters rather than pretending they are generic files
+- define a single normalized `SignalDocument` shape with provenance and channel semantics
+- ensure artifact runs write into `artifacts/north-star-hydration/<run-id>/`
+
+Non-goals:
+
+- do not build the shell UI in this phase
+- do not overfit the pipeline to Otter or Fireflies
+- do not collapse the canonical brain into harvested evidence
+
+Exit criteria:
+
+- one repeatable `harvest` run succeeds across the chosen source mix
+- normalized artifacts are deterministic and inspectable
+- Desktop/filesystem ingestion exists as a separate provider, not an ad hoc hack inside another source
+
+## Phase 2: Evidence Extraction and Skill Compilation
+
+Window:
+
+- April 2026
+
+Objective:
+
+Turn normalized source material into grounded evidence bundles and then into deployable skills.
+
+Must-haves:
+
+- `DavidVoiceEvidenceBundle`
+- `MojoSoloBrandEvidenceBundle`
+- compiler outputs for:
+  - `david-voice-skill/SKILL.md`
+  - `mojosolo-brand-skill/SKILL.md`
+  - `david-mojosolo-unified-skill/SKILL.md`
+- separation between evidence artifact and skill artifact
+- explicit uncertainty policy and anti-pattern extraction
+
+Non-goals:
+
+- do not stop at YAML
+- do not emit skill rules that cannot be tied back to evidence
+- do not let shell design work preempt compiler completeness
+
+Exit criteria:
+
+- the pipeline can run `harvest -> extract -> compile`
+- the output skills are actually loadable by downstream agents
+- evidence, provenance, and freshness are included in supporting artifacts
+
+## Phase 3: Validation and Review Loop
+
+Window:
+
+- immediately after compiler viability, likely late April 2026
+
+Objective:
+
+Create a human-review layer that can refine or reject compiled behavior without corrupting provenance.
+
+Must-haves:
+
+- review mirrors for generated skills
+- rule audit outputs
+- explicit flags such as:
+  - too polished
+  - too corporate
+  - wrong persona mode
+  - low-confidence rule
+  - unsupported inference
+- correction workflow that feeds the compiler rather than bypassing it
+
+Exit criteria:
+
+- a human can review a generated skill and understand why each major rule exists
+- low-confidence rules are visible and removable
+- validation becomes a standard run stage, not an ad hoc note
+
+## Phase 4: macOS Shell Alpha
+
+Window:
+
+- only after the lower layers are trustworthy
+
+Objective:
+
+Build the native shell as an operator product on top of the stable repo foundation.
+
+Must-haves:
+
+- SwiftUI shell scaffold
+- daemon manager for local MCP processes
+- deterministic intent router
+- computer-use provider seam
+- cockpit, terminal, and production dashboard primitives
+
+Rules:
+
+- deterministic MCP tools first
+- computer-use only when direct automation is insufficient
+- shell depends on interfaces and structured outputs, not repo internals
+
+Exit criteria:
+
+- shell can launch and supervise the local MCP stack
+- shell can route a defined set of intents against existing MCP tools
+- shell can surface structured outputs without inventing its own shadow logic
+
+## Phase 5: Packaging and Productization
+
+Window:
+
+- after shell alpha and validated compiler flows
+
+Objective:
+
+Turn the repo into a repeatable product surface for personal-first use and later commercial hardening.
+
+Must-haves:
+
+- package and distribution strategy per module
+- onboarding and permissions guidance
+- secrets and account isolation posture
+- clear boundary between personal defaults and distributable defaults
+
+## Immediate Sprint: March 13-31, 2026
+
+This is the working sprint the repo should run right now.
+
+### Sprint Name
+
+`Deterministic Hydration Spine`
+
+### Sprint Goal
+
+Prove that `apple-mcp` can harvest from deterministic local sources, normalize them into inspectable evidence artifacts, and compile toward deployable skill outputs without letting the shell work overtake the pipeline.
+
+### Must-Have Outcomes
+
+1. one explicit Desktop/filesystem source implementation
+2. one normalized source registry and `SignalDocument` contract
+3. one harvest run that writes complete artifacts for the selected sources
+4. one extraction layer that outputs evidence bundles with provenance
+5. one compiler skeleton that points to real `SKILL.md` outputs, not only placeholder YAML
+
+### Sprint Tracks
+
+#### Track A: Source model and provider seams
+
+- define source taxonomy and interfaces
+- separate filesystem/Desktop ingest from Mail/Notes/Messages providers
+- preserve transcript providers as a seam, not a hardcoded assumption
+
+#### Track B: Deterministic harvest and normalization
+
+- implement or harden Desktop/filesystem provider
+- unify normalization around a common signal contract
+- preserve provenance, timestamps, source identity, and hashes
+
+#### Track C: Evidence extraction
+
+- emit David and MojoSolo evidence bundles
+- make first-person / third-person and persona separation explicit
+- score evidence without overclaiming
+
+#### Track D: Compiler path
+
+- connect evidence bundles to skill compiler outputs
+- write artifact destinations and terminal file layout
+- guarantee compiler output is the endpoint, not an optional afterthought
+
+#### Track E: Validation path
+
+- emit review mirror outputs
+- flag low-confidence and overclaimed rules
+- create a human review surface for the generated skills
+
+### Explicit Cuts For This Sprint
+
+If time compresses, cut in this order:
+
+1. shell implementation work
+2. transcript-vendor expansion
+3. richer UI or cockpit ideas
+4. packaging polish
+
+Do not cut:
+
+1. deterministic source boundaries
+2. normalized artifact contract
+3. evidence bundle extraction
+4. compiler endpoint for skills
+
+## Key Decisions
+
+These decisions are now locked unless new evidence forces a change.
+
+1. The hydration bundle is an intermediate artifact, not the final artifact.
+2. The final artifacts for the hydration path are deployable skills.
+3. Mail, Notes, Messages, and Desktop/filesystem are distinct source types.
+4. The canonical brain is seed context and operating context, not the sole source of voice truth.
+5. The shell is a downstream product layer, not the first critical milestone.
+
+## Open Questions
+
+1. Should Desktop/filesystem ingest focus on `~/Desktop` first, or a broader local-source registry from day one?
+2. Which normalized source schema should become canonical across Mail, Messages, Notes, files, and transcripts?
+3. Should transcript support stay `Otter`-first because of current repo truth, or move immediately to a cleaner generic seam with fixtures only?
+4. Which artifacts should be committed versus treated as generated run output only?
+5. When should `apple-mcp` be exported into `mojoOS` portfolio state so KOSMOS knock can reach `current` instead of `warn`?
+
+## Success Metrics
+
+- one new source can be added without rewriting the pipeline
+- one hydration run can be replayed deterministically against the same input window
+- generated skill outputs are grounded in evidence and usable by downstream agents
+- human review focuses on rules and evidence quality, not on reconstructing what happened
+- shell work is clearly sequenced behind lower-layer trust rather than competing with it
+
+## Failure Modes To Avoid
+
+- treating the shell as the repo's main objective before the compiler path is trustworthy
+- mixing filesystem harvest into Mail or Notes adapters instead of giving it a real provider
+- letting transcript-vendor assumptions shape the entire architecture
+- using the canonical brain as if it were enough evidence for a voice compiler
+- stopping at intermediate YAML bundles and calling the system done
+- burying provenance so a human cannot tell where a generated rule came from
+
+## Recommended Next Moves
+
+1. preserve the active `feat/macos-shell` changes as the live workstream
+2. land this roadmap packet in the repo
+3. write the follow-on implementation packet for `Deterministic Hydration Spine`
+4. if needed, split shell work and hydration work into clearly separate branches or worktrees
+5. export `apple-mcp` into persisted `mojoOS` portfolio state after the roadmap and immediate packet exist

--- a/docs/plans/2026-03-13-david-mojosolo-skill-output-spec.md
+++ b/docs/plans/2026-03-13-david-mojosolo-skill-output-spec.md
@@ -1,0 +1,402 @@
+# David + MojoSolo Skill Output Specification
+
+**Goal:** Define the terminal artifacts emitted by the North Star hydration pipeline so the extractor is designing toward deployable cross-tool skills, not just an intermediate YAML bundle.
+
+**Consumers:** Claude Code, Codex, Cursor, and any future agent runtime that can load a local `SKILL.md`.
+
+**Core rule:** The hydration bundle is an evidence artifact. It is not the final artifact. The final artifact is one or more deployable skills.
+
+---
+
+## Required Output Artifacts
+
+The pipeline must emit these artifacts:
+
+1. `david-voice-skill/SKILL.md`
+2. `mojosolo-brand-skill/SKILL.md`
+3. `david-mojosolo-unified-skill/SKILL.md` (recommended wrapper)
+
+Optional supporting artifacts:
+
+- `evidence/david_hydration_bundle.yaml`
+- `evidence/mojosolo_brand_bundle.yaml`
+- `evidence/source_registry.yaml`
+- `validation/david_skill_review.md`
+- `validation/mojosolo_skill_review.md`
+
+The evidence artifacts exist to justify the skill. The skill is the thing downstream agents actually load.
+
+---
+
+## Skill Architecture
+
+### Layer 1: Evidence Extraction
+
+Input sources:
+
+- Apple Mail threads
+- Apple Messages history
+- Apple Notes writing samples
+- Fireflies transcripts
+- Vector-search recall over Fireflies transcripts
+- `knowledge-corpus/data/mojosolo_operating_brain.json` as seed context
+
+Output:
+
+- person-level evidence bundle
+- brand-level evidence bundle
+- provenance and confidence metadata
+
+### Layer 2: Skill Compilation
+
+Compiler input:
+
+- extracted evidence bundle
+- explicit target artifact type
+- optional validation corrections
+
+Compiler output:
+
+- `SKILL.md` files with executable operating guidance
+- optional reference files and templates if the resulting skill needs them
+
+---
+
+## Artifact 1: `david-voice-skill/SKILL.md`
+
+### Purpose
+
+This skill lets an agent write as David with enough fidelity that the result sounds plausibly authored by him, while preserving safety and uncertainty boundaries.
+
+### Trigger Scope
+
+Use this skill when the task is:
+
+- writing an email as David
+- drafting a text or DM as David
+- rewriting a note into David's real voice
+- responding to a client or collaborator in David's tone
+- producing first-person writing where David is the speaker
+
+Do not use it for broad company positioning unless the request is explicitly personal-first.
+
+### Required Sections
+
+#### 1. Frontmatter
+
+Must define:
+
+- `name`
+- `description`
+
+Description must mention:
+
+- write as David
+- email, text, notes, proposals, responses
+- voice fidelity over polish
+- when not to use the skill
+
+#### 2. Mission
+
+One concise paragraph stating:
+
+- the job is to sound like David, not a polished corporate approximation
+- authentic roughness is preserved when grounded in evidence
+- confidence must track available signal
+
+#### 3. Source of Truth
+
+Must define:
+
+- skill version
+- evidence window
+- freshness date
+- dominant source types
+- known blind spots
+- what was inferred vs directly observed
+
+#### 4. Voice Rules
+
+Must include explicit instructions for:
+
+- cadence
+- sentence length tendencies
+- setup phrases
+- qualifiers and hedges
+- how David transitions into the actual point
+- when he is direct vs elliptical
+- how much polish is too much
+
+#### 5. Phrase Bank
+
+Must contain:
+
+- signature phrases
+- setup phrases
+- transition phrases
+- emphasis repeaters
+- closers
+- phrases to avoid because they sound too clean or too corporate
+
+#### 6. Channel Rules
+
+Separate rules for:
+
+- email
+- text / iMessage
+- notes / memos
+- proposals or client-facing writing
+
+Each channel must specify:
+
+- expected level of polish
+- expected brevity
+- whether fragments are acceptable
+- whether explicit CTA language is natural
+
+#### 7. Do / Don't Transform Rules
+
+Must include examples of:
+
+- too-corporate -> David-like
+- too-marketing -> David-like
+- too-clean -> David-like
+- too-vague -> David-like
+
+These should be transformation patterns, not generic style advice.
+
+#### 8. Anti-Patterns
+
+Must explicitly forbid:
+
+- corporate abstraction
+- inflated certainty
+- generic sales language
+- sounding like a polished ghostwriter
+- removing all rough edges
+- fake confidence where evidence is thin
+
+#### 9. Uncertainty Policy
+
+Must tell the agent what to do when:
+
+- the request needs domain content but evidence is thin
+- the request conflicts with known voice patterns
+- the request is high-stakes or reputationally risky
+
+#### 10. Working Modes
+
+The David voice skill must support at least:
+
+- `reply_as_david`
+- `draft_as_david`
+- `rewrite_into_david_voice`
+- `audit_for_david_voice`
+
+---
+
+## Artifact 2: `mojosolo-brand-skill/SKILL.md`
+
+### Purpose
+
+This skill lets an agent write for MojoSolo as a company and switch deliberately among the repo's three operating personas.
+
+### Trigger Scope
+
+Use this skill when the task is:
+
+- writing company positioning
+- creating website or brand copy
+- drafting proposals for MojoSolo
+- describing methodology, systems, or product logic
+- writing in one of the company personas
+
+Do not use it for first-person David ghostwriting unless the request is explicitly personal.
+
+### Required Modes
+
+This skill must support four explicit output modes:
+
+1. `write_for_mojosolo_author`
+2. `write_for_mojosolo_operator`
+3. `write_for_mojosolo_machine`
+4. `brand_audit`
+
+### Required Sections
+
+#### 1. Brand Thesis
+
+Define:
+
+- what MojoSolo is
+- what category language it accepts and rejects
+- what makes the brand distinct
+- what kind of intelligence/product posture it projects
+
+#### 2. Persona Map
+
+Define all three personas explicitly.
+
+For each persona include:
+
+- role in the business
+- tonal center
+- vocabulary bias
+- preferred sentence shape
+- what it should never sound like
+- ideal use cases
+
+#### 3. Language Map
+
+Must define what MojoSolo calls:
+
+- the company
+- the system
+- the brain
+- the inbox layer
+- extraction / hydration work
+- agent / AI behavior
+- products, offers, and workflows
+
+This section is mandatory because named concepts are part of brand consistency.
+
+#### 4. Messaging Pillars
+
+Must define:
+
+- primary claims the brand can make
+- supporting proof patterns
+- what counts as overclaiming
+- what kind of transformation language is valid
+
+#### 5. Anti-Patterns
+
+Must explicitly prohibit:
+
+- SaaS boilerplate
+- startup hype language
+- generic AI future-talk
+- consultant cliches
+- benefit-density without mechanism
+- empty premium-brand language
+
+#### 6. Offer Framing
+
+Must define how MojoSolo should talk about:
+
+- services
+- systems
+- automation
+- media workflows
+- operator intelligence
+- implementation boundaries
+
+#### 7. Audience Adaptation
+
+Must define how the brand shifts for:
+
+- clients
+- internal use
+- collaborators
+- technical builders
+- creative partners
+
+The mode should change, but the brand should remain recognizable.
+
+#### 8. Calibration Examples
+
+Must include:
+
+- on-brand snippets
+- off-brand snippets
+- transforms from generic copy to MojoSolo copy
+
+---
+
+## Artifact 3: `david-mojosolo-unified-skill/SKILL.md`
+
+### Purpose
+
+This wrapper skill gives downstream agents one entry point while preserving explicit mode switches.
+
+### Required Modes
+
+The unified skill must expose these exact modes:
+
+1. `write_as_david`
+2. `write_for_mojosolo_author`
+3. `write_for_mojosolo_operator`
+4. `write_for_mojosolo_machine`
+5. `audit_output_against_source_voice`
+
+### Required Behavior
+
+- It must route personal-first writing to David rules.
+- It must route company writing to MojoSolo brand rules.
+- It must refuse silent blending between personal and company voices.
+- It must tell the caller which mode it selected when the request is ambiguous.
+- It must surface low-confidence warnings when evidence is thin.
+
+---
+
+## Compiler Input Contract
+
+The compiler stage must consume evidence organized around these domains:
+
+### Personal Voice Domain
+
+- phrasing patterns
+- cadence patterns
+- channel-specific behavior
+- confidence-weighted quotes
+- anti-patterns inferred from real writing
+
+### Brand Domain
+
+- core concepts
+- named systems
+- methodology terms
+- persona distinctions
+- offer and positioning language
+
+### Provenance Domain
+
+- source registry
+- date coverage
+- confidence per claim
+- direct quote inventory
+- validation corrections
+
+The compiler must not emit a rule that cannot be tied back to evidence, pattern extraction, or explicit human correction.
+
+---
+
+## Validation Requirements
+
+A generated skill is only acceptable if it passes all of these checks:
+
+1. A reviewer can identify the intended mode without being told.
+2. The David skill does not collapse into generic founder voice.
+3. The MojoSolo skill preserves the three-persona distinction.
+4. The wrapper skill does not silently blur personal and company voice.
+5. Claims and wording rules are traceable to evidence.
+6. The skill is usable by an agent without loading the raw evidence bundle.
+7. The skill contains explicit anti-patterns and uncertainty behavior.
+
+---
+
+## Non-Goals
+
+These are not acceptable terminal artifacts:
+
+- a YAML-only hydration bundle with no skill output
+- a flat biography of David
+- a CRM-style contact profile
+- a generic brand guide with no agent instructions
+- a single blended voice that erases the Author / Operator / Machine distinction
+
+---
+
+## Immediate Implication For North Star Hydration
+
+The current packet can remain the extractor if desired, but it is incomplete for this use case. A second-stage compiler is mandatory unless the packet itself is upgraded to emit deployable skills.

--- a/docs/plans/2026-03-13-deterministic-hydration-spine-implementation-packet.md
+++ b/docs/plans/2026-03-13-deterministic-hydration-spine-implementation-packet.md
@@ -1,0 +1,385 @@
+# Deterministic Hydration Spine Implementation Packet
+
+Last verified: 2026-03-13
+
+## Status
+
+- `Status`: implementation packet
+- `Execution authority`: none until explicitly approved
+- `Parent roadmap`: `docs/plans/2026-03-13-apple-mcp-governed-roadmap.md`
+- `Target repo area`: `hydration-pipeline`
+- `Planning base`: committed repo head `e3b2539`
+
+## Objective
+
+Build the first trustworthy spine of the hydration system:
+
+`source taxonomy -> deterministic harvest -> canonical SignalDocument -> evidence bundle -> skill compiler skeleton`
+
+This packet intentionally stops before validation implementation and before more shell work.
+
+## Scope Lock
+
+This packet covers only:
+
+1. deterministic source boundaries
+2. a unified normalized document contract
+3. a first Desktop/filesystem provider
+4. one evidence-bundle path
+5. one compiler skeleton that emits real skill-file targets
+
+This packet does not cover:
+
+- validation UI
+- shell implementation
+- transcript-vendor expansion beyond the existing seam
+- packaging or distribution work
+
+## Current Starting Point
+
+At `e3b2539`, the repo already has:
+
+- `hydration-pipeline/src/cli.ts`
+- `hydration-pipeline/src/config.ts`
+- source providers for:
+  - `mailSource.ts`
+  - `messagesSource.ts`
+  - `notesSource.ts`
+  - `corpusSource.ts`
+- per-channel normalization files for:
+  - `mailNormalization.ts`
+  - `messagesNormalization.ts`
+  - `notesNormalization.ts`
+- run artifact folder creation in `output/artifactPaths.ts`
+
+What is still missing for the actual target system:
+
+- one canonical `SignalDocument` contract shared across all sources
+- a first-class Desktop/filesystem source
+- extraction modules
+- compiler modules
+- a unified artifact manifest that ties harvest -> evidence -> skills together
+
+## Governing Decisions
+
+1. Desktop/filesystem ingest is a separate deterministic provider.
+2. Mail, Messages, Notes, and files are distinct source types and stay that way.
+3. The canonical brain is seed context and metadata, not proof of voice on its own.
+4. The endpoint of this sprint is skill-oriented compiler output, not only harvest JSON.
+5. Validation is contract-only in this packet and should not expand into another build stream yet.
+
+## P0 Deliverables
+
+### Deliverable 1: Source taxonomy and canonical registry
+
+Create one source taxonomy that every harvested item can map to.
+
+Required source types for this sprint:
+
+- `mail`
+- `message`
+- `note`
+- `filesystem`
+- `corpus_seed`
+
+Required output:
+
+- one canonical source registry artifact per run
+
+Proposed new file:
+
+- `hydration-pipeline/src/normalize/sourceRegistry.ts`
+
+Responsibilities:
+
+- define source-type metadata
+- define collector identifiers
+- emit the run-local source registry artifact
+
+### Deliverable 2: Canonical `SignalDocument`
+
+Unify the current per-channel normalization outputs under one shared document shape.
+
+Proposed new files:
+
+- `hydration-pipeline/src/normalize/signalDocument.ts`
+- `hydration-pipeline/src/normalize/provenance.ts`
+
+Current channel-specific normalizers should map into the shared shape instead of each inventing their own schema.
+
+Required minimum fields:
+
+```ts
+export interface SignalDocument {
+  id: string;
+  sourceType: "mail" | "message" | "note" | "filesystem" | "corpus_seed";
+  sourceId: string;
+  collector: string;
+  channel: string;
+  authoredBy: "david" | "external" | "mixed" | "unknown";
+  personaHint: "author" | "operator" | "machine" | "unknown";
+  timestamp: string;
+  rawTimestamp: string;
+  title: string | null;
+  text: string;
+  participants: string[];
+  tags: string[];
+  evidenceHash: string;
+  provenance: {
+    directness: "direct" | "quoted" | "third_party" | "inferred";
+    sourcePath?: string;
+    sourceApp?: string;
+    freshnessCapturedAt: string;
+  };
+  metadata: Record<string, unknown>;
+}
+```
+
+Acceptance rule:
+
+- mail, messages, notes, and filesystem documents must all serialize to this one interface
+
+### Deliverable 3: Desktop/filesystem provider
+
+Implement the first deterministic filesystem source.
+
+Proposed new files:
+
+- `hydration-pipeline/src/providers/filesystemSource.ts`
+- `hydration-pipeline/src/providers/filesystemRules.ts`
+
+Required behaviors:
+
+- root path defaults to `~/Desktop` unless overridden
+- recursive inventory
+- ignore rules
+- MIME/type detection
+- size capture
+- modification timestamp capture
+- content hashing
+- UTF-8 text extraction for supported text-like files
+- binary-safe metadata-only handling for unsupported binaries
+
+Required config additions in `hydration-pipeline/src/config.ts`:
+
+- `filesystemRoot?: string`
+- `filesystemLimit?: number`
+- `filesystemMode?: "desktop" | "path"`
+
+Required CLI additions in `hydration-pipeline/src/cli.ts`:
+
+- `--filesystem-root <path>`
+- `--filesystem-limit <n>`
+- `--filesystem-mode <desktop|path>`
+
+Required output artifacts:
+
+- `harvest/filesystem-harvest.json`
+- `harvest/filesystem-normalized.json`
+
+### Deliverable 4: Unified harvest manifest
+
+After harvest, each run should emit one manifest that describes what was actually captured.
+
+Proposed new file:
+
+- `hydration-pipeline/src/output/runManifest.ts`
+
+Artifact:
+
+- `logs/run-manifest.json`
+
+Required contents:
+
+- run id
+- config summary
+- source registry summary
+- counts by source type
+- errors by source
+- artifact paths produced
+
+### Deliverable 5: Evidence extraction v1
+
+Build one real extraction layer.
+
+Proposed new files:
+
+- `hydration-pipeline/src/extract/davidVoiceEvidence.ts`
+- `hydration-pipeline/src/extract/mojosoloBrandEvidence.ts`
+- `hydration-pipeline/src/extract/evidenceScoring.ts`
+
+Required outputs:
+
+- `evidence/david_voice_evidence.json`
+- `evidence/mojosolo_brand_evidence.json`
+
+Required v1 behavior:
+
+- select candidate `SignalDocument`s
+- separate first-person from third-person signal
+- separate David voice evidence from company/brand evidence
+- preserve provenance references back to source document ids
+- emit confidence notes without inventing certainty
+
+Acceptance rule:
+
+- each major extracted rule or observation must point back to source evidence ids
+
+### Deliverable 6: Compiler skeleton v1
+
+Build the first compiler endpoint, but keep it intentionally narrow.
+
+Proposed new files:
+
+- `hydration-pipeline/src/compile/davidSkillCompiler.ts`
+- `hydration-pipeline/src/compile/mojosoloSkillCompiler.ts`
+- `hydration-pipeline/src/compile/unifiedSkillCompiler.ts`
+
+Required outputs:
+
+- `skills/david-voice-skill/SKILL.md`
+- `skills/mojosolo-brand-skill/SKILL.md`
+- `skills/david-mojosolo-unified-skill/SKILL.md`
+
+Compiler v1 requirement:
+
+- emit skeletal but real `SKILL.md` artifacts with:
+  - mission
+  - source-of-truth / evidence window
+  - working modes
+  - voice or brand rules sections
+  - anti-pattern or uncertainty placeholders if evidence is incomplete
+
+The compiler does not need final polish in this sprint.
+It does need to prove that the endpoint is a skill, not only a bundle.
+
+## P1 Design-Only Deliverables
+
+These should be designed now but not fully implemented in this sprint:
+
+- `validation/` mirror file layout
+- human correction vocabulary
+- low-confidence rule audit format
+- correction-loop file contract
+
+Proposed design placeholder files only:
+
+- `hydration-pipeline/src/validate/validationMirror.ts`
+- `hydration-pipeline/src/validate/ruleAudit.ts`
+
+These may remain stubs if the compiler path is not yet complete.
+
+## File-Level Plan
+
+### Files to add
+
+- `hydration-pipeline/src/normalize/signalDocument.ts`
+- `hydration-pipeline/src/normalize/provenance.ts`
+- `hydration-pipeline/src/normalize/sourceRegistry.ts`
+- `hydration-pipeline/src/providers/filesystemSource.ts`
+- `hydration-pipeline/src/providers/filesystemRules.ts`
+- `hydration-pipeline/src/extract/davidVoiceEvidence.ts`
+- `hydration-pipeline/src/extract/mojosoloBrandEvidence.ts`
+- `hydration-pipeline/src/extract/evidenceScoring.ts`
+- `hydration-pipeline/src/compile/davidSkillCompiler.ts`
+- `hydration-pipeline/src/compile/mojosoloSkillCompiler.ts`
+- `hydration-pipeline/src/compile/unifiedSkillCompiler.ts`
+- `hydration-pipeline/src/output/runManifest.ts`
+
+### Files to modify
+
+- `hydration-pipeline/src/cli.ts`
+- `hydration-pipeline/src/config.ts`
+- `hydration-pipeline/src/output/artifactPaths.ts`
+- `hydration-pipeline/src/output/writeArtifacts.ts`
+- `hydration-pipeline/src/normalize/mailNormalization.ts`
+- `hydration-pipeline/src/normalize/messagesNormalization.ts`
+- `hydration-pipeline/src/normalize/notesNormalization.ts`
+
+## Execution Order
+
+### Step 1: shared contract first
+
+- add `SignalDocument`
+- add shared provenance helpers
+- refactor the three existing normalizers to emit the shared shape
+
+### Step 2: filesystem provider
+
+- add Desktop/filesystem provider
+- add ignore rules and hashing
+- connect harvest and normalization outputs
+
+### Step 3: run manifest
+
+- emit one run-local manifest that captures counts, errors, and outputs
+
+### Step 4: evidence extraction
+
+- build David and MojoSolo evidence bundles
+- keep provenance attached
+
+### Step 5: compiler endpoint
+
+- compile evidence into real `SKILL.md` file destinations
+- allow imperfect content, but enforce real terminal artifacts
+
+### Step 6: validation design only
+
+- define shapes and output paths
+- do not let validation UI or correction tooling delay the compiler path
+
+## Acceptance Criteria
+
+- one run can harvest mail, messages, notes, corpus seed, and filesystem inputs without changing code between runs
+- all normalized documents conform to one canonical `SignalDocument` interface
+- filesystem/Desktop ingest is a real source provider rather than logic hidden inside another adapter
+- evidence bundles contain source-document references
+- compiler output writes at least one real `SKILL.md` artifact
+- run artifacts are grouped under one run id with a machine-readable manifest
+- validation remains clearly downstream of extraction and compile
+
+## Verification
+
+Minimum required verification for implementation work against this packet:
+
+- `cd hydration-pipeline && npm run build`
+- one harvest run with bounded limits
+- inspect generated artifacts under `artifacts/north-star-hydration/<run-id>/`
+
+Suggested smoke command shape after implementation:
+
+```bash
+cd hydration-pipeline
+npm run hydrate -- all \
+  --output ../artifacts/north-star-hydration \
+  --messages-source export \
+  --transcript-source none \
+  --inbox-limit 2 \
+  --sent-limit 1 \
+  --notes-limit 2 \
+  --filesystem-mode desktop \
+  --filesystem-limit 25
+```
+
+## Risks
+
+- filesystem ingest can sprawl if ignore rules are weak
+- per-channel normalizers may resist unification if the shared contract is underspecified
+- compiler work can drift back into “just another YAML bundle” if output requirements are not enforced
+- validation work can prematurely consume the sprint if not held to design-only
+
+## Explicit Deferrals
+
+- validation implementation
+- review UI
+- shell feature work
+- transcript-vendor expansion beyond the seam
+- broad repo packaging changes
+
+## Recommended Next Move After This Packet
+
+1. approve this packet as the immediate build scope
+2. implement `SignalDocument` and filesystem source first
+3. then wire evidence extraction and one compiler output path
+4. only after that open the next packet for validation implementation

--- a/docs/plans/2026-03-13-north-star-hydration-rebuild-request.md
+++ b/docs/plans/2026-03-13-north-star-hydration-rebuild-request.md
@@ -1,0 +1,368 @@
+# North Star Hydration Rebuild Request
+
+**Goal:** Give the author of the current North Star Hydration packet an exact change request so the packet can support David voice-skill generation and MojoSolo brand-skill generation instead of stopping at an intermediate YAML bundle.
+
+**Current packet reviewed:** `/Users/david/Downloads/claude-code-northstar-hydration`
+
+---
+
+## Executive Summary
+
+The current packet is a solid extraction engine, but it is not yet a skill-building system.
+
+What works:
+
+- strong voice-first doctrine
+- good emphasis on provenance and confidence
+- useful full-profile extraction behavior
+
+What is broken or incomplete:
+
+1. `SKILL.md` points to `references/schema-v2.md`, `references/intelligence.md`, and `references/validation-protocol.md`, but those files currently live at the root of the folder.
+2. The packet's terminal artifact is `north_star_hydration_bundle.v2` YAML only.
+3. The schema is centered on person profiles, not emitted skills.
+4. The schema still contains leaked travel-domain fields in `scorecard_lens`:
+   - `trip_context`
+   - `booking_judgment`
+   - `traveler_alignment`
+5. The validation loop is designed for profile review, not generated-skill review.
+
+The result is that the packet can extract evidence, but it cannot finish the job for the actual use case.
+
+---
+
+## Target Outcome
+
+The rebuilt packet must support this pipeline:
+
+1. harvest human signal
+2. extract grounded evidence bundles
+3. compile that evidence into deployable `SKILL.md` artifacts
+4. validate the generated skills with a human review loop
+
+Required final artifacts:
+
+- `david-voice-skill/SKILL.md`
+- `mojosolo-brand-skill/SKILL.md`
+- optional `david-mojosolo-unified-skill/SKILL.md`
+
+The hydration bundle becomes an intermediate artifact, not the endpoint.
+
+---
+
+## Required Changes
+
+## 1. Fix the Broken File Layout
+
+Choose one and make it consistent:
+
+### Option A: Move the reference files
+
+Create:
+
+- `references/schema-v2.md`
+- `references/intelligence.md`
+- `references/validation-protocol.md`
+
+### Option B: Update `SKILL.md`
+
+Change the `Read:` instructions to the real current paths.
+
+This is a correctness bug, not a design preference. The current skill will fail if the referenced files are not where `SKILL.md` says they are.
+
+---
+
+## 2. Separate Extraction From Compilation
+
+The packet currently conflates extraction completion with system completion.
+
+That has to change.
+
+### Required architecture
+
+Stage 1: Extractor
+
+- reads source material
+- emits evidence bundle(s)
+- preserves provenance and confidence
+
+Stage 2: Compiler
+
+- reads the evidence bundle(s)
+- emits deployable `SKILL.md` files
+- includes rules, anti-patterns, mode switches, and uncertainty handling
+
+You can implement this in one skill with multiple modes or as two coordinated skills. Either is acceptable. What is not acceptable is stopping at YAML.
+
+---
+
+## 3. Add a New Mode: `Skill Compiler`
+
+Add a first-class mode with this job:
+
+- consume hydration output
+- compile personal voice rules
+- compile brand voice rules
+- emit deployable skill artifacts
+
+### Minimum outputs
+
+- personal voice skill
+- brand skill
+- optional unified wrapper skill
+
+### Minimum compiler concerns
+
+- mode switching
+- phrase bank generation
+- anti-pattern extraction
+- uncertainty policy
+- provenance/freshness section
+- audience/channel adaptation
+
+---
+
+## 4. Replace or Generalize `scorecard_lens`
+
+The current schema contains travel-domain leakage:
+
+- `trip_context`
+- `booking_judgment`
+- `traveler_alignment`
+
+That makes the schema look copied from another context.
+
+### Required fix
+
+Either:
+
+- replace `scorecard_lens` with a configurable `compiler_lens` or `evaluation_lens`
+
+Or:
+
+- remove it entirely from the canonical schema and move domain-specific scoring into deployment-specific overlays
+
+### Better replacement shape
+
+Use fields like:
+
+- `voice_fidelity`
+- `brand_consistency`
+- `judgment_transfer`
+- `channel_fit`
+- `persona_separation`
+- `trust_preservation`
+
+---
+
+## 5. Add a Brand-Level Schema
+
+The current schema is person-centric.
+
+That is insufficient for MojoSolo because the output has to model:
+
+- David as a person
+- MojoSolo as a brand/company
+- the Author / Operator / Machine persona system
+
+### Required addition
+
+Add a brand schema or brand bundle section covering:
+
+- brand thesis
+- named concepts / language map
+- messaging pillars
+- anti-patterns
+- persona definitions
+- offer framing
+- audience adaptations
+
+Without this, the system can produce a person profile but not a company skill.
+
+---
+
+## 6. Add Explicit Terminal Artifact Specs
+
+The packet currently tells the model to output only YAML.
+
+Replace that with explicit artifact choices.
+
+### Required deliverables
+
+#### `david-voice-skill/SKILL.md`
+
+Must include:
+
+- voice rules
+- phrase banks
+- channel rules
+- anti-patterns
+- uncertainty policy
+- rewrite/audit modes
+
+#### `mojosolo-brand-skill/SKILL.md`
+
+Must include:
+
+- brand thesis
+- persona map
+- language map
+- messaging pillars
+- anti-patterns
+- offer framing
+- audience adaptation
+
+#### `david-mojosolo-unified-skill/SKILL.md`
+
+Must expose exact modes:
+
+- `write_as_david`
+- `write_for_mojosolo_author`
+- `write_for_mojosolo_operator`
+- `write_for_mojosolo_machine`
+- `audit_output_against_source_voice`
+
+---
+
+## 7. Expand Source Doctrine For Real Voice Recovery
+
+The packet currently supports general human-signal extraction, which is useful, but the target use case requires a clearer doctrine for multi-source personal and brand voice building.
+
+### Required source classes
+
+- email threads
+- SMS / iMessage history
+- notes / private writing
+- meeting transcripts
+- vector-search retrieval over transcripts
+- canonical brain / operator documents as context seed
+
+### Required rule
+
+The compiler must know the difference between:
+
+- direct first-person voice
+- spoken meeting behavior
+- company/system language
+- inferred behavior from third-party descriptions
+
+Those should not be blended without provenance.
+
+---
+
+## 8. Add Skill Validation, Not Just Profile Validation
+
+The current validation protocol is oriented around reviewing person profiles.
+
+That is not enough.
+
+### Add a generated-skill validation layer
+
+A reviewer should be able to flag:
+
+- sounds unlike David
+- sounds unlike MojoSolo
+- persona boundary collapse
+- too polished
+- too corporate
+- overclaiming
+- wrong phrase bank
+- high-confidence claim with weak evidence
+
+### Minimum validation output
+
+For each generated skill, include:
+
+- what evidence window it reflects
+- what changed since prior version
+- highest-confidence traits/rules
+- lowest-confidence rules to review manually
+
+---
+
+## 9. Tighten Mode Semantics
+
+Current modes are extraction-centric.
+
+That is fine for the extractor, but insufficient for the terminal artifact.
+
+### Keep if useful
+
+- Full Extraction
+- Profile Update
+- Validation Deliverable
+- Voice-Only Extraction
+- Schema Audit
+
+### Add or update
+
+- `Brand Extraction`
+- `Skill Compiler`
+- `Skill Validation Deliverable`
+- `Wrapper Skill Build`
+
+The mode names should make it obvious whether the system is producing evidence or deployable instructions.
+
+---
+
+## 10. Suggested Folder Shape
+
+A clean minimal rebuild could look like this:
+
+```text
+north-star-hydration/
+├── SKILL.md
+├── references/
+│   ├── schema-v3.md
+│   ├── intelligence.md
+│   ├── validation-protocol.md
+│   ├── brand-schema.md
+│   └── skill-compiler.md
+├── assets/
+│   └── templates/
+│       ├── david-voice-skill-template.md
+│       ├── mojosolo-brand-skill-template.md
+│       └── unified-wrapper-template.md
+└── scripts/
+    └── validate_bundle_or_skill.py
+```
+
+This is not mandatory, but the separation of extractor rules, brand rules, and compiler rules is.
+
+---
+
+## What The Rebuilt Packet Should Say Explicitly
+
+The packet should state these rules clearly:
+
+1. The hydration bundle is an evidence artifact, not the final artifact.
+2. Voice extraction is highest priority, but brand/persona compilation is a required downstream step.
+3. A generated skill must contain executable agent instructions, not just description.
+4. Personal voice and company voice cannot be silently blended.
+5. All emitted rules need evidence, pattern support, or explicit human correction.
+
+---
+
+## Acceptance Criteria
+
+The rebuild is done when all of these are true:
+
+1. The skill can run without broken path references.
+2. The system can emit a valid evidence bundle.
+3. The system can emit `david-voice-skill/SKILL.md`.
+4. The system can emit `mojosolo-brand-skill/SKILL.md`.
+5. The system can emit a unified wrapper with explicit mode switches.
+6. Travel-domain leakage is removed from the canonical schema.
+7. Validation supports generated-skill review, not just profile review.
+8. The generated skills can be loaded directly by Claude Code, Codex, or Cursor without also loading the raw evidence bundle.
+
+---
+
+## Recommended Execution Order
+
+1. Fix file layout and path correctness.
+2. Define the terminal artifact spec.
+3. Update the schema to support person plus brand compilation.
+4. Add compiler mode.
+5. Add generated-skill validation.
+6. Test on David + MojoSolo as the reference use case.

--- a/docs/plans/2026-03-13-north-star-hydration-repo-pipeline-plan.md
+++ b/docs/plans/2026-03-13-north-star-hydration-repo-pipeline-plan.md
@@ -1,0 +1,687 @@
+# North Star Hydration Repo Pipeline Plan
+
+**Goal:** Build a repo-local pipeline that harvests David and MojoSolo signal from the existing Apple MCP stack, extracts grounded evidence bundles, compiles deployable `SKILL.md` artifacts, and emits human-review deliverables.
+
+**Depends on:**
+
+- [2026-03-13-david-mojosolo-skill-output-spec.md](../plans/2026-03-13-david-mojosolo-skill-output-spec.md)
+- [2026-03-13-north-star-hydration-rebuild-request.md](../plans/2026-03-13-north-star-hydration-rebuild-request.md)
+
+**Primary outcome:** A deterministic local pipeline that can produce:
+
+1. `david-voice-skill/SKILL.md`
+2. `mojosolo-brand-skill/SKILL.md`
+3. `david-mojosolo-unified-skill/SKILL.md`
+4. evidence bundles and validation mirrors tied to exact source windows
+
+---
+
+## Repo Facts This Plan Is Built On
+
+These are current, local facts in this repo and should drive the plan shape.
+
+1. `apple-mail`, `apple-messages`, `apple-notes`, `knowledge-corpus`, and `apple-mail-intelligence` already exist as local MCP servers.
+2. `knowledge-corpus/data/mojosolo_operating_brain.json` is the canonical brain and already models the three inbox personas and meeting-intel assumptions.
+3. The current brain names `Otter.ai` and `meeting transcripts` inside the Machine persona flow. It does not name Fireflies.
+4. `messages/messages-export.json` already contains a staged Apple Messages export with `348` messages.
+5. `messages/scripts/export-from-handles.mjs` already provides a deterministic export path from `~/Library/Messages/chat.db` for `mojosolo@mac.com` and `david@mojosolo.com`.
+6. There is no Fireflies MCP server or vector-search package in this repo today.
+7. `mail-intelligence` already understands the three inbox model and can summarize signal windows, but it is not a voice-skill compiler.
+8. Apple Notes is the default output sink for summaries today, but the architecture doc says Notes remain an output sink, not the source of truth.
+
+That means the pipeline should treat Mail, Messages, Notes, and the canonical brain as first-class local inputs, while treating Fireflies/vector retrieval as a provider seam to be added cleanly.
+
+---
+
+## Product Shape
+
+### Stage 1: Harvest
+
+Read local human signal from:
+
+- Apple Mail via MCP
+- Apple Messages via MCP or staged export JSON
+- Apple Notes via MCP
+- canonical brain via `knowledge-corpus`
+- transcript providers via a new adapter seam
+
+### Stage 2: Normalize
+
+Convert raw source material into a common evidence format with:
+
+- source id
+- source type
+- date range
+- speaker / author
+- first-person vs third-party classification
+- persona relevance
+- channel classification
+- text chunks and metadata
+
+### Stage 3: Extract
+
+Build two grounded intermediate bundles:
+
+1. `DavidVoiceEvidenceBundle`
+2. `MojoSoloBrandEvidenceBundle`
+
+These are not the final artifacts. They are the grounded evidence layer for the compiler.
+
+### Stage 4: Compile
+
+Emit deployable skills:
+
+- personal voice skill
+- brand skill
+- unified wrapper skill
+
+### Stage 5: Validate
+
+Emit review artifacts that let a human mark:
+
+- sounds right / wrong
+- too polished
+- too corporate
+- wrong phrase bank
+- wrong persona mode
+- overclaimed rule
+- low-confidence rule that needs pruning
+
+---
+
+## Implementation Strategy
+
+Create a new repo-local package:
+
+- `hydration-pipeline/`
+
+Reasoning:
+
+- This keeps extraction/compiler logic separate from the MCP server packages.
+- It avoids polluting `knowledge-corpus` with generated artifacts.
+- It can consume MCP servers over stdio without forcing those servers to become library packages.
+- It gives the repo one explicit place for harvest, normalization, extraction, compilation, and validation logic.
+
+### Proposed Layout
+
+```text
+hydration-pipeline/
+├── package.json
+├── tsconfig.json
+├── src/
+│   ├── cli.ts
+│   ├── config.ts
+│   ├── mcp/
+│   │   ├── client.ts
+│   │   └── localServers.ts
+│   ├── providers/
+│   │   ├── mailSource.ts
+│   │   ├── messagesSource.ts
+│   │   ├── notesSource.ts
+│   │   ├── corpusSource.ts
+│   │   └── transcript/
+│   │       ├── transcriptSource.ts
+│   │       ├── otterMailTranscriptSource.ts
+│   │       └── firefliesVectorSource.ts
+│   ├── normalize/
+│   │   ├── signalDocument.ts
+│   │   ├── chunking.ts
+│   │   └── provenance.ts
+│   ├── extract/
+│   │   ├── davidVoiceEvidence.ts
+│   │   ├── mojosoloBrandEvidence.ts
+│   │   └── evidenceScoring.ts
+│   ├── compile/
+│   │   ├── davidSkillCompiler.ts
+│   │   ├── mojosoloSkillCompiler.ts
+│   │   └── unifiedSkillCompiler.ts
+│   ├── validate/
+│   │   ├── validationMirror.ts
+│   │   └── ruleAudit.ts
+│   └── output/
+│       ├── artifactPaths.ts
+│       └── writeArtifacts.ts
+└── tests/
+```
+
+### Artifact Output Location
+
+Write generated outputs under:
+
+- `artifacts/north-star-hydration/<run-id>/`
+
+With subfolders:
+
+- `harvest/`
+- `evidence/`
+- `skills/`
+- `validation/`
+- `logs/`
+
+Reasoning:
+
+- Generated artifacts should not live inside `knowledge-corpus/data/` because that directory is the canonical brain seed, not an execution log.
+- This keeps run history inspectable and reversible.
+
+---
+
+## Runtime Interfaces
+
+### Local MCP Access
+
+Use stdio child processes against existing built packages:
+
+- `mail/build/index.js`
+- `messages/build/index.js`
+- `notes/build/index.js`
+- `knowledge-corpus/build/index.js`
+- `mail-intelligence/build/index.js`
+
+Build a minimal local MCP client in `hydration-pipeline/src/mcp/client.ts` that can:
+
+- start a server
+- call a tool by name with arguments
+- parse JSON tool responses
+- stop the server cleanly
+
+This should reuse the same local-child-process assumption already present in the shell architecture.
+
+### Transcript Provider Seam
+
+Define a provider seam instead of hardcoding Fireflies:
+
+```ts
+export interface TranscriptSource {
+  name: string;
+  listSessions(query?: string): Promise<TranscriptSession[]>;
+  fetchSession(sessionId: string): Promise<TranscriptDocument>;
+  search(query: string, opts?: TranscriptSearchOptions): Promise<TranscriptHit[]>;
+}
+```
+
+Initial provider implementations:
+
+1. `OtterMailTranscriptSource`
+   - harvests transcript-style summaries from the Machine inbox using Apple Mail / mail-intelligence conventions
+   - grounded in the current brain's `Otter.ai` assumptions
+
+2. `FirefliesVectorSource`
+   - env-configured external adapter
+   - not implemented against any repo-local server today
+   - should ship initially as interface + fixture-backed tests + stub CLI validation
+
+This is the correct seam because Fireflies/vector retrieval is not yet in-repo.
+
+---
+
+## Source Plan By Channel
+
+### 1. Apple Mail
+
+Use `apple-mail` as the primary long-form written-signal source.
+
+Primary tools:
+
+- `list_mailboxes`
+- `list_messages`
+- `get_message`
+- `search_messages`
+- `get_unread_count`
+
+Use `apple-mail-intelligence` for persona-aware bootstrapping:
+
+- `get_persona_map`
+- `scan_persona_inboxes`
+- `analyze_signal_trends`
+
+Mail harvest must produce at least three partitions:
+
+1. `author_mail`
+2. `operator_mail`
+3. `machine_mail`
+
+And one explicit subset:
+
+- `david_first_person_mail`
+
+The extraction pipeline must separate mail written by David from mail written about David or merely received by him.
+
+### 2. Apple Messages
+
+Use two paths:
+
+#### Live path
+
+- `apple-messages` MCP
+- `list_chats`
+- `get_chat_messages`
+- `search_messages`
+- `get_chat_participants`
+
+#### Staged path
+
+- `messages/messages-export.json`
+- refreshed by `messages/scripts/export-from-handles.mjs`
+
+This gives the pipeline a deterministic fixture path for testing and a live path for fresh harvests.
+
+### 3. Apple Notes
+
+Use `apple-notes` as a private writing / output review channel, not the canonical truth store.
+
+Primary tools:
+
+- `list_folders`
+- `list_notes`
+- `get_note`
+- `search_notes` if added later through MCP surface discovery
+- `create_note` / `update_note` only for review-output emission, not evidence mutation
+
+Notes should contribute:
+
+- private writing samples
+- working language and internal naming
+- review sink material
+
+Notes should not silently override stronger evidence from direct emails, texts, or transcripts.
+
+### 4. Knowledge Corpus
+
+Use `knowledge-corpus` as seed context, vocabulary context, and persona/brand scaffold.
+
+Primary tools:
+
+- `get_corpus_overview`
+- `get_corpus_section`
+- `search_corpus`
+- `list_sources`
+- `get_source`
+- `get_mail_intelligence_config`
+
+Use this layer for:
+
+- named concepts
+- persona map
+- known language anchors
+- inbox role definitions
+- source registry grounding
+
+Do not use it as proof of David's real voice. It is context scaffolding, not primary voice evidence.
+
+### 5. Transcript / Meeting Intel
+
+Short-term truth in this repo:
+
+- meeting-intel is currently represented as `Otter.ai` style traffic in the Machine inbox and in the canonical brain
+
+Future seam:
+
+- Fireflies transcript retrieval
+- vector-search recall over transcript corpus
+
+The plan must support both without pretending both already exist.
+
+---
+
+## Data Model
+
+### `SignalDocument`
+
+Normalized unit of evidence.
+
+```ts
+interface SignalDocument {
+  id: string;
+  sourceType: "mail" | "message" | "note" | "transcript" | "brain_seed";
+  sourceId: string;
+  channel: string;
+  authoredBy: "david" | "external" | "mixed" | "unknown";
+  personaHint?: "author" | "operator" | "machine";
+  timestamp: string;
+  title?: string;
+  participants: string[];
+  text: string;
+  tags: string[];
+  provenance: {
+    collector: string;
+    directness: "direct" | "quoted" | "third_party" | "inferred";
+    freshness: string;
+  };
+}
+```
+
+### `DavidVoiceEvidenceBundle`
+
+Must include:
+
+- dominant phrasing patterns
+- direct quote bank
+- setup/transition/closing phrases
+- channel differences
+- anti-patterns
+- confidence-weighted rules
+- blind spots and contradictions
+
+### `MojoSoloBrandEvidenceBundle`
+
+Must include:
+
+- brand thesis candidates
+- named concepts / language map
+- persona separation evidence
+- offer framing evidence
+- anti-pattern evidence
+- audience adaptation evidence
+
+---
+
+## CLI Shape
+
+Provide one deterministic CLI with these commands:
+
+```bash
+npm run hydrate -- harvest
+npm run hydrate -- extract
+npm run hydrate -- compile
+npm run hydrate -- validate
+npm run hydrate -- all
+```
+
+Suggested flags:
+
+```bash
+--profile david
+--brand mojosolo
+--from 2024-01-01
+--to 2026-03-13
+--messages-source live|export
+--transcript-source otter_mail|fireflies_vector|none
+--output artifacts/north-star-hydration/manual-run
+```
+
+The CLI must make the selected evidence window and provider mix explicit in every run.
+
+---
+
+## Task Plan
+
+## Task 1: Scaffold `hydration-pipeline/`
+
+Create the package, CLI shell, artifact writer, and config loader.
+
+Files:
+
+- `hydration-pipeline/package.json`
+- `hydration-pipeline/tsconfig.json`
+- `hydration-pipeline/src/cli.ts`
+- `hydration-pipeline/src/config.ts`
+- `hydration-pipeline/src/output/artifactPaths.ts`
+
+Verification:
+
+- `npm run build`
+- `npm run hydrate -- --help`
+
+## Task 2: Implement local MCP client + server launcher
+
+Build a minimal stdio client for local child-process MCP tools.
+
+Files:
+
+- `hydration-pipeline/src/mcp/client.ts`
+- `hydration-pipeline/src/mcp/localServers.ts`
+- tests with fixture responses
+
+Verification:
+
+- can call `knowledge-corpus:get_corpus_overview`
+- can call `mail-intelligence:get_persona_map`
+
+## Task 3: Implement corpus and persona bootstrap
+
+Harvest seed context from the canonical brain and mail-intelligence.
+
+Files:
+
+- `hydration-pipeline/src/providers/corpusSource.ts`
+
+Output:
+
+- brain snapshot
+- persona map snapshot
+- source registry snapshot
+
+Verification:
+
+- extracts Author / Operator / Machine roles correctly
+- captures `Otter.ai` / meeting-intel assumptions from the current brain
+
+## Task 4: Implement Mail harvester
+
+Build persona-aware mail collection and David-authored filtering.
+
+Files:
+
+- `hydration-pipeline/src/providers/mailSource.ts`
+- `hydration-pipeline/src/normalize/mailNormalization.ts`
+
+Output:
+
+- raw mail harvest JSON
+- normalized `SignalDocument[]`
+
+Verification:
+
+- separates received mail from authored/replied mail where possible
+- preserves account/mailbox metadata
+
+## Task 5: Implement Messages harvester
+
+Support both live MCP reads and staged export JSON.
+
+Files:
+
+- `hydration-pipeline/src/providers/messagesSource.ts`
+- `hydration-pipeline/src/normalize/messagesNormalization.ts`
+
+Verification:
+
+- reads `messages/messages-export.json`
+- can classify `from_me` vs external messages
+- handles the current 348-message export deterministically in tests
+
+## Task 6: Implement Notes harvester
+
+Read writing samples and emit review notes later.
+
+Files:
+
+- `hydration-pipeline/src/providers/notesSource.ts`
+- `hydration-pipeline/src/normalize/notesNormalization.ts`
+
+Verification:
+
+- can load selected folders/notes
+- can emit review-output notes without mutating evidence inputs
+
+## Task 7: Implement transcript provider seam
+
+Define the interface and ship two initial providers.
+
+Files:
+
+- `hydration-pipeline/src/providers/transcript/transcriptSource.ts`
+- `hydration-pipeline/src/providers/transcript/otterMailTranscriptSource.ts`
+- `hydration-pipeline/src/providers/transcript/firefliesVectorSource.ts`
+
+Rules:
+
+- `OtterMailTranscriptSource` is the only repo-grounded provider on day one.
+- `FirefliesVectorSource` ships as env-driven adapter + fixtures until a real endpoint contract is wired.
+
+Verification:
+
+- provider selection works from CLI flags
+- missing Fireflies env fails clearly, not silently
+
+## Task 8: Normalize all sources into a common evidence corpus
+
+Merge harvest results into deduplicated `SignalDocument[]` plus chunked evidence views.
+
+Files:
+
+- `hydration-pipeline/src/normalize/signalDocument.ts`
+- `hydration-pipeline/src/normalize/chunking.ts`
+- `hydration-pipeline/src/normalize/provenance.ts`
+
+Verification:
+
+- direct first-person evidence is tagged distinctly from third-party mentions
+- duplicated transcript/mail summary content can be detected and marked
+
+## Task 9: Extract David voice evidence bundle
+
+Build a deterministic extraction pass focused on voice and channel behavior.
+
+Files:
+
+- `hydration-pipeline/src/extract/davidVoiceEvidence.ts`
+- `hydration-pipeline/src/extract/evidenceScoring.ts`
+
+Output:
+
+- `evidence/david-voice-evidence.json`
+- `evidence/david-voice-evidence.yaml`
+
+Verification:
+
+- phrase banks are evidence-linked
+- low-signal rules remain low confidence
+
+## Task 10: Extract MojoSolo brand evidence bundle
+
+Build a separate extraction pass for company language, named concepts, and persona separation.
+
+Files:
+
+- `hydration-pipeline/src/extract/mojosoloBrandEvidence.ts`
+
+Output:
+
+- `evidence/mojosolo-brand-evidence.json`
+- `evidence/mojosolo-brand-evidence.yaml`
+
+Verification:
+
+- Author / Operator / Machine distinctions are explicit
+- named concepts reflect corpus + notes + mail evidence instead of generic brand filler
+
+## Task 11: Compile the three skill artifacts
+
+Transform evidence into deployable skills.
+
+Files:
+
+- `hydration-pipeline/src/compile/davidSkillCompiler.ts`
+- `hydration-pipeline/src/compile/mojosoloSkillCompiler.ts`
+- `hydration-pipeline/src/compile/unifiedSkillCompiler.ts`
+
+Output:
+
+- `skills/david-voice-skill/SKILL.md`
+- `skills/mojosolo-brand-skill/SKILL.md`
+- `skills/david-mojosolo-unified-skill/SKILL.md`
+
+Verification:
+
+- required modes from the spec are present
+- wrapper does not silently blend David and company voice
+
+## Task 12: Emit validation mirrors and audit reports
+
+Produce human-review artifacts for each generated skill.
+
+Files:
+
+- `hydration-pipeline/src/validate/validationMirror.ts`
+- `hydration-pipeline/src/validate/ruleAudit.ts`
+
+Output:
+
+- `validation/david-skill-review.md`
+- `validation/mojosolo-skill-review.md`
+- `validation/rule-audit.json`
+
+Verification:
+
+- every high-confidence rule can point back to evidence ids
+- low-confidence rules are surfaced for manual review
+
+---
+
+## Testing Strategy
+
+### Unit tests
+
+Cover:
+
+- MCP client response parsing
+- mail normalization
+- messages export normalization
+- transcript provider selection
+- evidence scoring
+- compiler output sections
+
+### Fixture tests
+
+Use:
+
+- `messages/messages-export.json`
+- fixture mail payloads
+- fixture note payloads
+- fixture transcript payloads
+- small corpus snapshots from `knowledge-corpus`
+
+### Integration tests
+
+Run only when the local machine can support them:
+
+- Apple Mail access
+- Apple Messages database access
+- Apple Notes access
+
+These should be opt-in because they depend on macOS permissions and local user data.
+
+---
+
+## Acceptance Criteria
+
+This pipeline is done when:
+
+1. it can harvest from the current local Apple MCP stack without hand editing code between runs
+2. it can ingest the staged 348-message export deterministically
+3. it can use the canonical brain as seed context without treating it as primary voice truth
+4. it can emit separate David and MojoSolo evidence bundles
+5. it can compile the three required `SKILL.md` artifacts
+6. it can emit validation mirrors tied to evidence ids
+7. Fireflies/vector retrieval is represented as a clean provider seam, not a fake in-repo dependency
+8. generated artifacts live outside `knowledge-corpus/data/`
+
+---
+
+## Execution Order Recommendation
+
+Build in this order:
+
+1. scaffold package and MCP client
+2. bootstrap corpus + persona map
+3. messages staged-path ingestion
+4. mail ingestion
+5. notes ingestion
+6. transcript provider seam
+7. evidence extraction
+8. compilers
+9. validation outputs
+10. live integration pass on the local Mac
+
+This order front-loads the deterministic fixtures and delays the most permission-heavy and externally coupled work until the pipeline shape is already proven.

--- a/hydration-pipeline/.gitignore
+++ b/hydration-pipeline/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/hydration-pipeline/package-lock.json
+++ b/hydration-pipeline/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@griches/hydration-pipeline",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1"
+      },
       "bin": {
         "hydration-pipeline": "build/cli.js"
       },
@@ -19,6 +22,58 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
@@ -27,6 +82,1020 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typescript": {
@@ -49,6 +1118,63 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
     }
   }
 }

--- a/hydration-pipeline/package-lock.json
+++ b/hydration-pipeline/package-lock.json
@@ -1,0 +1,54 @@
+{
+  "name": "@griches/hydration-pipeline",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@griches/hydration-pipeline",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "hydration-pipeline": "build/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.3",
+        "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/hydration-pipeline/package.json
+++ b/hydration-pipeline/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@griches/hydration-pipeline",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Repo-local North Star hydration harvest and skill compiler pipeline",
+  "main": "build/cli.js",
+  "bin": {
+    "hydration-pipeline": "build/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node build/cli.js",
+    "hydrate": "npm run build && node build/cli.js"
+  },
+  "keywords": [
+    "hydration",
+    "voice",
+    "skill",
+    "compiler",
+    "mcp"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.3",
+    "typescript": "^5.8.3"
+  }
+}

--- a/hydration-pipeline/package.json
+++ b/hydration-pipeline/package.json
@@ -23,6 +23,9 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1"
+  },
   "devDependencies": {
     "@types/node": "^22.15.3",
     "typescript": "^5.8.3"

--- a/hydration-pipeline/src/cli.ts
+++ b/hydration-pipeline/src/cli.ts
@@ -12,11 +12,13 @@ import { writeJsonArtifact } from "./output/writeArtifacts.js";
 import { bootstrapCorpusContext } from "./providers/corpusSource.js";
 import { harvestMail } from "./providers/mailSource.js";
 import { harvestMessages } from "./providers/messagesSource.js";
+import { harvestNotes } from "./providers/notesSource.js";
 import { normalizeMailHarvest, selectDavidFirstPersonMail } from "./normalize/mailNormalization.js";
 import {
   normalizeMessagesHarvest,
   selectDavidFirstPersonMessages,
 } from "./normalize/messagesNormalization.js";
+import { normalizeNotesHarvest, selectDavidFirstPersonNotes } from "./normalize/notesNormalization.js";
 
 const HELP_TEXT = `North Star Hydration Pipeline
 
@@ -40,6 +42,7 @@ Options:
                                    Transcript ingestion mode (default: otter_mail)
   --inbox-limit <n>                Mail inbox messages per persona to fetch (default: 3)
   --sent-limit <n>                 Mail sent messages per persona to fetch (default: 1)
+  --notes-limit <n>                Notes to fetch per folder (default: 2)
   --output <path>                  Output root relative to repo root
   --run-id <id>                    Override generated run id
   --help                           Show this help text
@@ -131,6 +134,9 @@ function parseArgs(argv: string[]): CliOptions | null {
       case "--sent-limit":
         options.sentLimit = parsePositiveInt(token, value);
         break;
+      case "--notes-limit":
+        options.notesLimit = parsePositiveInt(token, value);
+        break;
       default:
         throw new Error(`Unknown option: ${token}`);
     }
@@ -159,6 +165,7 @@ function printPlannedRun(config: ReturnType<typeof resolveConfig>): void {
           transcriptSource: config.transcriptSource,
           inboxLimit: config.inboxLimit,
           sentLimit: config.sentLimit,
+          notesLimit: config.notesLimit,
           artifactPaths: config.artifactPaths,
         },
       },
@@ -187,6 +194,11 @@ async function runHarvest(config: ReturnType<typeof resolveConfig>): Promise<voi
   });
   const normalizedMessages = normalizeMessagesHarvest(messagesHarvest);
   const davidFirstPersonMessages = selectDavidFirstPersonMessages(normalizedMessages);
+  const notesHarvest = await harvestNotes(config.repoRoot, {
+    limitPerFolder: config.notesLimit,
+  });
+  const normalizedNotes = normalizeNotesHarvest(notesHarvest);
+  const davidFirstPersonNotes = selectDavidFirstPersonNotes(normalizedNotes);
 
   writeJsonArtifact(join(config.artifactPaths.harvestDir, "bootstrap.json"), bootstrap);
   writeJsonArtifact(join(config.artifactPaths.harvestDir, "mail-harvest.json"), mailHarvest);
@@ -198,6 +210,9 @@ async function runHarvest(config: ReturnType<typeof resolveConfig>): Promise<voi
     join(config.artifactPaths.harvestDir, "david-first-person-messages.json"),
     davidFirstPersonMessages,
   );
+  writeJsonArtifact(join(config.artifactPaths.harvestDir, "notes-harvest.json"), notesHarvest);
+  writeJsonArtifact(join(config.artifactPaths.harvestDir, "notes-normalized.json"), normalizedNotes);
+  writeJsonArtifact(join(config.artifactPaths.harvestDir, "david-first-person-notes.json"), davidFirstPersonNotes);
 
   process.stdout.write(
     `${JSON.stringify(
@@ -222,6 +237,14 @@ async function runHarvest(config: ReturnType<typeof resolveConfig>): Promise<voi
           normalizedDocuments: normalizedMessages.length,
           davidFirstPersonDocuments: davidFirstPersonMessages.length,
           errors: messagesHarvest.errors,
+        },
+        notes: {
+          folders: notesHarvest.discoveredFolders.length,
+          harvestedNotes: notesHarvest.harvestedNotes.length,
+          skippedNotes: notesHarvest.skippedNotes.length,
+          normalizedDocuments: normalizedNotes.length,
+          davidFirstPersonDocuments: davidFirstPersonNotes.length,
+          errors: notesHarvest.errors,
         },
       },
       null,

--- a/hydration-pipeline/src/cli.ts
+++ b/hydration-pipeline/src/cli.ts
@@ -1,5 +1,22 @@
 #!/usr/bin/env node
-import { resolveConfig, type CliOptions, type HydrationCommand, type MessagesSourceMode, type TranscriptSourceMode } from "./config.js";
+import { join } from "node:path";
+import {
+  resolveConfig,
+  type CliOptions,
+  type HydrationCommand,
+  type MessagesSourceMode,
+  type TranscriptSourceMode,
+} from "./config.js";
+import { ensureArtifactDirectories } from "./output/artifactPaths.js";
+import { writeJsonArtifact } from "./output/writeArtifacts.js";
+import { bootstrapCorpusContext } from "./providers/corpusSource.js";
+import { harvestMail } from "./providers/mailSource.js";
+import { harvestMessages } from "./providers/messagesSource.js";
+import { normalizeMailHarvest, selectDavidFirstPersonMail } from "./normalize/mailNormalization.js";
+import {
+  normalizeMessagesHarvest,
+  selectDavidFirstPersonMessages,
+} from "./normalize/messagesNormalization.js";
 
 const HELP_TEXT = `North Star Hydration Pipeline
 
@@ -21,6 +38,8 @@ Options:
   --messages-source <live|export>  Messages ingestion mode (default: export)
   --transcript-source <otter_mail|fireflies_vector|none>
                                    Transcript ingestion mode (default: otter_mail)
+  --inbox-limit <n>                Mail inbox messages per persona to fetch (default: 3)
+  --sent-limit <n>                 Mail sent messages per persona to fetch (default: 1)
   --output <path>                  Output root relative to repo root
   --run-id <id>                    Override generated run id
   --help                           Show this help text
@@ -40,6 +59,14 @@ function isMessagesSourceMode(value: string): value is MessagesSourceMode {
 
 function isTranscriptSourceMode(value: string): value is TranscriptSourceMode {
   return ["otter_mail", "fireflies_vector", "none"].includes(value);
+}
+
+function parsePositiveInt(flag: string, value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Invalid value for ${flag}: ${value}`);
+  }
+  return parsed;
 }
 
 function parseArgs(argv: string[]): CliOptions | null {
@@ -98,6 +125,12 @@ function parseArgs(argv: string[]): CliOptions | null {
         }
         options.transcriptSource = value;
         break;
+      case "--inbox-limit":
+        options.inboxLimit = parsePositiveInt(token, value);
+        break;
+      case "--sent-limit":
+        options.sentLimit = parsePositiveInt(token, value);
+        break;
       default:
         throw new Error(`Unknown option: ${token}`);
     }
@@ -124,6 +157,8 @@ function printPlannedRun(config: ReturnType<typeof resolveConfig>): void {
           to: config.to ?? null,
           messagesSource: config.messagesSource,
           transcriptSource: config.transcriptSource,
+          inboxLimit: config.inboxLimit,
+          sentLimit: config.sentLimit,
           artifactPaths: config.artifactPaths,
         },
       },
@@ -134,7 +169,68 @@ function printPlannedRun(config: ReturnType<typeof resolveConfig>): void {
   process.stdout.write("\n");
 }
 
-function main(): void {
+async function runHarvest(config: ReturnType<typeof resolveConfig>): Promise<void> {
+  ensureArtifactDirectories(config.artifactPaths);
+
+  const bootstrap = await bootstrapCorpusContext(config.repoRoot);
+  const mailHarvest = await harvestMail(config.repoRoot, {
+    bootstrap,
+    inboxLimit: config.inboxLimit,
+    sentLimit: config.sentLimit,
+    includeSent: config.sentLimit > 0,
+  });
+  const normalizedMail = normalizeMailHarvest(mailHarvest);
+  const davidFirstPersonMail = selectDavidFirstPersonMail(normalizedMail);
+  const messagesHarvest = await harvestMessages(config.repoRoot, {
+    sourceMode: config.messagesSource,
+    limitPerChat: config.inboxLimit,
+  });
+  const normalizedMessages = normalizeMessagesHarvest(messagesHarvest);
+  const davidFirstPersonMessages = selectDavidFirstPersonMessages(normalizedMessages);
+
+  writeJsonArtifact(join(config.artifactPaths.harvestDir, "bootstrap.json"), bootstrap);
+  writeJsonArtifact(join(config.artifactPaths.harvestDir, "mail-harvest.json"), mailHarvest);
+  writeJsonArtifact(join(config.artifactPaths.harvestDir, "mail-normalized.json"), normalizedMail);
+  writeJsonArtifact(join(config.artifactPaths.harvestDir, "david-first-person-mail.json"), davidFirstPersonMail);
+  writeJsonArtifact(join(config.artifactPaths.harvestDir, "messages-harvest.json"), messagesHarvest);
+  writeJsonArtifact(join(config.artifactPaths.harvestDir, "messages-normalized.json"), normalizedMessages);
+  writeJsonArtifact(
+    join(config.artifactPaths.harvestDir, "david-first-person-messages.json"),
+    davidFirstPersonMessages,
+  );
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        status: "harvest_complete",
+        runId: config.runId,
+        outputDir: config.artifactPaths.baseDir,
+        bootstrap: {
+          corpus: bootstrap.overview.corpus_name,
+          personas: bootstrap.personas.length,
+          meetingIntelHints: bootstrap.meetingIntelHints.length,
+        },
+        mail: {
+          personaAccounts: mailHarvest.accounts.length,
+          normalizedDocuments: normalizedMail.length,
+          davidFirstPersonDocuments: davidFirstPersonMail.length,
+          errors: mailHarvest.errors,
+        },
+        messages: {
+          sourceMode: messagesHarvest.sourceMode,
+          chats: messagesHarvest.chats.length,
+          normalizedDocuments: normalizedMessages.length,
+          davidFirstPersonDocuments: davidFirstPersonMessages.length,
+          errors: messagesHarvest.errors,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+async function main(): Promise<void> {
   try {
     const parsed = parseArgs(process.argv.slice(2));
 
@@ -144,6 +240,11 @@ function main(): void {
     }
 
     const config = resolveConfig(parsed);
+    if (config.command === "harvest") {
+      await runHarvest(config);
+      return;
+    }
+
     printPlannedRun(config);
   } catch (error) {
     process.stderr.write(`Error: ${(error as Error).message}\n\n`);
@@ -152,4 +253,7 @@ function main(): void {
   }
 }
 
-main();
+main().catch((error) => {
+  process.stderr.write(`Fatal error: ${(error as Error).message}\n`);
+  process.exit(1);
+});

--- a/hydration-pipeline/src/cli.ts
+++ b/hydration-pipeline/src/cli.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+import { resolveConfig, type CliOptions, type HydrationCommand, type MessagesSourceMode, type TranscriptSourceMode } from "./config.js";
+
+const HELP_TEXT = `North Star Hydration Pipeline
+
+Usage:
+  npm run hydrate -- <command> [options]
+
+Commands:
+  harvest     Harvest source material from local providers
+  extract     Build evidence bundles from harvested material
+  compile     Emit deployable SKILL.md artifacts
+  validate    Emit human-review mirrors and rule audits
+  all         Run harvest -> extract -> compile -> validate
+
+Options:
+  --profile <name>                 Profile target (default: david)
+  --brand <name>                   Brand target (default: mojosolo)
+  --from <YYYY-MM-DD>              Inclusive lower bound for source window
+  --to <YYYY-MM-DD>                Inclusive upper bound for source window
+  --messages-source <live|export>  Messages ingestion mode (default: export)
+  --transcript-source <otter_mail|fireflies_vector|none>
+                                   Transcript ingestion mode (default: otter_mail)
+  --output <path>                  Output root relative to repo root
+  --run-id <id>                    Override generated run id
+  --help                           Show this help text
+`;
+
+function printHelp(): void {
+  process.stdout.write(`${HELP_TEXT}\n`);
+}
+
+function isHydrationCommand(value: string): value is HydrationCommand {
+  return ["harvest", "extract", "compile", "validate", "all"].includes(value);
+}
+
+function isMessagesSourceMode(value: string): value is MessagesSourceMode {
+  return ["live", "export"].includes(value);
+}
+
+function isTranscriptSourceMode(value: string): value is TranscriptSourceMode {
+  return ["otter_mail", "fireflies_vector", "none"].includes(value);
+}
+
+function parseArgs(argv: string[]): CliOptions | null {
+  const [commandToken, ...rest] = argv;
+
+  if (!commandToken || commandToken === "--help" || commandToken === "-h") {
+    return null;
+  }
+
+  if (!isHydrationCommand(commandToken)) {
+    throw new Error(`Unknown command: ${commandToken}`);
+  }
+
+  const options: CliOptions = { command: commandToken };
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    const value = rest[index + 1];
+
+    if (token === "--help" || token === "-h") {
+      return null;
+    }
+
+    if (!value) {
+      throw new Error(`Missing value for ${token}`);
+    }
+
+    switch (token) {
+      case "--profile":
+        options.profile = value;
+        break;
+      case "--brand":
+        options.brand = value;
+        break;
+      case "--from":
+        options.from = value;
+        break;
+      case "--to":
+        options.to = value;
+        break;
+      case "--output":
+        options.output = value;
+        break;
+      case "--run-id":
+        options.runId = value;
+        break;
+      case "--messages-source":
+        if (!isMessagesSourceMode(value)) {
+          throw new Error(`Invalid messages source: ${value}`);
+        }
+        options.messagesSource = value;
+        break;
+      case "--transcript-source":
+        if (!isTranscriptSourceMode(value)) {
+          throw new Error(`Invalid transcript source: ${value}`);
+        }
+        options.transcriptSource = value;
+        break;
+      default:
+        throw new Error(`Unknown option: ${token}`);
+    }
+
+    index += 1;
+  }
+
+  return options;
+}
+
+function printPlannedRun(config: ReturnType<typeof resolveConfig>): void {
+  process.stdout.write(
+    JSON.stringify(
+      {
+        status: "scaffold_only",
+        message: `Command '${config.command}' is scaffolded but not implemented yet.`,
+        config: {
+          repoRoot: config.repoRoot,
+          outputRoot: config.outputRoot,
+          runId: config.runId,
+          profile: config.profile,
+          brand: config.brand,
+          from: config.from ?? null,
+          to: config.to ?? null,
+          messagesSource: config.messagesSource,
+          transcriptSource: config.transcriptSource,
+          artifactPaths: config.artifactPaths,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  process.stdout.write("\n");
+}
+
+function main(): void {
+  try {
+    const parsed = parseArgs(process.argv.slice(2));
+
+    if (!parsed) {
+      printHelp();
+      return;
+    }
+
+    const config = resolveConfig(parsed);
+    printPlannedRun(config);
+  } catch (error) {
+    process.stderr.write(`Error: ${(error as Error).message}\n\n`);
+    printHelp();
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/hydration-pipeline/src/config.ts
+++ b/hydration-pipeline/src/config.ts
@@ -18,6 +18,7 @@ export interface HydrationConfig {
   transcriptSource: TranscriptSourceMode;
   inboxLimit: number;
   sentLimit: number;
+  notesLimit: number;
   artifactPaths: ArtifactPaths;
 }
 
@@ -33,6 +34,7 @@ export interface CliOptions {
   transcriptSource?: TranscriptSourceMode;
   inboxLimit?: number;
   sentLimit?: number;
+  notesLimit?: number;
 }
 
 export function resolveRepoRoot(cwd = process.cwd()): string {
@@ -61,6 +63,7 @@ export function resolveConfig(options: CliOptions, cwd = process.cwd()): Hydrati
     transcriptSource: options.transcriptSource ?? "otter_mail",
     inboxLimit: options.inboxLimit ?? 3,
     sentLimit: options.sentLimit ?? 1,
+    notesLimit: options.notesLimit ?? 2,
     artifactPaths: createArtifactPaths(outputRoot, runId),
   };
 }

--- a/hydration-pipeline/src/config.ts
+++ b/hydration-pipeline/src/config.ts
@@ -1,0 +1,60 @@
+import { resolve } from "node:path";
+import { createArtifactPaths, type ArtifactPaths } from "./output/artifactPaths.js";
+
+export type HydrationCommand = "harvest" | "extract" | "compile" | "validate" | "all";
+export type MessagesSourceMode = "live" | "export";
+export type TranscriptSourceMode = "otter_mail" | "fireflies_vector" | "none";
+
+export interface HydrationConfig {
+  repoRoot: string;
+  outputRoot: string;
+  runId: string;
+  command: HydrationCommand;
+  profile: string;
+  brand: string;
+  from?: string;
+  to?: string;
+  messagesSource: MessagesSourceMode;
+  transcriptSource: TranscriptSourceMode;
+  artifactPaths: ArtifactPaths;
+}
+
+export interface CliOptions {
+  command: HydrationCommand;
+  profile?: string;
+  brand?: string;
+  from?: string;
+  to?: string;
+  output?: string;
+  runId?: string;
+  messagesSource?: MessagesSourceMode;
+  transcriptSource?: TranscriptSourceMode;
+}
+
+export function resolveRepoRoot(cwd = process.cwd()): string {
+  return cwd.endsWith("/hydration-pipeline") ? resolve(cwd, "..") : cwd;
+}
+
+export function createDefaultRunId(now = new Date()): string {
+  return now.toISOString().replace(/[:]/g, "-").replace(/\..+/, "Z");
+}
+
+export function resolveConfig(options: CliOptions, cwd = process.cwd()): HydrationConfig {
+  const repoRoot = resolveRepoRoot(cwd);
+  const outputRoot = resolve(repoRoot, options.output ?? "artifacts/north-star-hydration");
+  const runId = options.runId ?? createDefaultRunId();
+
+  return {
+    repoRoot,
+    outputRoot,
+    runId,
+    command: options.command,
+    profile: options.profile ?? "david",
+    brand: options.brand ?? "mojosolo",
+    from: options.from,
+    to: options.to,
+    messagesSource: options.messagesSource ?? "export",
+    transcriptSource: options.transcriptSource ?? "otter_mail",
+    artifactPaths: createArtifactPaths(outputRoot, runId),
+  };
+}

--- a/hydration-pipeline/src/config.ts
+++ b/hydration-pipeline/src/config.ts
@@ -16,6 +16,8 @@ export interface HydrationConfig {
   to?: string;
   messagesSource: MessagesSourceMode;
   transcriptSource: TranscriptSourceMode;
+  inboxLimit: number;
+  sentLimit: number;
   artifactPaths: ArtifactPaths;
 }
 
@@ -29,6 +31,8 @@ export interface CliOptions {
   runId?: string;
   messagesSource?: MessagesSourceMode;
   transcriptSource?: TranscriptSourceMode;
+  inboxLimit?: number;
+  sentLimit?: number;
 }
 
 export function resolveRepoRoot(cwd = process.cwd()): string {
@@ -55,6 +59,8 @@ export function resolveConfig(options: CliOptions, cwd = process.cwd()): Hydrati
     to: options.to,
     messagesSource: options.messagesSource ?? "export",
     transcriptSource: options.transcriptSource ?? "otter_mail",
+    inboxLimit: options.inboxLimit ?? 3,
+    sentLimit: options.sentLimit ?? 1,
     artifactPaths: createArtifactPaths(outputRoot, runId),
   };
 }

--- a/hydration-pipeline/src/mcp/client.ts
+++ b/hydration-pipeline/src/mcp/client.ts
@@ -1,0 +1,121 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { existsSync } from "node:fs";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface McpContent {
+  type: string;
+  text?: string;
+}
+
+export interface McpToolResult {
+  content: McpContent[];
+  isError?: boolean;
+}
+
+/** A live, connected session to one MCP server process. */
+export interface McpSession {
+  readonly serverName: string;
+  callTool(name: string, args?: Record<string, unknown>): Promise<McpToolResult>;
+  close(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+class McpSessionImpl implements McpSession {
+  readonly serverName: string;
+  private readonly client: Client;
+  private readonly transport: StdioClientTransport;
+
+  constructor(serverName: string, client: Client, transport: StdioClientTransport) {
+    this.serverName = serverName;
+    this.client = client;
+    this.transport = transport;
+  }
+
+  async callTool(name: string, args: Record<string, unknown> = {}): Promise<McpToolResult> {
+    const result = await this.client.callTool({ name, arguments: args });
+    return result as McpToolResult;
+  }
+
+  async close(): Promise<void> {
+    await this.transport.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface ConnectOptions {
+  /** Human-readable server name for logging and error messages. */
+  serverName: string;
+  /** Absolute path to the built server script (build/index.js). */
+  scriptPath: string;
+  /** Environment variables to pass to the server process. */
+  env?: Record<string, string>;
+}
+
+/**
+ * Spawn a local MCP server as a child process and return a connected session.
+ *
+ * The server must already be built (build/index.js must exist). Throws if the
+ * artifact is missing so callers get a clear error rather than a silent hang.
+ */
+export async function connectToLocalServer(options: ConnectOptions): Promise<McpSession> {
+  const { serverName, scriptPath, env } = options;
+
+  if (!existsSync(scriptPath)) {
+    throw new Error(
+      `[McpClient] Server artifact not found for "${serverName}": ${scriptPath}\n` +
+        `Run "npm run build" inside the server directory first.`,
+    );
+  }
+
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: [scriptPath],
+    env: env ?? (process.env as Record<string, string>),
+  });
+
+  const client = new Client({
+    name: "hydration-pipeline",
+    version: "0.1.0",
+  });
+
+  await client.connect(transport);
+
+  return new McpSessionImpl(serverName, client, transport);
+}
+
+// ---------------------------------------------------------------------------
+// Convenience helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the text content from a tool result into a typed value.
+ * Returns null if the result is an error or has no text content.
+ */
+export function parseToolResult<T>(result: McpToolResult): T | null {
+  if (result.isError) return null;
+  const textContent = result.content.find((c) => c.type === "text" && c.text !== undefined);
+  if (!textContent?.text) return null;
+  try {
+    return JSON.parse(textContent.text) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract raw text from a tool result (for non-JSON responses).
+ */
+export function extractText(result: McpToolResult): string {
+  const textContent = result.content.find((c) => c.type === "text" && c.text !== undefined);
+  return textContent?.text ?? "";
+}

--- a/hydration-pipeline/src/mcp/localServers.ts
+++ b/hydration-pipeline/src/mcp/localServers.ts
@@ -1,0 +1,104 @@
+import { join } from "node:path";
+import { connectToLocalServer, type McpSession } from "./client.js";
+
+// ---------------------------------------------------------------------------
+// Server registry
+// ---------------------------------------------------------------------------
+
+/** All local MCP servers the pipeline can connect to. */
+export type LocalServerName =
+  | "knowledge-corpus"
+  | "mail-intelligence"
+  | "apple-mail"
+  | "apple-messages"
+  | "apple-notes";
+
+interface ServerDef {
+  /** Directory name under repo root. */
+  directory: string;
+}
+
+const SERVER_DEFS: Record<LocalServerName, ServerDef> = {
+  "knowledge-corpus": { directory: "knowledge-corpus" },
+  "mail-intelligence": { directory: "mail-intelligence" },
+  "apple-mail": { directory: "mail" },
+  "apple-messages": { directory: "messages" },
+  "apple-notes": { directory: "notes" },
+};
+
+// ---------------------------------------------------------------------------
+// Script path resolution
+// ---------------------------------------------------------------------------
+
+export function serverScriptPath(serverName: LocalServerName, repoRoot: string): string {
+  const def = SERVER_DEFS[serverName];
+  return join(repoRoot, def.directory, "build", "index.js");
+}
+
+// ---------------------------------------------------------------------------
+// Connection factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Connect to a local MCP server by name.
+ *
+ * Callers are responsible for calling `session.close()` when done.
+ * The server process is kept alive for the duration of the session.
+ */
+export async function connectToServer(
+  serverName: LocalServerName,
+  repoRoot: string,
+  env?: Record<string, string>,
+): Promise<McpSession> {
+  const scriptPath = serverScriptPath(serverName, repoRoot);
+  return connectToLocalServer({ serverName, scriptPath, env });
+}
+
+// ---------------------------------------------------------------------------
+// Multi-server convenience
+// ---------------------------------------------------------------------------
+
+export interface ServerPool {
+  sessions: Partial<Record<LocalServerName, McpSession>>;
+  get(name: LocalServerName): McpSession;
+  closeAll(): Promise<void>;
+}
+
+/**
+ * Connect to multiple servers in parallel and return a pool.
+ * Servers that fail to connect are excluded from the pool and logged.
+ * Use `pool.get(name)` to access a session — throws if not connected.
+ */
+export async function connectServerPool(
+  names: LocalServerName[],
+  repoRoot: string,
+  env?: Record<string, string>,
+): Promise<ServerPool> {
+  const settled = await Promise.allSettled(
+    names.map((name) => connectToServer(name, repoRoot, env).then((s) => ({ name, session: s }))),
+  );
+
+  const sessions: Partial<Record<LocalServerName, McpSession>> = {};
+
+  for (const result of settled) {
+    if (result.status === "fulfilled") {
+      sessions[result.value.name] = result.value.session;
+    } else {
+      process.stderr.write(`[LocalServers] Failed to connect: ${String(result.reason)}\n`);
+    }
+  }
+
+  return {
+    sessions,
+    get(name: LocalServerName): McpSession {
+      const session = sessions[name];
+      if (!session) {
+        throw new Error(`[LocalServers] Server "${name}" is not connected in this pool.`);
+      }
+      return session;
+    },
+    async closeAll(): Promise<void> {
+      await Promise.allSettled(Object.values(sessions).map((s) => s?.close()));
+    },
+  };
+}

--- a/hydration-pipeline/src/normalize/mailNormalization.ts
+++ b/hydration-pipeline/src/normalize/mailNormalization.ts
@@ -1,0 +1,137 @@
+import type { HarvestedMailMessage, MailHarvestResult } from "../providers/mailSource.js";
+
+export interface MailSignalDocument {
+  id: string;
+  sourceType: "mail";
+  sourceId: string;
+  channel: string;
+  authoredBy: "david" | "external" | "mixed" | "unknown";
+  personaHint: "author" | "operator" | "machine" | "unknown";
+  timestamp: string;
+  rawDate: string;
+  title: string;
+  participants: string[];
+  text: string;
+  tags: string[];
+  mailbox: string;
+  account: string;
+  configuredAccount: string;
+  direction: "inbound" | "outbound";
+  sender: string;
+  toRecipients: string[];
+  ccRecipients: string[];
+  matchedRuleLabels: string[];
+  matchedDomains: string[];
+  matchedLanes: string[];
+  provenance: {
+    collector: string;
+    directness: "direct" | "quoted" | "third_party" | "inferred";
+    freshness: string;
+  };
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\r/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function parseTimestamp(rawDate: string): string {
+  const parsed = Date.parse(rawDate);
+  return Number.isNaN(parsed) ? rawDate : new Date(parsed).toISOString();
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function extractEmail(text: string): string | null {
+  const match = text.match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+  return match ? match[0].toLowerCase() : null;
+}
+
+function classifyAuthoredBy(message: HarvestedMailMessage): "david" | "external" | "mixed" | "unknown" {
+  if (message.direction === "inbound") {
+    return "external";
+  }
+
+  if (message.catchAll) {
+    return "mixed";
+  }
+
+  if (message.primaryReplyFrom || message.personaId === "author" || message.personaId === "operator") {
+    return "david";
+  }
+
+  return "unknown";
+}
+
+function buildParticipants(message: HarvestedMailMessage): string[] {
+  const senderEmail = extractEmail(message.sender);
+  return unique([
+    message.sender,
+    ...(senderEmail ? [senderEmail] : []),
+    ...message.toRecipients,
+    ...message.ccRecipients,
+    ...message.accountEmails,
+  ]);
+}
+
+function deriveTags(message: HarvestedMailMessage): string[] {
+  return unique([
+    "mail",
+    `persona:${message.personaId}`,
+    `lane:${message.defaultLane}`,
+    `direction:${message.direction}`,
+    `mailbox:${message.mailbox}`,
+    `account:${message.actualAccountName}`,
+    ...message.matchedRules.map((rule) => `rule:${rule.label}`),
+    ...message.matchedRules.map((rule) => `domain:${rule.domain}`),
+    ...message.matchedRules.map((rule) => `matched_lane:${rule.lane}`),
+  ]).sort((left, right) => left.localeCompare(right));
+}
+
+export function normalizeMailMessage(message: HarvestedMailMessage): MailSignalDocument {
+  const text = normalizeWhitespace(message.content || message.subject);
+  const personaHint = ["author", "operator", "machine"].includes(message.personaId)
+    ? (message.personaId as "author" | "operator" | "machine")
+    : "unknown";
+
+  return {
+    id: `mail:${message.actualAccountName}:${message.mailbox}:${message.id}`,
+    sourceType: "mail",
+    sourceId: String(message.id),
+    channel: `mail:${message.personaId}:${message.direction}`,
+    authoredBy: classifyAuthoredBy(message),
+    personaHint,
+    timestamp: parseTimestamp(message.date),
+    rawDate: message.date,
+    title: message.subject,
+    participants: buildParticipants(message),
+    text,
+    tags: deriveTags(message),
+    mailbox: message.mailbox,
+    account: message.actualAccountName,
+    configuredAccount: message.configuredAccount,
+    direction: message.direction,
+    sender: message.sender,
+    toRecipients: [...message.toRecipients],
+    ccRecipients: [...message.ccRecipients],
+    matchedRuleLabels: unique(message.matchedRules.map((rule) => rule.label)),
+    matchedDomains: unique(message.matchedRules.map((rule) => rule.domain)),
+    matchedLanes: unique(message.matchedRules.map((rule) => rule.lane)),
+    provenance: {
+      collector: "hydration-pipeline/mailSource",
+      directness: message.direction === "outbound" ? "direct" : "third_party",
+      freshness: new Date().toISOString(),
+    },
+  };
+}
+
+export function normalizeMailHarvest(result: MailHarvestResult): MailSignalDocument[] {
+  return result.accounts.flatMap((account) =>
+    [...account.inboxMessages, ...account.sentMessages].map(normalizeMailMessage),
+  );
+}
+
+export function selectDavidFirstPersonMail(documents: MailSignalDocument[]): MailSignalDocument[] {
+  return documents.filter((document) => document.authoredBy === "david");
+}

--- a/hydration-pipeline/src/normalize/messagesNormalization.ts
+++ b/hydration-pipeline/src/normalize/messagesNormalization.ts
@@ -1,0 +1,98 @@
+import type { HarvestedChatMessage, MessagesHarvestResult } from "../providers/messagesSource.js";
+
+export interface MessageSignalDocument {
+  id: string;
+  sourceType: "message";
+  sourceId: string;
+  channel: string;
+  authoredBy: "david" | "external" | "mixed" | "unknown";
+  personaHint: "author" | "operator" | "machine" | "unknown";
+  timestamp: string;
+  rawDate: string;
+  participants: string[];
+  text: string;
+  tags: string[];
+  chatId: string;
+  displayName: string | null;
+  sender: string | null;
+  service: string | null;
+  fromMe: boolean;
+  provenance: {
+    collector: string;
+    directness: "direct" | "quoted" | "third_party" | "inferred";
+    freshness: string;
+  };
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function parseTimestamp(rawDate: string): string {
+  const parsed = Date.parse(rawDate);
+  return Number.isNaN(parsed) ? rawDate : new Date(parsed).toISOString();
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\r/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function derivePersonaHint(chatId: string): "author" | "operator" | "machine" | "unknown" {
+  const normalized = chatId.toLowerCase();
+  if (normalized.includes("mojosolo@mac.com")) {
+    return "author";
+  }
+  if (normalized.includes("david@mojosolo.com")) {
+    return "operator";
+  }
+  return "unknown";
+}
+
+function classifyAuthoredBy(message: HarvestedChatMessage): "david" | "external" | "mixed" | "unknown" {
+  return message.fromMe ? "david" : "external";
+}
+
+function deriveTags(message: HarvestedChatMessage, personaHint: string): string[] {
+  return unique([
+    "messages",
+    `chat:${message.chatId}`,
+    `persona:${personaHint}`,
+    `direction:${message.fromMe ? "outbound" : "inbound"}`,
+    ...(message.service ? [`service:${message.service}`] : []),
+  ]).sort((left, right) => left.localeCompare(right));
+}
+
+export function normalizeHarvestedMessage(message: HarvestedChatMessage): MessageSignalDocument {
+  const personaHint = derivePersonaHint(message.chatId);
+  return {
+    id: `message:${message.chatId}:${message.messageId}`,
+    sourceType: "message",
+    sourceId: message.messageId,
+    channel: `messages:${personaHint}`,
+    authoredBy: classifyAuthoredBy(message),
+    personaHint,
+    timestamp: parseTimestamp(message.date),
+    rawDate: message.date,
+    participants: unique([message.chatId, message.sender ?? ""]),
+    text: normalizeWhitespace(message.text),
+    tags: deriveTags(message, personaHint),
+    chatId: message.chatId,
+    displayName: message.displayName,
+    sender: message.sender,
+    service: message.service,
+    fromMe: message.fromMe,
+    provenance: {
+      collector: "hydration-pipeline/messagesSource",
+      directness: message.fromMe ? "direct" : "third_party",
+      freshness: new Date().toISOString(),
+    },
+  };
+}
+
+export function normalizeMessagesHarvest(result: MessagesHarvestResult): MessageSignalDocument[] {
+  return result.chats.flatMap((chat) => chat.messages.map(normalizeHarvestedMessage));
+}
+
+export function selectDavidFirstPersonMessages(documents: MessageSignalDocument[]): MessageSignalDocument[] {
+  return documents.filter((document) => document.authoredBy === "david");
+}

--- a/hydration-pipeline/src/normalize/notesNormalization.ts
+++ b/hydration-pipeline/src/normalize/notesNormalization.ts
@@ -1,0 +1,87 @@
+import type { HarvestedNote, NotesHarvestResult } from "../providers/notesSource.js";
+
+export interface NoteSignalDocument {
+  id: string;
+  sourceType: "note";
+  sourceId: string;
+  channel: string;
+  authoredBy: "david" | "external" | "mixed" | "unknown";
+  personaHint: "author" | "operator" | "machine" | "unknown";
+  timestamp: string;
+  rawDate: string;
+  title: string;
+  participants: string[];
+  text: string;
+  tags: string[];
+  folder: string;
+  provenance: {
+    collector: string;
+    directness: "direct" | "quoted" | "third_party" | "inferred";
+    freshness: string;
+  };
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/\r/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/[ \t]{2,}/g, " ")
+    .trim();
+}
+
+function parseTimestamp(rawDate: string): string {
+  const parsed = Date.parse(rawDate);
+  return Number.isNaN(parsed) ? rawDate : new Date(parsed).toISOString();
+}
+
+function derivePersonaHint(note: HarvestedNote): "author" | "operator" | "machine" | "unknown" {
+  const haystack = `${note.folder} ${note.title} ${note.body}`.toLowerCase();
+  if (haystack.includes("mojomosaic") || haystack.includes("daily intel") || haystack.includes("operator")) {
+    return "operator";
+  }
+  if (haystack.includes("campaign") || haystack.includes("machine")) {
+    return "machine";
+  }
+  return "author";
+}
+
+export function normalizeHarvestedNote(note: HarvestedNote): NoteSignalDocument {
+  const personaHint = derivePersonaHint(note);
+  return {
+    id: `note:${note.folder}:${note.id}`,
+    sourceType: "note",
+    sourceId: note.id,
+    channel: `notes:${personaHint}`,
+    authoredBy: "david",
+    personaHint,
+    timestamp: parseTimestamp(note.modificationDate),
+    rawDate: note.modificationDate,
+    title: note.title,
+    participants: ["david", note.folder],
+    text: stripHtml(note.body),
+    tags: ["notes", `folder:${note.folder}`, `persona:${personaHint}`].sort((left, right) => left.localeCompare(right)),
+    folder: note.folder,
+    provenance: {
+      collector: "hydration-pipeline/notesSource",
+      directness: "direct",
+      freshness: new Date().toISOString(),
+    },
+  };
+}
+
+export function normalizeNotesHarvest(result: NotesHarvestResult): NoteSignalDocument[] {
+  return result.harvestedNotes.map(normalizeHarvestedNote);
+}
+
+export function selectDavidFirstPersonNotes(documents: NoteSignalDocument[]): NoteSignalDocument[] {
+  return documents.filter((document) => document.authoredBy === "david");
+}

--- a/hydration-pipeline/src/output/artifactPaths.ts
+++ b/hydration-pipeline/src/output/artifactPaths.ts
@@ -1,0 +1,32 @@
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+export interface ArtifactPaths {
+  baseDir: string;
+  harvestDir: string;
+  evidenceDir: string;
+  skillsDir: string;
+  validationDir: string;
+  logsDir: string;
+}
+
+export function createArtifactPaths(outputRoot: string, runId: string): ArtifactPaths {
+  const baseDir = join(outputRoot, runId);
+
+  return {
+    baseDir,
+    harvestDir: join(baseDir, "harvest"),
+    evidenceDir: join(baseDir, "evidence"),
+    skillsDir: join(baseDir, "skills"),
+    validationDir: join(baseDir, "validation"),
+    logsDir: join(baseDir, "logs"),
+  };
+}
+
+export function ensureArtifactDirectories(paths: ArtifactPaths): void {
+  mkdirSync(paths.harvestDir, { recursive: true });
+  mkdirSync(paths.evidenceDir, { recursive: true });
+  mkdirSync(paths.skillsDir, { recursive: true });
+  mkdirSync(paths.validationDir, { recursive: true });
+  mkdirSync(paths.logsDir, { recursive: true });
+}

--- a/hydration-pipeline/src/output/writeArtifacts.ts
+++ b/hydration-pipeline/src/output/writeArtifacts.ts
@@ -1,0 +1,7 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export function writeJsonArtifact(targetPath: string, value: unknown): void {
+  mkdirSync(dirname(targetPath), { recursive: true });
+  writeFileSync(targetPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}

--- a/hydration-pipeline/src/providers/corpusSource.ts
+++ b/hydration-pipeline/src/providers/corpusSource.ts
@@ -1,0 +1,271 @@
+import { extractText, parseToolResult, type McpSession, type McpToolResult } from "../mcp/client.js";
+import { connectToServer } from "../mcp/localServers.js";
+
+export interface CorpusOverview {
+  corpus_name: string;
+  corpus_version: string;
+  generated_on: string;
+  target_company: string;
+  target_domain: string;
+  section_count: number;
+  sections: string[];
+  source_count: number;
+  report_available: boolean;
+  report_section_count: number;
+  machine_ingest_entities: string[];
+  corpus_path: string;
+  report_path: string;
+}
+
+export interface CanonicalProfile {
+  brand_name: string;
+  operating_frame: string[];
+  public_identity_summary: string;
+  canonical_brain_location: string;
+  primary_application_layer: string;
+  primary_output_layer: string;
+}
+
+export interface CorpusSourceRecord {
+  id: string;
+  title: string;
+  organization: string;
+  source_class: string;
+  role_in_corpus: string;
+  trust_level: string;
+  url: string;
+}
+
+export interface MailIntelligenceDomain {
+  name: string;
+  matches: string[];
+}
+
+export interface MailIntelligenceSourceRule {
+  label: string;
+  matches: string[];
+  domain: string;
+  lane: string;
+  priority: "high" | "normal";
+}
+
+export interface MailIntelligenceAccount {
+  account: string;
+  mailbox: string;
+  personaId: string;
+  persona: string;
+  role: string;
+  summary: string;
+  primaryReplyFrom: boolean;
+  catchAll: boolean;
+  defaultLane: string;
+  sourceRules: MailIntelligenceSourceRule[];
+}
+
+export interface MailIntelligenceConfig {
+  notes: {
+    folder: string;
+    titlePrefix: string;
+    defaultLookbackDays: number;
+    defaultLimitPerAccount: number;
+  };
+  scoring: Record<string, string[]>;
+  domains: MailIntelligenceDomain[];
+  accounts: MailIntelligenceAccount[];
+}
+
+export interface PersonaMapAccount {
+  account: string;
+  persona: string;
+  persona_id: string;
+  role: string;
+  primary_reply_from: boolean;
+  catch_all: boolean;
+  default_lane: string;
+  source_rule_count: number;
+}
+
+export interface PersonaMapSummary {
+  config_path: string;
+  note_output: {
+    folder: string;
+    titlePrefix: string;
+    defaultLookbackDays: number;
+    defaultLimitPerAccount: number;
+  };
+  accounts: PersonaMapAccount[];
+  domains: string[];
+}
+
+export interface PersonaAnchor {
+  personaId: string;
+  persona: string;
+  account: string;
+  role: string;
+  defaultLane: string;
+  primaryReplyFrom: boolean;
+  catchAll: boolean;
+  sourceRuleCount: number;
+}
+
+export interface MeetingIntelHint {
+  account: string;
+  label: string;
+  lane: string;
+  matches: string[];
+}
+
+export interface CorpusBootstrapSnapshot {
+  capturedAt: string;
+  overview: CorpusOverview;
+  canonicalProfile: CanonicalProfile;
+  sourceRegistry: CorpusSourceRecord[];
+  mailIntelligenceConfig: MailIntelligenceConfig;
+  personaMap: PersonaMapSummary;
+  personas: PersonaAnchor[];
+  vocabularyAnchors: string[];
+  meetingIntelHints: MeetingIntelHint[];
+}
+
+interface ToolCaller {
+  callTool(name: string, args?: Record<string, unknown>): Promise<McpToolResult>;
+}
+
+function requireParsedResult<T>(label: string, result: McpToolResult): T {
+  const parsed = parseToolResult<T>(result);
+  if (parsed !== null) {
+    return parsed;
+  }
+
+  const raw = extractText(result);
+  throw new Error(`[CorpusBootstrap] Failed to parse ${label}. Raw result: ${raw || "<empty>"}`);
+}
+
+export async function loadCorpusOverview(session: ToolCaller): Promise<CorpusOverview> {
+  return requireParsedResult<CorpusOverview>("knowledge-corpus:get_corpus_overview", await session.callTool("get_corpus_overview"));
+}
+
+export async function loadCanonicalProfile(session: ToolCaller): Promise<CanonicalProfile> {
+  return requireParsedResult<CanonicalProfile>(
+    "knowledge-corpus:get_corpus_section(canonical_profile)",
+    await session.callTool("get_corpus_section", { section: "canonical_profile" }),
+  );
+}
+
+export async function loadSourceRegistry(session: ToolCaller): Promise<CorpusSourceRecord[]> {
+  return requireParsedResult<CorpusSourceRecord[]>("knowledge-corpus:list_sources", await session.callTool("list_sources"));
+}
+
+export async function loadMailIntelligenceConfig(session: ToolCaller): Promise<MailIntelligenceConfig> {
+  return requireParsedResult<MailIntelligenceConfig>(
+    "knowledge-corpus:get_mail_intelligence_config",
+    await session.callTool("get_mail_intelligence_config"),
+  );
+}
+
+export async function loadPersonaMap(session: ToolCaller): Promise<PersonaMapSummary> {
+  return requireParsedResult<PersonaMapSummary>("mail-intelligence:get_persona_map", await session.callTool("get_persona_map"));
+}
+
+export function derivePersonaAnchors(personaMap: PersonaMapSummary): PersonaAnchor[] {
+  return personaMap.accounts.map((account) => ({
+    personaId: account.persona_id,
+    persona: account.persona,
+    account: account.account,
+    role: account.role,
+    defaultLane: account.default_lane,
+    primaryReplyFrom: account.primary_reply_from,
+    catchAll: account.catch_all,
+    sourceRuleCount: account.source_rule_count,
+  }));
+}
+
+export function deriveMeetingIntelHints(config: MailIntelligenceConfig): MeetingIntelHint[] {
+  return config.accounts.flatMap((account) =>
+    account.sourceRules
+      .filter((rule) => rule.domain === "Meeting Intel")
+      .map((rule) => ({
+        account: account.account,
+        label: rule.label,
+        lane: rule.lane,
+        matches: [...rule.matches],
+      })),
+  );
+}
+
+export function deriveVocabularyAnchors(
+  overview: CorpusOverview,
+  profile: CanonicalProfile,
+  config: MailIntelligenceConfig,
+  personaMap: PersonaMapSummary,
+): string[] {
+  const values = new Set<string>();
+
+  values.add(profile.brand_name);
+  values.add(profile.primary_application_layer);
+  values.add(profile.primary_output_layer);
+
+  for (const value of profile.operating_frame) {
+    values.add(value);
+  }
+
+  for (const value of overview.machine_ingest_entities) {
+    values.add(value);
+  }
+
+  for (const account of config.accounts) {
+    values.add(account.persona);
+    values.add(account.personaId);
+    values.add(account.defaultLane);
+    for (const rule of account.sourceRules) {
+      values.add(rule.label);
+      values.add(rule.domain);
+      values.add(rule.lane);
+    }
+  }
+
+  for (const domain of personaMap.domains) {
+    values.add(domain);
+  }
+
+  return [...values].filter(Boolean).sort((left, right) => left.localeCompare(right));
+}
+
+export async function bootstrapCorpusContext(repoRoot: string, env?: Record<string, string>): Promise<CorpusBootstrapSnapshot> {
+  const knowledgeCorpus = await connectToServer("knowledge-corpus", repoRoot, env);
+  const mailIntelligence = await connectToServer("mail-intelligence", repoRoot, env);
+
+  try {
+    return await bootstrapCorpusContextFromSessions({
+      knowledgeCorpus,
+      mailIntelligence,
+    });
+  } finally {
+    await Promise.allSettled([knowledgeCorpus.close(), mailIntelligence.close()]);
+  }
+}
+
+export async function bootstrapCorpusContextFromSessions(sessions: {
+  knowledgeCorpus: McpSession;
+  mailIntelligence: McpSession;
+}): Promise<CorpusBootstrapSnapshot> {
+  const [overview, canonicalProfile, sourceRegistry, mailIntelligenceConfig, personaMap] = await Promise.all([
+    loadCorpusOverview(sessions.knowledgeCorpus),
+    loadCanonicalProfile(sessions.knowledgeCorpus),
+    loadSourceRegistry(sessions.knowledgeCorpus),
+    loadMailIntelligenceConfig(sessions.knowledgeCorpus),
+    loadPersonaMap(sessions.mailIntelligence),
+  ]);
+
+  return {
+    capturedAt: new Date().toISOString(),
+    overview,
+    canonicalProfile,
+    sourceRegistry,
+    mailIntelligenceConfig,
+    personaMap,
+    personas: derivePersonaAnchors(personaMap),
+    vocabularyAnchors: deriveVocabularyAnchors(overview, canonicalProfile, mailIntelligenceConfig, personaMap),
+    meetingIntelHints: deriveMeetingIntelHints(mailIntelligenceConfig),
+  };
+}

--- a/hydration-pipeline/src/providers/mailSource.ts
+++ b/hydration-pipeline/src/providers/mailSource.ts
@@ -1,0 +1,370 @@
+import { extractText, parseToolResult, type McpSession, type McpToolResult } from "../mcp/client.js";
+import { connectToServer } from "../mcp/localServers.js";
+import { bootstrapCorpusContext, type CorpusBootstrapSnapshot, type MailIntelligenceAccount, type MailIntelligenceSourceRule } from "./corpusSource.js";
+
+export interface DiscoveredMailAccount {
+  name: string;
+  emails: string[];
+}
+
+export interface MailboxInventoryRecord {
+  name: string;
+  account: string;
+  unreadCount: number;
+}
+
+export interface MailMessageSummary {
+  id: number;
+  subject: string;
+  sender: string;
+  date: string;
+  isRead: boolean;
+}
+
+export interface MailMessageDetail {
+  id: number;
+  subject: string;
+  sender: string;
+  date: string;
+  isRead: boolean;
+  content: string;
+  toRecipients: string[];
+  ccRecipients: string[];
+}
+
+export interface ResolvedMailAccount {
+  configuredAccount: string;
+  actualAccountName: string;
+  emails: string[];
+  mailbox: string;
+  sentMailbox: string | null;
+  personaId: string;
+  persona: string;
+  role: string;
+  summary: string;
+  primaryReplyFrom: boolean;
+  catchAll: boolean;
+  defaultLane: string;
+  sourceRules: MailIntelligenceSourceRule[];
+}
+
+export interface HarvestedMailMessage {
+  id: number;
+  subject: string;
+  sender: string;
+  date: string;
+  isRead: boolean;
+  content: string;
+  toRecipients: string[];
+  ccRecipients: string[];
+  configuredAccount: string;
+  actualAccountName: string;
+  accountEmails: string[];
+  mailbox: string;
+  personaId: string;
+  persona: string;
+  role: string;
+  summary: string;
+  defaultLane: string;
+  primaryReplyFrom: boolean;
+  catchAll: boolean;
+  direction: "inbound" | "outbound";
+  matchedRules: MailIntelligenceSourceRule[];
+}
+
+export interface MailHarvestAccountResult {
+  account: ResolvedMailAccount;
+  inboxMessages: HarvestedMailMessage[];
+  sentMessages: HarvestedMailMessage[];
+}
+
+export interface MailHarvestResult {
+  capturedAt: string;
+  bootstrap: CorpusBootstrapSnapshot;
+  discoveredAccounts: DiscoveredMailAccount[];
+  mailboxInventory: MailboxInventoryRecord[];
+  accounts: MailHarvestAccountResult[];
+  errors: string[];
+}
+
+export interface HarvestMailOptions {
+  bootstrap?: CorpusBootstrapSnapshot;
+  env?: Record<string, string>;
+  inboxLimit?: number;
+  sentLimit?: number;
+  includeSent?: boolean;
+}
+
+interface ToolCaller {
+  callTool(name: string, args?: Record<string, unknown>): Promise<McpToolResult>;
+}
+
+function requireParsedResult<T>(label: string, result: McpToolResult): T {
+  const parsed = parseToolResult<T>(result);
+  if (parsed !== null) {
+    return parsed;
+  }
+
+  throw new Error(`[MailSource] Failed to parse ${label}. Raw result: ${extractText(result) || "<empty>"}`);
+}
+
+export async function loadDiscoveredMailAccounts(session: ToolCaller): Promise<DiscoveredMailAccount[]> {
+  return requireParsedResult<DiscoveredMailAccount[]>(
+    "mail-intelligence:discover_mail_accounts",
+    await session.callTool("discover_mail_accounts"),
+  );
+}
+
+export async function loadMailboxInventory(session: ToolCaller): Promise<MailboxInventoryRecord[]> {
+  return requireParsedResult<MailboxInventoryRecord[]>("apple-mail:list_mailboxes", await session.callTool("list_mailboxes"));
+}
+
+export async function listMailboxMessages(
+  session: ToolCaller,
+  mailbox: string,
+  account: string,
+  limit: number,
+): Promise<MailMessageSummary[]> {
+  return requireParsedResult<MailMessageSummary[]>(
+    `apple-mail:list_messages(${account}/${mailbox})`,
+    await session.callTool("list_messages", { mailbox, account, limit }),
+  );
+}
+
+export async function getMailboxMessage(
+  session: ToolCaller,
+  mailbox: string,
+  account: string,
+  messageId: number,
+): Promise<MailMessageDetail> {
+  return requireParsedResult<MailMessageDetail>(
+    `apple-mail:get_message(${account}/${mailbox}/${messageId})`,
+    await session.callTool("get_message", { mailbox, account, message_id: messageId }),
+  );
+}
+
+function normalizeForMatch(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function resolveMailAccountName(configuredAccount: string, discoveredAccounts: DiscoveredMailAccount[]): DiscoveredMailAccount {
+  const normalized = normalizeForMatch(configuredAccount);
+
+  const exactName = discoveredAccounts.find((account) => normalizeForMatch(account.name) === normalized);
+  if (exactName) {
+    return exactName;
+  }
+
+  const exactEmail = discoveredAccounts.find((account) =>
+    account.emails.some((email) => normalizeForMatch(email) === normalized),
+  );
+  if (exactEmail) {
+    return exactEmail;
+  }
+
+  const partialEmail = discoveredAccounts.find((account) =>
+    account.emails.some((email) => normalizeForMatch(email).includes(normalized)),
+  );
+  if (partialEmail) {
+    return partialEmail;
+  }
+
+  throw new Error(
+    `[MailSource] Could not resolve configured account "${configuredAccount}" against discovered Apple Mail accounts.`,
+  );
+}
+
+function selectSentMailbox(actualAccountName: string, mailboxInventory: MailboxInventoryRecord[]): string | null {
+  const candidates = mailboxInventory.filter((mailbox) => mailbox.account === actualAccountName);
+  const preferred = ["Sent Mail", "Sent Messages"];
+
+  for (const exact of preferred) {
+    const match = candidates.find((candidate) => candidate.name === exact);
+    if (match) {
+      return match.name;
+    }
+  }
+
+  const fuzzy = candidates.find((candidate) => /sent/i.test(candidate.name));
+  return fuzzy?.name ?? null;
+}
+
+export function resolveConfiguredMailAccounts(
+  configAccounts: MailIntelligenceAccount[],
+  discoveredAccounts: DiscoveredMailAccount[],
+  mailboxInventory: MailboxInventoryRecord[],
+): ResolvedMailAccount[] {
+  return configAccounts.map((account) => {
+    const resolved = resolveMailAccountName(account.account, discoveredAccounts);
+    return {
+      configuredAccount: account.account,
+      actualAccountName: resolved.name,
+      emails: [...resolved.emails],
+      mailbox: account.mailbox,
+      sentMailbox: selectSentMailbox(resolved.name, mailboxInventory),
+      personaId: account.personaId,
+      persona: account.persona,
+      role: account.role,
+      summary: account.summary,
+      primaryReplyFrom: account.primaryReplyFrom,
+      catchAll: account.catchAll,
+      defaultLane: account.defaultLane,
+      sourceRules: account.sourceRules,
+    };
+  });
+}
+
+function matchSourceRules(message: { subject: string; sender: string; content: string }, account: ResolvedMailAccount): MailIntelligenceSourceRule[] {
+  const haystack = `${message.subject}\n${message.sender}\n${message.content}`.toLowerCase();
+  return account.sourceRules.filter((rule) => rule.matches.some((term) => haystack.includes(term.toLowerCase())));
+}
+
+async function harvestMailbox(
+  session: ToolCaller,
+  account: ResolvedMailAccount,
+  mailbox: string,
+  direction: "inbound" | "outbound",
+  limit: number,
+  errors: string[],
+): Promise<HarvestedMailMessage[]> {
+  const summaries = await listMailboxMessages(session, mailbox, account.actualAccountName, limit);
+
+  return Promise.all(
+    summaries.map(async (summary) => {
+      try {
+        const detail = await getMailboxMessage(session, mailbox, account.actualAccountName, summary.id);
+        return {
+          ...detail,
+          configuredAccount: account.configuredAccount,
+          actualAccountName: account.actualAccountName,
+          accountEmails: [...account.emails],
+          mailbox,
+          personaId: account.personaId,
+          persona: account.persona,
+          role: account.role,
+          summary: account.summary,
+          defaultLane: account.defaultLane,
+          primaryReplyFrom: account.primaryReplyFrom,
+          catchAll: account.catchAll,
+          direction,
+          matchedRules: matchSourceRules(detail, account),
+        } satisfies HarvestedMailMessage;
+      } catch (error) {
+        errors.push(
+          `[MailSource] Failed to fetch message ${summary.id} from ${account.actualAccountName}/${mailbox}: ${(error as Error).message}`,
+        );
+        return {
+          ...summary,
+          content: "",
+          toRecipients: [],
+          ccRecipients: [],
+          configuredAccount: account.configuredAccount,
+          actualAccountName: account.actualAccountName,
+          accountEmails: [...account.emails],
+          mailbox,
+          personaId: account.personaId,
+          persona: account.persona,
+          role: account.role,
+          summary: account.summary,
+          defaultLane: account.defaultLane,
+          primaryReplyFrom: account.primaryReplyFrom,
+          catchAll: account.catchAll,
+          direction,
+          matchedRules: matchSourceRules({ ...summary, content: "" }, account),
+        } satisfies HarvestedMailMessage;
+      }
+    }),
+  );
+}
+
+export async function harvestMailFromSessions(
+  bootstrap: CorpusBootstrapSnapshot,
+  sessions: { appleMail: McpSession; mailIntelligence: McpSession },
+  options: Omit<HarvestMailOptions, "bootstrap" | "env"> = {},
+): Promise<MailHarvestResult> {
+  const inboxLimit = options.inboxLimit ?? 5;
+  const sentLimit = options.sentLimit ?? 3;
+  const includeSent = options.includeSent ?? true;
+  const errors: string[] = [];
+
+  const [discoveredAccounts, mailboxInventory] = await Promise.all([
+    loadDiscoveredMailAccounts(sessions.mailIntelligence),
+    loadMailboxInventory(sessions.appleMail),
+  ]);
+
+  const resolvedAccounts = resolveConfiguredMailAccounts(
+    bootstrap.mailIntelligenceConfig.accounts,
+    discoveredAccounts,
+    mailboxInventory,
+  );
+
+  const accounts: MailHarvestAccountResult[] = [];
+
+  for (const account of resolvedAccounts) {
+    let inboxMessages: HarvestedMailMessage[] = [];
+    let sentMessages: HarvestedMailMessage[] = [];
+
+    try {
+      inboxMessages = await harvestMailbox(
+        sessions.appleMail,
+        account,
+        account.mailbox,
+        "inbound",
+        inboxLimit,
+        errors,
+      );
+    } catch (error) {
+      errors.push(
+        `[MailSource] Failed to harvest inbox for ${account.configuredAccount}: ${(error as Error).message}`,
+      );
+    }
+
+    if (includeSent && account.sentMailbox) {
+      try {
+        sentMessages = await harvestMailbox(
+          sessions.appleMail,
+          account,
+          account.sentMailbox,
+          "outbound",
+          sentLimit,
+          errors,
+        );
+      } catch (error) {
+        errors.push(
+          `[MailSource] Failed to harvest sent mailbox for ${account.configuredAccount}: ${(error as Error).message}`,
+        );
+      }
+    }
+
+    accounts.push({ account, inboxMessages, sentMessages });
+  }
+
+  return {
+    capturedAt: new Date().toISOString(),
+    bootstrap,
+    discoveredAccounts,
+    mailboxInventory,
+    accounts,
+    errors,
+  };
+}
+
+export async function harvestMail(repoRoot: string, options: HarvestMailOptions = {}): Promise<MailHarvestResult> {
+  const bootstrap = options.bootstrap ?? (await bootstrapCorpusContext(repoRoot, options.env));
+  const appleMail = await connectToServer("apple-mail", repoRoot, options.env);
+  const mailIntelligence = await connectToServer("mail-intelligence", repoRoot, options.env);
+
+  try {
+    return await harvestMailFromSessions(
+      bootstrap,
+      { appleMail, mailIntelligence },
+      {
+        inboxLimit: options.inboxLimit,
+        sentLimit: options.sentLimit,
+        includeSent: options.includeSent,
+      },
+    );
+  } finally {
+    await Promise.allSettled([appleMail.close(), mailIntelligence.close()]);
+  }
+}

--- a/hydration-pipeline/src/providers/messagesSource.ts
+++ b/hydration-pipeline/src/providers/messagesSource.ts
@@ -1,0 +1,206 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseToolResult, type McpSession, type McpToolResult } from "../mcp/client.js";
+import { connectToServer } from "../mcp/localServers.js";
+
+export type MessagesHarvestMode = "live" | "export";
+
+export interface ExportedChatMessage {
+  date: string;
+  from_me: boolean;
+  sender: string | null;
+  text: string;
+}
+
+export interface ExportedChat {
+  chat_id: string;
+  display_name: string | null;
+  messages: ExportedChatMessage[];
+}
+
+export interface MessagesExportFile {
+  exported_at: string;
+  handles: string[];
+  total_messages: number;
+  chats: ExportedChat[];
+}
+
+export interface LiveChatSummary {
+  chat_id: string;
+  display_name: string | null;
+  last_message_date: string | null;
+  last_message_text: string | null;
+}
+
+export interface LiveChatMessage {
+  rowid: number;
+  text: string | null;
+  is_from_me: boolean;
+  date: string | null;
+  sender: string | null;
+  service: string | null;
+}
+
+export interface HarvestedChatMessage {
+  messageId: string;
+  date: string;
+  fromMe: boolean;
+  sender: string | null;
+  text: string;
+  service: string | null;
+  chatId: string;
+  displayName: string | null;
+}
+
+export interface HarvestedChat {
+  chatId: string;
+  displayName: string | null;
+  messages: HarvestedChatMessage[];
+}
+
+export interface MessagesHarvestResult {
+  capturedAt: string;
+  sourceMode: MessagesHarvestMode;
+  targetChatIds: string[];
+  exportPath: string | null;
+  chats: HarvestedChat[];
+  errors: string[];
+}
+
+export interface HarvestMessagesOptions {
+  sourceMode?: MessagesHarvestMode;
+  exportPath?: string;
+  targetChatIds?: string[];
+  limitPerChat?: number;
+  env?: Record<string, string>;
+}
+
+interface ToolCaller {
+  callTool(name: string, args?: Record<string, unknown>): Promise<McpToolResult>;
+}
+
+const DEFAULT_TARGET_CHAT_IDS = ["mojosolo@mac.com", "david@mojosolo.com"];
+
+function requireParsedResult<T>(label: string, result: McpToolResult): T {
+  const parsed = parseToolResult<T>(result);
+  if (parsed !== null) {
+    return parsed;
+  }
+
+  throw new Error(`[MessagesSource] Failed to parse ${label}.`);
+}
+
+export function defaultMessagesExportPath(repoRoot: string): string {
+  return join(repoRoot, "messages", "messages-export.json");
+}
+
+export function loadMessagesExport(exportPath: string): MessagesExportFile {
+  return JSON.parse(readFileSync(exportPath, "utf8")) as MessagesExportFile;
+}
+
+export async function listChats(session: ToolCaller, limit = 50): Promise<LiveChatSummary[]> {
+  return requireParsedResult<LiveChatSummary[]>("apple-messages:list_chats", await session.callTool("list_chats", { limit }));
+}
+
+export async function getChatMessages(session: ToolCaller, chatId: string, limit = 100): Promise<LiveChatMessage[]> {
+  return requireParsedResult<LiveChatMessage[]>(
+    `apple-messages:get_chat_messages(${chatId})`,
+    await session.callTool("get_chat_messages", { chat_id: chatId, limit }),
+  );
+}
+
+export function harvestMessagesFromExportFile(
+  file: MessagesExportFile,
+  options: Pick<HarvestMessagesOptions, "targetChatIds" | "limitPerChat"> = {},
+): MessagesHarvestResult {
+  const targetChatIds = options.targetChatIds ?? file.handles ?? DEFAULT_TARGET_CHAT_IDS;
+  const limitPerChat = options.limitPerChat ?? 100;
+
+  const chats = file.chats
+    .filter((chat) => targetChatIds.includes(chat.chat_id))
+    .map((chat) => ({
+      chatId: chat.chat_id,
+      displayName: chat.display_name,
+      messages: chat.messages.slice(0, limitPerChat).map((message, index) => ({
+        messageId: `${chat.chat_id}:${index}:${message.date}`,
+        date: message.date,
+        fromMe: message.from_me,
+        sender: message.sender,
+        text: message.text,
+        service: null,
+        chatId: chat.chat_id,
+        displayName: chat.display_name,
+      })),
+    } satisfies HarvestedChat));
+
+  return {
+    capturedAt: new Date().toISOString(),
+    sourceMode: "export",
+    targetChatIds,
+    exportPath: null,
+    chats,
+    errors: [],
+  };
+}
+
+export async function harvestMessagesFromSession(
+  session: McpSession,
+  options: Pick<HarvestMessagesOptions, "targetChatIds" | "limitPerChat"> = {},
+): Promise<MessagesHarvestResult> {
+  const targetChatIds = options.targetChatIds ?? DEFAULT_TARGET_CHAT_IDS;
+  const limitPerChat = options.limitPerChat ?? 100;
+  const errors: string[] = [];
+  const chatIndex = new Map((await listChats(session, 200)).map((chat) => [chat.chat_id, chat]));
+  const chats: HarvestedChat[] = [];
+
+  for (const chatId of targetChatIds) {
+    try {
+      const summary = chatIndex.get(chatId) ?? null;
+      const messages = await getChatMessages(session, chatId, limitPerChat);
+      chats.push({
+        chatId,
+        displayName: summary?.display_name ?? null,
+        messages: messages.map((message) => ({
+          messageId: String(message.rowid),
+          date: message.date ?? "unknown",
+          fromMe: message.is_from_me,
+          sender: message.sender,
+          text: message.text ?? "",
+          service: message.service,
+          chatId,
+          displayName: summary?.display_name ?? null,
+        })),
+      });
+    } catch (error) {
+      errors.push(`[MessagesSource] Failed to harvest chat ${chatId}: ${(error as Error).message}`);
+    }
+  }
+
+  return {
+    capturedAt: new Date().toISOString(),
+    sourceMode: "live",
+    targetChatIds,
+    exportPath: null,
+    chats,
+    errors,
+  };
+}
+
+export async function harvestMessages(repoRoot: string, options: HarvestMessagesOptions = {}): Promise<MessagesHarvestResult> {
+  const sourceMode = options.sourceMode ?? "export";
+  const targetChatIds = options.targetChatIds ?? DEFAULT_TARGET_CHAT_IDS;
+  const limitPerChat = options.limitPerChat ?? 100;
+
+  if (sourceMode === "export") {
+    const exportPath = options.exportPath ?? defaultMessagesExportPath(repoRoot);
+    const result = harvestMessagesFromExportFile(loadMessagesExport(exportPath), { targetChatIds, limitPerChat });
+    return { ...result, exportPath };
+  }
+
+  const session = await connectToServer("apple-messages", repoRoot, options.env);
+  try {
+    return await harvestMessagesFromSession(session, { targetChatIds, limitPerChat });
+  } finally {
+    await session.close();
+  }
+}

--- a/hydration-pipeline/src/providers/notesSource.ts
+++ b/hydration-pipeline/src/providers/notesSource.ts
@@ -1,0 +1,172 @@
+import { extractText, parseToolResult, type McpSession, type McpToolResult } from "../mcp/client.js";
+import { connectToServer } from "../mcp/localServers.js";
+
+export interface NotesFolder {
+  name: string;
+}
+
+export interface NotesListItem {
+  title: string;
+  id: string;
+  creationDate: string;
+  modificationDate: string;
+}
+
+export interface NotesDetail {
+  title: string;
+  id: string;
+  body: string;
+  creationDate: string;
+  modificationDate: string;
+}
+
+export interface HarvestedNote {
+  folder: string;
+  title: string;
+  id: string;
+  creationDate: string;
+  modificationDate: string;
+  body: string;
+}
+
+export interface SkippedNote {
+  folder: string;
+  title: string;
+  reason: string;
+}
+
+export interface NotesHarvestResult {
+  capturedAt: string;
+  requestedFolders: string[] | null;
+  discoveredFolders: string[];
+  harvestedNotes: HarvestedNote[];
+  skippedNotes: SkippedNote[];
+  errors: string[];
+}
+
+export interface HarvestNotesOptions {
+  folders?: string[];
+  limitPerFolder?: number;
+  env?: Record<string, string>;
+}
+
+interface ToolCaller {
+  callTool(name: string, args?: Record<string, unknown>): Promise<McpToolResult>;
+}
+
+function requireParsedResult<T>(label: string, result: McpToolResult): T {
+  const parsed = parseToolResult<T>(result);
+  if (parsed !== null) {
+    return parsed;
+  }
+
+  throw new Error(`[NotesSource] Failed to parse ${label}. Raw result: ${extractText(result) || "<empty>"}`);
+}
+
+export async function listFolders(session: ToolCaller): Promise<NotesFolder[]> {
+  return requireParsedResult<NotesFolder[]>("apple-notes:list_folders", await session.callTool("list_folders"));
+}
+
+export async function listNotesInFolder(session: ToolCaller, folder: string): Promise<NotesListItem[]> {
+  return requireParsedResult<NotesListItem[]>(
+    `apple-notes:list_notes(${folder})`,
+    await session.callTool("list_notes", { folder }),
+  );
+}
+
+export async function getNote(session: ToolCaller, title: string, folder: string): Promise<NotesDetail> {
+  return requireParsedResult<NotesDetail>(
+    `apple-notes:get_note(${folder}/${title})`,
+    await session.callTool("get_note", { title, folder }),
+  );
+}
+
+function uniqueFolderNames(folders: NotesFolder[]): string[] {
+  return [...new Set(folders.map((folder) => folder.name).filter(Boolean))].sort((left, right) => left.localeCompare(right));
+}
+
+function selectFolders(discoveredFolders: string[], requestedFolders?: string[]): string[] {
+  if (!requestedFolders || requestedFolders.length === 0) {
+    return discoveredFolders;
+  }
+
+  const requested = new Set(requestedFolders);
+  return discoveredFolders.filter((folder) => requested.has(folder));
+}
+
+function groupByTitle(items: NotesListItem[]): Map<string, NotesListItem[]> {
+  const grouped = new Map<string, NotesListItem[]>();
+  for (const item of items) {
+    const bucket = grouped.get(item.title) ?? [];
+    bucket.push(item);
+    grouped.set(item.title, bucket);
+  }
+  return grouped;
+}
+
+export async function harvestNotesFromSession(
+  session: McpSession,
+  options: Omit<HarvestNotesOptions, "env"> = {},
+): Promise<NotesHarvestResult> {
+  const limitPerFolder = options.limitPerFolder ?? 3;
+  const errors: string[] = [];
+  const skippedNotes: SkippedNote[] = [];
+  const harvestedNotes: HarvestedNote[] = [];
+
+  const discoveredFolders = uniqueFolderNames(await listFolders(session));
+  const targetFolders = selectFolders(discoveredFolders, options.folders);
+
+  for (const folder of targetFolders) {
+    try {
+      const listed = await listNotesInFolder(session, folder);
+      const grouped = groupByTitle(listed);
+      const candidates = listed.slice(0, limitPerFolder);
+
+      for (const item of candidates) {
+        const sameTitle = grouped.get(item.title) ?? [];
+        if (sameTitle.length > 1) {
+          skippedNotes.push({
+            folder,
+            title: item.title,
+            reason: "duplicate_title_in_folder",
+          });
+          continue;
+        }
+
+        try {
+          const detail = await getNote(session, item.title, folder);
+          harvestedNotes.push({
+            folder,
+            title: detail.title,
+            id: detail.id,
+            creationDate: detail.creationDate,
+            modificationDate: detail.modificationDate,
+            body: detail.body,
+          });
+        } catch (error) {
+          errors.push(`[NotesSource] Failed to fetch note ${folder}/${item.title}: ${(error as Error).message}`);
+        }
+      }
+    } catch (error) {
+      errors.push(`[NotesSource] Failed to list notes in folder ${folder}: ${(error as Error).message}`);
+    }
+  }
+
+  return {
+    capturedAt: new Date().toISOString(),
+    requestedFolders: options.folders ?? null,
+    discoveredFolders,
+    harvestedNotes,
+    skippedNotes,
+    errors,
+  };
+}
+
+export async function harvestNotes(repoRoot: string, options: HarvestNotesOptions = {}): Promise<NotesHarvestResult> {
+  const session = await connectToServer("apple-notes", repoRoot, options.env);
+  try {
+    return await harvestNotesFromSession(session, options);
+  } finally {
+    await session.close();
+  }
+}

--- a/hydration-pipeline/tsconfig.json
+++ b/hydration-pipeline/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./build",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "build", "tests"]
+}

--- a/knowledge-corpus/README.md
+++ b/knowledge-corpus/README.md
@@ -1,0 +1,93 @@
+# Knowledge Corpus MCP Server
+
+An MCP server that exposes a bundled structured knowledge corpus and companion research report.
+
+The package now defaults to the MojoSolo operating brain and also includes a Laravel projection layer so the same corpus can drive an application backend.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `get_corpus_overview` | Return corpus metadata, available sections, source counts, and report availability |
+| `list_corpus_sections` | List the top-level corpus sections with lightweight summaries |
+| `get_corpus_section` | Return a full top-level corpus section by name |
+| `get_mail_intelligence_config` | Return the mail-intelligence config embedded in the canonical brain |
+| `search_corpus` | Search the structured corpus, the bundled report, or both |
+| `get_laravel_brain_blueprint` | Return Laravel tables, routes, and seed data derived from the brain |
+| `export_laravel_brain_pack` | Write a Laravel integration pack to a target directory |
+| `list_sources` | List all `source_registry` entries with ids, URLs, and trust levels |
+| `get_source` | Return a single `source_registry` entry by id |
+| `list_report_sections` | List the sections available in the bundled markdown report |
+| `get_report_section` | Return one bundled markdown report section by title or slug |
+
+## Requirements
+
+- Node.js 18+
+
+## Quick Start
+
+```bash
+cd knowledge-corpus
+npm install
+npm run build
+node build/index.js
+```
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "knowledge-corpus": {
+      "command": "node",
+      "args": ["/absolute/path/to/apple-mcp/knowledge-corpus/build/index.js"]
+    }
+  }
+}
+```
+
+### Claude Code
+
+```bash
+claude mcp add knowledge-corpus -- node /absolute/path/to/apple-mcp/knowledge-corpus/build/index.js
+```
+
+## Custom Corpus Files
+
+By default, the server reads the bundled files in `knowledge-corpus/data/`.
+
+You can point the server at a different structured corpus and markdown report:
+
+```bash
+KNOWLEDGE_CORPUS_PATH=/absolute/path/to/corpus.yaml \
+KNOWLEDGE_REPORT_PATH=/absolute/path/to/report.md \
+node build/index.js
+```
+
+- `KNOWLEDGE_CORPUS_PATH` supports `.yaml`, `.yml`, and `.json` structured corpora.
+- `KNOWLEDGE_REPORT_PATH` is optional. If omitted, report tools use the bundled markdown file when present.
+
+## Laravel Export
+
+Export a Laravel-ready brain pack:
+
+```bash
+cd knowledge-corpus
+npm install
+npm run export:laravel -- /absolute/path/to/laravel-app
+```
+
+The export writes:
+
+- `config/brain.php`
+- `database/migrations/2026_03_12_000000_create_brain_tables.php`
+- `database/seeders/BrainSeeder.php`
+- `app/Http/Controllers/BrainController.php`
+- `routes/brain.php`
+
+## Example Queries
+
+- "Show me the persona_architecture section"
+- "Show me the mail-intelligence config"
+- "Give me the Laravel brain blueprint"
+- "Export the Laravel brain pack into my app"

--- a/knowledge-corpus/data/aaru_product_knowledge_corpus.yaml
+++ b/knowledge-corpus/data/aaru_product_knowledge_corpus.yaml
@@ -1,0 +1,925 @@
+schema:
+  name: aaru_product_knowledge_corpus
+  version: 1.0.0
+  generated_on: '2026-03-12'
+  target_company: Aaru
+  target_domain: https://aaru.com
+  capture_scope: public_web_materials_only
+  authoring_profile:
+    deterministic_structure_ratio: 0.986
+    human_irrationality_ratio: 0.014
+    note: This ratio is a user-requested authoring profile for the corpus shape. It is not asserted as an Aaru product parameter.
+  completeness_status: high_coverage_public_web_corpus_not_private_internal_complete
+  limitations:
+  - No public API reference, developer documentation, pricing sheet, security whitepaper, model card, or architecture whitepaper
+    was found in the reviewed public materials.
+  - The corpus is restricted to publicly accessible web sources reviewed on the generation date; non-indexed, customer-only,
+    or internal materials may exist and are outside scope.
+  - Where public materials were silent, values are set to null or described as unknown rather than inferred beyond evidence.
+  epistemic_status_legend:
+    explicit_claim: Directly stated in reviewed source material.
+    external_partner_claim: Stated by a partner, validation study, or public press release about Aaru.
+    structured_inference: Derived conservatively by combining explicit public signals.
+    unknown: Not established in reviewed public materials.
+source_registry:
+- id: src_aaru_home
+  title: Aaru — Rethinking the science of prediction
+  organization: Aaru
+  url: https://aaru.com/
+  source_class: official_site
+  role_in_corpus: primary_product_positioning
+  trust_level: high
+- id: src_aaru_products
+  title: Aaru Products
+  organization: Aaru
+  url: https://aaru.com/products
+  source_class: official_site
+  role_in_corpus: product_portfolio
+  trust_level: high
+- id: src_aaru_about
+  title: About — Aaru
+  organization: Aaru
+  url: https://aaru.com/about
+  source_class: official_site
+  role_in_corpus: ethos_founders_company_claims
+  trust_level: high
+- id: src_aaru_contact
+  title: Contact — Aaru
+  organization: Aaru
+  url: https://aaru.com/contact
+  source_class: official_site
+  role_in_corpus: contact_and_demo_flow
+  trust_level: high
+- id: src_aaru_privacy
+  title: Privacy Policy — Aaru
+  organization: Aaru
+  url: https://aaru.com/policies/privacy
+  source_class: official_policy
+  role_in_corpus: privacy_governance
+  trust_level: high
+- id: src_aaru_cookies
+  title: Cookie Policy — Aaru
+  organization: Aaru
+  url: https://aaru.com/policies/cookies
+  source_class: official_policy
+  role_in_corpus: cookie_governance
+  trust_level: high
+- id: src_aaru_dpa
+  title: Data Processing Agreement — Aaru
+  organization: Aaru
+  url: https://aaru.com/policies/data-processing
+  source_class: official_policy
+  role_in_corpus: data_processing_governance
+  trust_level: high
+- id: src_aaru_careers_software_engineer
+  title: Software Engineer — Aaru
+  organization: Aaru
+  url: https://aaru.com/careers/software-engineer
+  source_class: official_careers
+  role_in_corpus: stack_and_product_surface_signals
+  trust_level: high
+- id: src_aaru_careers_platform
+  title: Software Engineer, Platform — Aaru
+  organization: Aaru
+  url: https://aaru.com/careers/207a61bf-084c-403c-b60a-5c8efda4f83c
+  source_class: official_careers
+  role_in_corpus: platform_scope_signals
+  trust_level: high
+- id: src_aaru_careers_infrastructure
+  title: Software Engineer, Infrastructure — Aaru
+  organization: Aaru
+  url: https://aaru.com/careers/48fffbe2-f5e9-4c48-a686-11a829955884
+  source_class: official_careers
+  role_in_corpus: infrastructure_scope_signals
+  trust_level: high
+- id: src_aaru_careers_forecasting
+  title: Research Lead, Forecasting — Aaru
+  organization: Aaru
+  url: https://aaru.com/careers/f718d12f-67e9-4fe9-91cc-9e3b69ff00fe
+  source_class: official_careers
+  role_in_corpus: forecasting_method_signals
+  trust_level: high
+- id: src_aaru_careers_individuals
+  title: Research Lead, Individuals — Aaru
+  organization: Aaru
+  url: https://aaru.com/careers/877146b7-41a1-4ba9-b5b5-76d5abc7a21c
+  source_class: official_careers
+  role_in_corpus: individual_modeling_method_signals
+  trust_level: high
+- id: src_aaru_careers_organizations
+  title: Research Lead, Organizations — Aaru
+  organization: Aaru
+  url: https://aaru.com/careers/d2fb9f74-4e97-47e0-ad4f-dc64bfe5ee99
+  source_class: official_careers
+  role_in_corpus: organizational_modeling_method_signals
+  trust_level: high
+- id: src_aaru_careers_fde
+  title: Forward Deployed Engineer, Simulations — Aaru
+  organization: Aaru
+  url: https://aaru.com/careers/41936e87-4707-4a10-84a1-8a213fd206be
+  source_class: official_careers
+  role_in_corpus: client_integration_signals
+  trust_level: high
+- id: src_aaru_careers_deployment
+  title: Deployment Manager / Deployment Lead — Aaru
+  organization: Aaru
+  url: https://aaru.com/careers/807d62c0-7bc4-453c-9a60-d6e35b65c993
+  source_class: official_careers
+  role_in_corpus: delivery_model_signals
+  trust_level: high
+- id: src_aaru_careers_channel
+  title: Deployment Manager, Channel — Aaru
+  organization: Aaru
+  url: https://aaru.com/careers/1fab9358-f236-4bcc-aa9f-f7639d6e6426
+  source_class: official_careers
+  role_in_corpus: advisory_channel_signals
+  trust_level: high
+- id: src_aaru_careers_designer
+  title: Product Designer — Aaru
+  organization: Aaru
+  url: https://aaru.com/careers/designer
+  source_class: official_careers
+  role_in_corpus: ux_visualization_signals
+  trust_level: high
+- id: src_ey_validation
+  title: Wealth and asset management AI simulation with Aaru | EY
+  organization: EY
+  url: https://www.ey.com/en_us/insights/wealth-asset-management/how-ai-simulation-accelerates-growth-in-wealth-and-asset-management
+  source_class: official_partner_or_validation
+  role_in_corpus: external_validation_methodology_and_results
+  trust_level: high
+- id: src_accenture_investment
+  title: Accenture Invests in and Collaborates with AI-Powered Agentic Prediction Engine Aaru
+  organization: Accenture
+  url: https://newsroom.accenture.com/news/2025/accenture-invests-in-and-collaborates-with-ai-powered-agentic-prediction-engine-aaru
+  source_class: official_partner_or_investor
+  role_in_corpus: partnership_and_positioning_validation
+  trust_level: high
+- id: src_interpublic_partnership
+  title: Interpublic Partners with Aaru to Leverage AI-Powered Predictive Simulations to Accelerate, Scale and Optimize Marketing
+  organization: Interpublic Group
+  url: https://www.globenewswire.com/news-release/2025/08/11/3130751/0/en/interpublic-partners-with-aaru-to-leverage-ai-powered-predictive-simulations-to-accelerate-scale-and-optimize-marketing.html
+  source_class: official_partner_press_release
+  role_in_corpus: marketing_use_case_validation
+  trust_level: high
+- id: src_heartland_poll
+  title: Heartland Forward Releases First-of-its-Kind Poll on AI Sentiment Across the Heartland
+  organization: Heartland Forward
+  url: https://heartlandforward.org/news/press-release-heartland-forward-releases-first-of-its-kind-poll-on-ai-sentiment-across-the-heartland/
+  source_class: official_partner_or_customer_press_release
+  role_in_corpus: public_methodology_example
+  trust_level: medium_high
+epistemic_contract:
+  public_web_only: true
+  unknown_value_policy: explicit_null_or_explicit_unknown_string
+  self_claims_are_not_auto_validated: true
+  external_partner_claims_are_not_treated_as_internal_architecture_proof: true
+  absence_of_public_evidence_is_not_evidence_of_absence: true
+  review_goal: maximize public-source coverage while minimizing unsupported inference
+canonical_profile:
+  evidence_source_ids:
+  - src_aaru_home
+  - src_aaru_products
+  - src_aaru_about
+  - src_aaru_contact
+  - src_aaru_careers_fde
+  - src_aaru_careers_channel
+  - src_accenture_investment
+  status: mixed_explicit_and_structured_inference
+  brand_name: Aaru
+  legal_name: Aaru Inc.
+  website: https://aaru.com
+  company_frame:
+    value:
+    - predictive_intelligence_company
+    - multi_agent_simulation_software_company
+    - behavioral_modeling_and_applied_ai_company
+    status: explicit_claim
+  public_positioning_summary: Aaru presents itself as a predictive intelligence company that simulates individuals, groups,
+    organizations, and entire populations with multi-agent AI so operators can test decisions before acting.
+  customer_domain_segments:
+  - business_private_sector
+  - government_public_sector
+  - politics
+  go_to_market_motion:
+    value:
+    - request_demo_contact_led_sales
+    - direct_client_deployment
+    - channel_or_advisory_partnerships
+    - forward_deployed_engineering
+    status: mixed_explicit_and_structured_inference
+  public_access_model:
+    request_demo_or_contact_entrypoint_found: true
+    public_pricing_found_in_review_scope: false
+    pricing_status_note: No public pricing page was found in the reviewed materials.
+    public_self_serve_documentation_found_in_review_scope: false
+    absence_interpretation_rule: Fields ending in _found_in_review_scope describe only what was found during the reviewed
+      public-web pass.
+  contact:
+    general_inquiries_email: inquiries@aaru.com
+    jobs_email: jobs@aaru.com
+    contact_flow_fields:
+    - first_name
+    - last_name
+    - business_email
+    - job_title
+    - organization
+    - project_message
+  operating_location_public_signal:
+    value: New York City, New York, USA
+    status: structured_inference
+    confidence: medium
+    basis: Multiple open roles are explicitly based in New York City and describe Aaru as an in-person company there.
+    hq_confirmed: false
+  founders:
+  - name: Ned Koh
+    role: Co-Founder & President
+    status: explicit_claim
+  - name: Cam Fink
+    role: Co-Founder & CEO
+    status: explicit_claim
+  - name: John Kessler
+    role: Co-Founder & CTO
+    status: explicit_claim
+positioning_and_messaging:
+  evidence_source_ids:
+  - src_aaru_home
+  - src_aaru_products
+  - src_aaru_about
+  - src_accenture_investment
+  status: explicit_claim
+  primary_short_phrases:
+  - Rendering human granularity.
+  - Simulate any decision.
+  - decision dominance
+  - Working toward a more certain future
+  value_proposition_summary:
+  - Replace or augment slow, bias-prone research with simulation-driven foresight.
+  - Model populations that are hard to reach directly.
+  - Test futures that do not yet exist in the real world.
+  - Deliver outputs that connect predicted behavior to operational decisions.
+  claimed_differentiators:
+  - Aaru argues that humans misreport future behavior because memory, incentives, and social pressure distort answers.
+  - Aaru positions simulation as a way to represent difficult-to-reach populations at scale.
+  - Aaru claims to operate across industries and use cases, adapting outputs to the operator and problem.
+  - Aaru and partners frame the system as faster than surveys, focus groups, and conventional research experiments.
+  claimed_outcomes:
+  - analysis
+  - segmentation
+  - strategic pathways
+  - predictions
+  - decision-ready outputs
+  replacement_or_complement_targets:
+  - surveys
+  - focus_groups
+  - traditional_market_research
+  - research_experiments
+  - retrospective_only_decisioning
+philosophy_and_theory_of_operation:
+  evidence_source_ids:
+  - src_aaru_home
+  - src_aaru_about
+  status: explicit_claim
+  ethos:
+    name: transactionalism
+    aaru_definition: Aaru says its multi-agent approach is rooted in the belief that value is created through dynamic interactions
+      among multiple parties.
+  core_beliefs:
+  - belief: Humans are unreliable narrators of their own behavior.
+    status: explicit_claim
+  - belief: The most valuable populations to understand are often the hardest to access.
+    status: explicit_claim
+  - belief: The future cannot be surveyed directly because many high-value decisions concern conditions that do not yet exist.
+    status: explicit_claim
+  - belief: Prediction is only useful if it closes the gap between data and action for the operator.
+    status: explicit_claim
+  - belief: Whole-world simulation is the long-horizon ambition toward which Aaru sees its products as incremental pieces.
+    status: explicit_claim
+  human_behavior_assumptions:
+  - memory_can_fail
+  - incentives_can_distort_answers
+  - social_pressure_can_warp_self_reported_responses
+  - stated_preference_and_real_behavior_can_diverge
+  operator_logic:
+    statement: Every Aaru system is described as connecting predicted behavior to the decision it informs so users act on
+      evidence rather than instinct.
+    status: explicit_claim
+  philosophical_motifs:
+  - simulation_as_measurement
+  - whole_world_simulation
+  - decision_dominance
+  - certainty_through_behavioral_modeling
+claim_calibration:
+  evidence_source_ids:
+  - src_aaru_home
+  - src_aaru_about
+  - src_ey_validation
+  - src_accenture_investment
+  - src_interpublic_partnership
+  externally_supported_claims:
+  - Aaru participated in an EY validation exercise that recreated a major wealth management study in one day and achieved
+    a median Spearman correlation of 0.90 across 53 matched single-select questions.
+  - Accenture Ventures invested in Aaru and Accenture Song said it intends to integrate Lumen into AI products and services.
+  - Interpublic publicly announced a strategic partnership with Aaru for predictive simulations in marketing workflows.
+  self_descriptions_requiring_caution:
+  - unprecedented_accuracy
+  - predict_the_worlds_events
+  - more_accurate_than_any_survey_or_traditional_research
+  - used_to_win_wars
+  non_claims:
+  - No public material reviewed establishes that Aaru guarantees future outcomes.
+  - No public material reviewed establishes universal superiority over all research methods in all contexts.
+  - EY explicitly noted that future behavior is inherently uncertain and that AI simulation does not guarantee what people
+    will do.
+domain_model:
+  evidence_source_ids:
+  - src_aaru_home
+  - src_aaru_products
+  - src_aaru_about
+  - src_aaru_careers_individuals
+  - src_aaru_careers_organizations
+  - src_aaru_careers_forecasting
+  - src_heartland_poll
+  - src_ey_validation
+  status: mixed_explicit_and_structured_inference
+  modeled_entity_classes:
+  - individual
+  - small_group
+  - organization
+  - institution
+  - stakeholder
+  - audience
+  - citizen
+  - electorate
+  - customer
+  - population
+  decision_object_classes:
+  - product
+  - policy
+  - campaign
+  - communication
+  - crisis_response
+  - regulatory_shift
+  - program_design
+  - infrastructure_rollout
+  - election
+  - narrative
+  - price_change
+  - market_strategy
+  modeling_concepts:
+  - agent
+  - synthetic_or_simulated_population
+  - behavioral_architecture
+  - signal
+  - belief_system
+  - distribution
+  - hypothetical
+  - scenario
+  - environment
+  - structured_prediction_input
+  - outcome
+  - analysis
+  - segment
+  - strategic_pathway
+  canonical_relations:
+  - operator_defines_decision_problem
+  - decision_problem_targets_population_or_actor_class
+  - signals_are_ingested_and_structured
+  - agents_are_constructed_or_orchestrated_to_mirror_relevant_human_behavior
+  - agents_interact_with_simulated_environments_and_hypotheticals
+  - simulation_generates_predicted_outcomes
+  - predicted_outcomes_are_transformed_into_operator_facing_analysis
+simulation_pipeline:
+  evidence_source_ids:
+  - src_aaru_home
+  - src_aaru_careers_forecasting
+  - src_aaru_careers_individuals
+  - src_aaru_careers_organizations
+  - src_aaru_careers_infrastructure
+  - src_ey_validation
+  - src_accenture_investment
+  - src_heartland_poll
+  - src_interpublic_partnership
+  status: mixed_explicit_and_external_partner_claim
+  input_signal_families:
+  - family: demographic
+    status: external_partner_claim
+  - family: behavioral
+    status: external_partner_claim
+  - family: sentiment
+    status: external_partner_claim
+  - family: organizational_behavior
+    status: explicit_claim
+  - family: individual_specific_signals
+    status: explicit_claim
+  - family: real_world_event_signals
+    status: explicit_claim
+  - family: public_data_sources
+    status: external_partner_claim
+  - family: proprietary_data_sources
+    status: external_partner_claim
+  - family: licensed_data
+    status: external_partner_claim
+  - family: recent_news_and_social_media_context
+    status: external_partner_claim
+  ingestion_and_representation:
+  - Aaru hiring materials describe ingestion of heterogeneous real-world signals into structured prediction inputs.
+  - Aaru hiring materials describe ingesting heterogeneous signals about specific individuals and organizations.
+  - Aaru marketing materials describe linking raw distributions and mapping belief systems.
+  - Infrastructure roles indicate complex data ingestion pipelines from diverse sources.
+  modeling_primitives:
+  - multi_agent_infrastructure
+  - agents_that_mirror_humans
+  - behavioral_architectures
+  - simulated_environments
+  - scenario_permutations
+  - hypotheticals
+  reasoning_and_methods:
+    language_model_roles:
+    - signal_extraction
+    - reasoning
+    - behavioral_simulation
+    classical_method_families:
+    - forecasting
+    - predictive_modeling
+    - discrete_event_prediction
+    - time_series
+    - decision_theory
+    - behavioral_science
+    - psychometrics
+    - organizational_theory
+    - institutional_analysis
+    tractability_note: The Individuals research role explicitly mentions bounding open-ended outcome spaces into tractable
+      prediction problems.
+  execution_patterns:
+  - simulate_entire_populations
+  - run_many_permutations_or_scenarios
+  - support_prelaunch_testing
+  - support_postlaunch_optimization
+  - forecast_real_world_events
+  - recreate_large_research_studies_quickly
+  output_artifacts:
+  - predictions
+  - analysis
+  - segmentation
+  - strategic_pathways
+  - campaign_performance_estimates
+  - optimization_guidance
+  - tailored_client_analyses
+  - data_visualizations_and_charts
+  - reports
+  speed_claims:
+    minutes:
+      statement: Accenture described Aaru as delivering predictions of behavior in a matter of minutes.
+      status: external_partner_claim
+    one_day_validation_case:
+      statement: EY reported that an Aaru simulation recreated a large wealth management survey in one day instead of six
+        months.
+      status: external_partner_claim
+  publicly_unknown_pipeline_details:
+  - exact_agent_memory_design
+  - exact_model_provider_or_base_models
+  - training_data_composition_by_source
+  - orchestration_framework_details
+  - scoring_and_calibration_pipeline_details
+  - tenant_isolation_implementation_details
+product_portfolio:
+  evidence_source_ids:
+  - src_aaru_products
+  - src_accenture_investment
+  - src_interpublic_partnership
+  status: mixed_explicit_and_external_partner_claim
+  shared_portfolio_principle: Aaru says each system is purpose-built for a decision domain and connects predicted behavior
+    to the decision it informs.
+  products:
+  - name: Lumen
+    sector: business_private_sector
+    portfolio_role:
+      value: flagship_model_for_the_private_sector
+      status: external_partner_claim
+    core_purpose: Pressure-test business strategies, optimize campaigns, and forecast market reactions before committing capital.
+    use_case_taxonomy:
+    - creative_and_message_evaluation
+    - product_launch_planning
+    - pricing_strategy
+    - market_segmentation
+    - value_proposition_testing
+    - churn_prediction
+    - campaign_strategy
+    - competitive_positioning
+    - brand_perception_tracking
+    notable_external_signals:
+    - Accenture Song said it intends to integrate Lumen into AI products and services for product development, marketing,
+      customer strategy, and customer service.
+  - name: Seraph
+    sector: government_public_sector
+    portfolio_role:
+      value: government_system
+      status: explicit_claim
+    core_purpose: Evaluate how citizens, institutions, and stakeholders may respond to policy initiatives, crises, and communications
+      before deployment.
+    use_case_taxonomy:
+    - public_communication
+    - crisis_response
+    - regulatory_shift_analysis
+    - policy_sequencing
+    - program_design
+    - stakeholder_sentiment_modeling
+    - unreachable_population_modeling
+    - infrastructure_rollout_planning
+    notable_external_signals:
+    - Heartland Forward described a poll conducted by Aaru using AI-powered simulations and digital environments built from
+      recent news and social media.
+  - name: Dynamo
+    sector: politics
+    portfolio_role:
+      value: political_system
+      status: explicit_claim
+    core_purpose: Model how events and narratives affect sentiment, preference, and turnout across the electorate.
+    use_case_taxonomy:
+    - election_forecasting
+    - turnout_modeling
+    - message_testing
+    - opposition_scenario_planning
+    - endorsement_impact
+    - donor_sentiment
+    - ground_game_strategy
+    - narrative_tracking
+    notable_external_signals:
+    - Aaru says its work is used to select candidates for office.
+canonical_problem_templates:
+  evidence_source_ids:
+  - src_aaru_home
+  status: structured_inference
+  note: These are normalized templates derived from official example questions; they are paraphrased rather than quoted verbatim.
+  templates:
+  - domain: business_private_sector
+    template: Estimate customer choice shifts under a product price increase or pricing bundle change.
+  - domain: business_private_sector
+    template: Predict click-through or engagement response to alternative marketing messages before launch.
+  - domain: business_private_sector
+    template: Estimate adoption pressure and social influence effects around a product category.
+  - domain: politics
+    template: Estimate how much information a voter needs to feel confident about a lower-ballot candidate.
+  - domain: politics
+    template: Estimate support movement after a prominent endorsement in a district or race.
+  - domain: politics
+    template: Simulate likely vote choice if an election were held under current conditions.
+  - domain: government_public_sector
+    template: Compare evacuation communication strategies by income level and language group during a disaster.
+  - domain: government_public_sector
+    template: Estimate adoption of a public digital identity program among older rural citizens.
+operating_model_and_delivery:
+  evidence_source_ids:
+  - src_aaru_contact
+  - src_aaru_careers_deployment
+  - src_aaru_careers_channel
+  - src_aaru_careers_fde
+  - src_aaru_careers_designer
+  - src_interpublic_partnership
+  - src_accenture_investment
+  status: mixed_explicit_and_structured_inference
+  engagement_channels:
+  - direct_request_demo
+  - direct_client_delivery
+  - advisory_channel_delivery
+  - forward_deployed_integration
+  delivery_modes:
+  - tailored_analyses
+  - simulation_driven_insights
+  - custom_products
+  - custom_integrations
+  - custom_workflows
+  - reports
+  - data_visualizations
+  primary_user_or_buyer_personas:
+  - senior_client_stakeholder
+  - enterprise_technical_leader
+  - advisory_partner
+  - government_operator
+  - campaign_operator
+  - creative_and_strategy_team
+  technical_integration_signals:
+  - python
+  - sql
+  - rest_apis
+  - cloud_platforms
+  - data_pipelines
+  - complex_enterprise_environments
+  - government_environments
+  platform_surface_signals:
+  - Aaru has a simulation platform with user experiences and interfaces designed to show insights, predictions, outcomes,
+    and charts.
+  - The Platform team is described as building the foundation the rest of the product sits on and writing framework-level
+    code that absorbs complexity for users and agents.
+  channel_model_signals:
+  - Aaru has a channel deployment motion built to make the company indispensable to advisory partners and reach clients through
+    advisory networks.
+internal_capability_map:
+  evidence_source_ids:
+  - src_aaru_about
+  - src_aaru_careers_forecasting
+  - src_aaru_careers_individuals
+  - src_aaru_careers_organizations
+  - src_aaru_careers_platform
+  - src_aaru_careers_infrastructure
+  - src_aaru_careers_fde
+  - src_aaru_careers_deployment
+  - src_aaru_careers_channel
+  status: structured_inference_from_roles
+  research_tracks:
+  - name: forecasting
+    scope: forecast real-world events across domains
+  - name: individuals
+    scope: model how specific people and small groups make decisions
+  - name: organizations
+    scope: model how organizations behave and make decisions
+  engineering_tracks:
+  - name: platform
+    scope: build the product foundation and user/agent-facing abstractions
+  - name: infrastructure
+    scope: scale compute, reliability, data ingestion, and long-running pipelines
+  - name: solutions_or_forward_deployed
+    scope: embed Aaru technology in complex client environments through custom products and integrations
+  commercial_and_delivery_tracks:
+  - name: deployment
+    scope: configure analyses and deliver simulation-driven insights to senior stakeholders
+  - name: channel_deployment
+    scope: serve advisory partners and their client networks
+technical_stack_signals_from_public_hiring:
+  evidence_source_ids:
+  - src_aaru_careers_software_engineer
+  - src_aaru_careers_platform
+  - src_aaru_careers_infrastructure
+  - src_aaru_careers_fde
+  - src_aaru_careers_designer
+  status: structured_inference_from_hiring_signals
+  interpretation_rule: These are public hiring signals and should be treated as technology indicators rather than guaranteed
+    exhaustive architecture facts.
+  application_stack_signals:
+    languages:
+    - Python
+    - JavaScript
+    - TypeScript
+    frontend:
+    - React
+    backend:
+    - Node.js
+    - FastAPI
+    api_style:
+    - RESTful APIs
+    data_layer_signals:
+    - databases_for_storage_and_retrieval
+  engineering_system_signals:
+  - deployment_pipelines
+  - unit_tests
+  - integration_tests
+  - high_performance_low_latency_infrastructure
+  - complex_data_ingestion_pipelines
+  - reliability_optimization
+  - cloud_primitives
+  - networking_protocol_awareness_http_tls
+  - transition_of_research_experiments_into_production_pipelines
+  - framework_level_code_for_users_and_agents
+  - long_running_computational_pipeline_bottleneck_elimination
+  research_engineering_signals:
+  - simulation_model_optimization
+  - experiment_design
+  - result_analysis
+  - accuracy_speed_consistency_improvement
+  - external_research_publication
+  publicly_unknown_stack_details:
+  - cloud_vendor
+  - gpu_or_accelerator_vendor
+  - container_or_orchestrator_choice
+  - database_brands
+  - vector_database_usage
+  - exact_model_provider
+  - on_premises_deployment_support
+  - multi_tenant_design
+  - sla_and_uptime_commitments
+governance_privacy_and_security:
+  evidence_source_ids:
+  - src_aaru_privacy
+  - src_aaru_cookies
+  - src_aaru_dpa
+  - src_interpublic_partnership
+  status: mixed_explicit_and_external_partner_claim
+  policy_dates:
+    privacy_policy_effective_date: '2025-04-24'
+    privacy_policy_last_updated: '2025-04-24'
+    cookie_policy_effective_date: '2024-04-24'
+    dpa_effective_date: '2025-04-24'
+  data_collection_categories:
+    personal_information:
+    - name
+    - email_address
+    - phone_number
+    - postal_address
+    - payment_information
+    - account_credentials
+    non_personal_information:
+    - browser_type
+    - ip_address
+    - device_identifiers
+    - pages_visited
+    - time_and_date_of_access
+    - referring_url
+  processing_purposes:
+  - provide_and_maintain_services
+  - process_transactions
+  - respond_to_inquiries_and_support
+  - personalize_and_improve_experience
+  - send_marketing_if_opted_in
+  - comply_with_legal_obligations
+  - detect_and_prevent_fraud_and_abuse
+  sharing_and_sale:
+    shared_with:
+    - service_providers_and_vendors
+    - affiliates_within_corporate_group
+    - law_enforcement_or_regulators_when_required
+    - parties_to_business_transfers
+    sells_personal_information: false
+  user_rights:
+  - access
+  - correction
+  - deletion
+  - restriction_or_objection
+  - data_portability
+  - withdraw_consent
+  security_statement: Aaru says it implements appropriate technical and organizational measures, while noting that no internet
+    transmission method is completely secure.
+  children_policy: Services are not directed to children under 13, or 16 where applicable.
+  cookie_categories:
+  - essential
+  - performance_and_functionality
+  - analytics_and_customization
+  - advertising
+  dpa_controls:
+  - processor_acts_on_documented_controller_instructions
+  - confidentiality_and_personnel_training
+  - technical_and_organizational_security_measures
+  - assistance_with_data_subject_requests
+  - breach_notification_without_undue_delay
+  - cooperation_with_supervisory_authorities
+  - records_of_processing_activities
+  - subprocessor_written_consent_requirement
+  - equivalent_subprocessor_obligations
+  - chapter_v_gdpr_transfer_safeguards
+  - return_or_deletion_on_termination
+  - audit_rights_for_controller
+  ethics_and_training_data_signal:
+    statement: Interpublic said Aaru maintains an ethics-first approach to responsible research and language model building
+      and exclusively trains its models on licensed data.
+    status: external_partner_claim
+  not_found_in_review_scope:
+  - public_subprocessor_list
+  - soc_2_report
+  - iso_27001_claim
+  - public_security_whitepaper
+  - public_penetration_test_summary
+  - public_data_residency_matrix
+  - granular_retention_schedule_by_data_type
+validation_and_external_evidence:
+  evidence_source_ids:
+  - src_ey_validation
+  - src_accenture_investment
+  - src_interpublic_partnership
+  - src_heartland_poll
+  - src_aaru_about
+  status: external_partner_claim_plus_self_claims
+  ey_validation_case:
+    date_signal: August 2025 partnership; article published 2025
+    summary: EY said it used Aaru's proprietary multi-agent infrastructure to recreate its Global Wealth Management Survey
+      in one day instead of six months.
+    study_scope:
+      markets: 30_plus
+      respondents_in_original_study: 3600
+      matched_single_select_questions: 53
+    reported_result_metrics:
+      median_spearman_correlation: 0.9
+      average_rmse_percentage_points: 7.1
+      average_euclidean_distance: 12.9
+    methodology_signals:
+    - real_world_datasets_including_demographic_behavioral_and_sentiment_data
+    - sources_included_national_censuses_financial_institutions_and_social_media
+    - agents_used_behavioral_architectures_modeling_decision_making_traits
+    - agents_interacted_with_simulated_environments
+    - thousands_of_strategic_scenarios_were_tested
+    important_caveat: EY explicitly said AI simulation cannot guarantee what people will do because future behavior is inherently
+      uncertain.
+  accenture_collaboration:
+    announcement_date: '2025-03-04'
+    facts:
+    - Accenture Ventures invested in Aaru.
+    - Accenture Song said it intends to integrate Lumen into AI products and services.
+    - Baiju Shah was announced as a strategic advisor to Aaru.
+    - Accenture described Aaru as simulating any customer audience to deliver predictions of behavior in minutes.
+  interpublic_partnership:
+    announcement_date: '2025-08-11'
+    facts:
+    - Interpublic announced a strategic partnership with Aaru for predictive simulations in marketing.
+    - Interpublic said Aaru would support audience sentiment forecasting for creative testing, live activations, influencer
+      marketing, corporate communications, and earned media.
+    - Interpublic said Aaru had already been used in financial services, healthcare, and CPG engagements.
+    - Interpublic said Aaru would be incorporated into campaign design modules within Interact.
+    - Interpublic said Aaru uses an ethics-first approach and licensed training data.
+  heartland_forward_poll_example:
+    announcement_date: '2024-08-28'
+    facts:
+    - Heartland Forward said its AI poll was conducted by Aaru.
+    - The release said Aaru recreated digital environments with recent news and social media and populated them with AI-generated
+      respondents reflecting real human profiles.
+    - The release said the survey included a minimum of 500 respondents per state and respondents were age 15 and older.
+  self_reported_real_world_applications:
+  - select_candidates_for_office
+  - test_movie_trailers
+  - trade_futures
+  - win_wars
+risk_and_limit_statements:
+  evidence_source_ids:
+  - src_ey_validation
+  - src_aaru_home
+  - src_aaru_about
+  status: mixed_explicit_and_external_partner_claim
+  core_limit: Aaru's public story is strongest on positioning and selected validation cases; the detailed internal mechanics
+    remain only partially public.
+  prediction_limit: Future behavior remains uncertain; public sources do not support any interpretation of Aaru as a guaranteed
+    oracle.
+  marketing_claim_limit: Public self-descriptions include bold language about accuracy and impact that should be treated as
+    marketing claims unless separately validated.
+  completeness_limit: No public evidence reviewed provides a full end-to-end specification of training data lineage, model
+    architecture, deployment topology, or evaluation protocol outside the cited examples.
+known_unknowns_and_nonclaims:
+  status: unknown
+  items:
+  - exact_model_architecture
+  - exact_agent_memory_or_state_management_approach
+  - specific_base_model_or_model_provider
+  - rlhf_or_fine_tuning_strategy
+  - customer_tenancy_model
+  - self_serve_product_availability
+  - public_api_contract
+  - sdk_languages
+  - pricing_model
+  - contract_terms
+  - service_level_agreements
+  - public_compliance_certifications
+  - detailed_subprocessor_inventory
+  - data_residency_options
+  - on_prem_or_air_gapped_deployment_support
+  - formal_model_cards
+  - formal_bias_audit_reports
+machine_ingest_index:
+  entity_names:
+  - Aaru
+  - Lumen
+  - Seraph
+  - Dynamo
+  - Ned Koh
+  - Cam Fink
+  - John Kessler
+  domain_tags:
+  - predictive_intelligence
+  - multi_agent_simulation
+  - behavioral_modeling
+  - applied_ai
+  - market_research
+  - forecasting
+  - government_decision_support
+  - political_modeling
+  - marketing_simulation
+  method_tags:
+  - language_models
+  - agents
+  - hybrid_modeling
+  - forecasting
+  - decision_theory
+  - behavioral_science
+  - psychometrics
+  - organizational_theory
+  - institutional_analysis
+  input_tags:
+  - demographic_data
+  - behavioral_data
+  - sentiment_data
+  - news_context
+  - social_media_context
+  - proprietary_data
+  - public_data
+  - licensed_data
+  output_tags:
+  - predictions
+  - analysis
+  - segmentation
+  - strategic_pathways
+  - campaign_guidance
+  - scenario_evaluation
+  - visualization
+  - reporting
+  commercial_tags:
+  - enterprise
+  - government
+  - advisory_channel
+  - forward_deployed
+  - demo_led_sales

--- a/knowledge-corpus/data/deep-research-report.md
+++ b/knowledge-corpus/data/deep-research-report.md
@@ -1,0 +1,460 @@
+# Building a Logic–Philosophy Corpus for Product Knowledge
+
+## Executive summary
+
+A full technical “logic–philosophy corpus of product knowledge” is a **versioned, machine-checkable body of product knowledge** that (a) defines a shared **ontology/taxonomy** of product concepts, (b) encodes **normative and epistemic commitments** (what *must/should/may* be true; what is *known/assumed/uncertain*), and (c) supports **formal reasoning** across requirements, decisions, risks, and evidence—while still remaining usable by product teams day to day. The practical foundation is to represent knowledge as a graph (triples) and validate it with constraints, using standards-based web semantics: RDF for the data model, OWL for formal meaning, SKOS for controlled vocabularies/taxonomies, SHACL for validation, JSON-LD for integration with typical JSON systems, and PROV-O for provenance. citeturn1search0turn1search1turn10search2turn10search3turn1search6turn1search3
+
+The corpus should be structured as layered “modules,” each with clear semantics and governance: (1) a **core ontology** for product knowledge, (2) a **logic layer** (multiple logics, chosen per task), (3) a **specification/template library** for requirements, stories, acceptance criteria, trade-offs, uncertainty/risk, and governance, (4) scenario “worked examples,” and (5) an **operational toolchain** (schema registry, API, validation pipeline, and change control). Requirements engineering and documentation standards provide an anchor for content expectations and life-cycle artifacts (ISO/IEC/IEEE 29148 for requirements engineering; ISO/IEC/IEEE 15288 and 12207 for life-cycle processes; ISO/IEC/IEEE 15289 for documentation information items). citeturn0search5turn0search1turn4search0turn4search1turn11search0
+
+To make this corpus *analytically rigorous*, it must explicitly separate:
+- **Deontic/normative statements** (obligations, permissions, prohibitions) from **descriptive statements** (observations, forecasts, measurements). Deontic logic originates as a formal treatment of obligation/permission/prohibition, and is a natural foundation for compliance, policy, and governance rules. citeturn12search1turn12search13  
+- **Epistemic status**: what the organization treats as knowledge vs. justified belief vs. assumption vs. open question. The “Gettier problem” illustrates why “justified true belief” can fail to be knowledge, motivating explicit representation of justification and defeaters in product evidence. citeturn9search0turn9search16  
+- **Uncertainty and causality**: probability as axiomatized measure (Kolmogorov), Bayesian updating (Bayes), Bayesian networks for structured uncertainty (Pearl), and causal reasoning distinguishing observation from intervention (Pearl’s causality framework). citeturn8search13turn8search0turn12search3turn8search3turn13search2
+
+Finally, the corpus must be tested like any engineering artifact: validated via SHACL/OWL reasoning, measured for coverage and usefulness, and governed with provenance + versioning so “why we believe this” is queryable and auditable. citeturn10search3turn1search3turn0search3
+
+## Scope, objectives, and design principles
+
+**Scope.** “Product knowledge” in this corpus is not only “what the product does,” but the *entire justified body of claims* that supports product decisions and documentation across the life cycle: stakeholder needs, requirements, designs, decisions, evidence, risks, quality attributes, compliance obligations, and operational learnings. This aligns with systems/software life-cycle thinking and requirements engineering process/product guidance. citeturn4search0turn4search1turn0search5
+
+**Primary objectives.**
+1. **Formalize shared meaning**: create a common vocabulary (ontology/taxonomy) so teams interpret “requirement,” “assumption,” “risk,” “acceptance criterion,” and “evidence” consistently. A standard definition of an ontology as a specification of vocabulary (classes/relations/functions) is widely used in knowledge engineering. citeturn10search0turn10search4  
+2. **Enable traceable reasoning**: every important product claim (e.g., “feature X improves retention,” “system is safe enough,” “data processing is permitted”) should trace to evidence and assumptions with provenance. PROV-O is designed to represent and interchange provenance information across systems. citeturn1search3turn1search27  
+3. **Improve decision quality under uncertainty**: encode probabilistic beliefs, causal hypotheses, and trade-off models so decisions are explainable and revisable. Probability’s axiomatization and Bayesian inference are canonical foundations, and Bayesian networks are a standard representation for probabilistic knowledge. citeturn8search13turn8search0turn12search3  
+4. **Make documentation executable/validatable**: requirements and acceptance criteria become machine-checkable with constraint languages and normative keywords (MUST/SHOULD/MAY), reducing ambiguity and drift. RFC 2119 defines requirement-level keywords and RFC 8174 clarifies that only uppercase forms carry the defined normative meaning. citeturn0search2turn13search3  
+5. **Support governance and assurance**: for high-stakes products, represent structured assurance cases linking claims to evidence and assumptions (ISO/IEC 15026-2) and use safety standards where required (e.g., IEC 61508; DO-178C referenced by FAA guidance; ISO 26262 for automotive functional safety). citeturn14search2turn3search28turn3search6turn3search30turn3search1
+
+**Design principles.**
+- **Layered formality (“right logic for the job”)**: not everything should be forced into one formalism. Use SHACL for structural constraints, OWL for taxonomy/semantics, deontic logic for obligations, Bayesian nets for uncertainty, temporal logic/model checking for behaviors. citeturn10search3turn1search1turn12search3turn6search0  
+- **Explicit epistemic labeling**: every claim is tagged as *observed*, *modeled*, *assumed*, *normative*, *counterfactual*, etc. This is an operational response to classic epistemic concerns about justification and knowledge. citeturn9search0turn9search16  
+- **Separation of normative vs descriptive**: policy/obligation statements are represented distinctly from empirical claims; they interact via compliance checks, not conflation. Deontic logic’s purpose is precisely to formalize obligation/permission/prohibition. citeturn12search1turn12search13  
+- **Provenance-first**: every imported dataset, experiment, and external report receives provenance metadata to support trust calibration and audits. citeturn1search3  
+- **Versioned, governed evolution**: treat the corpus as a product with releases, migrations, and backward compatibility policies; documentation standards explicitly treat “information items” as managed life-cycle artifacts. citeturn11search0turn11search4
+
+## Target audiences and use cases
+
+**Product managers.** Use the corpus to maintain a coherent chain from problem framing → hypotheses → requirements → success metrics → decisions and rationale. Requirements engineering standards emphasize defining requirements content and characteristics across life cycle. citeturn0search5turn0search1
+
+**Engineers and architects.** Use formal specs (temporal logic/model checking; structural constraint checking) to prove properties (safety, liveness, invariants) or find counterexamples early. Temporal logic for programs and formal specification languages such as TLA+ are canonical foundations for such verification approaches. citeturn6search0turn6search1turn6search29
+
+**Designers and researchers.** Use epistemic structure to maintain “what is known” from research vs “what is believed,” and connect qualitative and quantitative evidence to decisions; structured provenance helps teams interpret evidence reliability. citeturn1search3turn9search0
+
+**Legal/compliance, security, and risk owners.** Use deontic constraints (“must,” “must not”), plus risk frameworks, to encode obligations and produce auditable compliance evidence. Risk management guidelines are standardized (e.g., ISO 31000; NIST risk assessment guidance). citeturn2search2turn2search7turn12search1turn13search3
+
+**Safety/assurance engineers (safety-critical domains).** Use assurance cases connecting claims to evidence and assumptions (ISO/IEC 15026-2), plus domain safety standards and structured argument notations (e.g., GSN community standard). citeturn14search2turn14search13
+
+**Representative use cases.**
+- **Ambiguity reduction in specs**: enforce normative keyword conventions (RFC 2119/8174) and validate requirement templates with SHACL. citeturn0search2turn13search3turn10search3  
+- **Decision traceability**: maintain “decision records” that cite evidence, alternatives, assumptions, and trade-offs, with provenance and versioning. citeturn1search3turn11search0  
+- **Uncertainty-aware roadmaps**: represent probabilities and causal hypotheses about outcomes rather than “certainty theater,” grounded in formal probability and Bayesian methods. citeturn8search13turn8search0  
+- **Integration of predictive/simulation evidence**: modern products increasingly rely on simulation/agent-based prediction for decisions; for example, entity["company","Aaru","ai prediction startup"] describes itself as simulating populations to connect predicted behavior to decisions, illustrating a class of evidence sources a corpus can capture (as “model output” with provenance + assumptions). citeturn0search0turn0search8turn0news40
+
+## Ontology and taxonomy of concepts
+
+### Knowledge representation choices
+
+A corpus that wants both human usability and machine rigor benefits from separating:
+- **Vocabulary/taxonomy** (concept schemes, labels, hierarchies): SKOS provides a “common data model for sharing and linking knowledge organization systems” such as taxonomies and thesauri. citeturn10search2  
+- **Formal semantics** (classes/properties with logical meaning): OWL provides a formally defined ontology language “roadmap” used with RDF. citeturn1search1turn1search0  
+- **Validation constraints** (what data must look like): SHACL defines constraints for validating RDF graphs. citeturn10search3turn0search3  
+- **Interoperable serialization**: JSON-LD provides a JSON-based linked data format for interoperable web services and storage engines. citeturn1search6turn1search2  
+- **Provenance**: PROV-O provides classes/properties to represent provenance information and can be specialized. citeturn1search3  
+Underlying all of this is RDF’s triple-based graph model (subject–predicate–object). citeturn1search0
+
+### Core taxonomy table
+
+The table below is a **reference taxonomy** (classes plus high-value relations). It is intended to be implementable in OWL (types/relations) with SKOS concept schemes (controlled vocab labels) and SHACL shapes (validation rules). citeturn1search1turn10search2turn10search3
+
+| Class (top-level) | Definition (operational) | Key relations (examples) | Typical instances |
+|---|---|---|---|
+| Stakeholder | Any party affected by or influencing the product | `hasNeed`, `hasConstraint`, `imposesObligation` | customer segment, regulator, internal ops |
+| Goal | Desired outcome state (business/user/safety) | `decomposesTo`, `measuredBy` | “reduce churn,” “avoid hazardous overdose” |
+| Claim | Asserted proposition about product/world | `supportedBy`, `defeatedBy`, `hasStatus` | “feature A increases retention” |
+| Assumption | Provisional premise treated as true for reasoning | `assumptionFor`, `invalidatedBy` | “users enable notifications” |
+| Evidence | Artifact supporting/refuting a claim | `evidenceFor`, `derivedFrom`, `hasProvenance` | experiment result, interview summary |
+| Requirement | Constraint on system/product behavior or quality | `satisfiesGoal`, `verifiedBy`, `conflictsWith` | functional; quality; regulatory |
+| Specification | Formal/semi-formal description implementing requirements | `implements`, `constrains`, `refines` | API spec, state machine, model |
+| DesignDecision | Chosen alternative with rationale | `selectsAlternative`, `justifiedBy`, `hasTradeoff` | “use OAuth,” “batch processing” |
+| Alternative | Candidate option for a decision | `comparedAgainst`, `hasCost`, `hasRisk` | “GraphQL vs REST” |
+| Risk | Uncertain event with negative impact | `hasLikelihood`, `hasImpact`, `mitigatedBy` | data breach risk, safety hazard |
+| Hazard | Source of potential harm (safety-critical) | `leadsTo`, `controlledBy` | “overheating,” “over-infusion” |
+| Control/Mitigation | Measure reducing likelihood/impact | `mitigatesRisk`, `verifiesControl` | rate limiter, redundancy |
+| Metric | Quantitative measure with definition | `measuresGoal`, `computedFrom` | retention, latency p95 |
+| Policy/Obligation | Normative constraint (must/shall/forbidden) | `obligates`, `permits`, `prohibits` | privacy rule, access policy |
+| GovernanceArtifact | Managed record ensuring accountability | `approvedBy`, `versionOf`, `supersedes` | decision record, audit log |
+| ProvenanceRecord | “Who/what/when/how produced this” | `wasGeneratedBy`, `wasAttributedTo` | PROV activity/entity/agent |
+
+### Ontology diagram
+
+```mermaid
+graph TD
+  Stakeholder -->|hasNeed| Goal
+  Stakeholder -->|imposes| Policy
+  Goal -->|decomposesTo| Requirement
+  Requirement -->|refinedBy| Specification
+  DesignDecision -->|selects| Alternative
+  DesignDecision -->|justifiedBy| Evidence
+  Claim -->|supportedBy| Evidence
+  Claim -->|assumes| Assumption
+  Evidence -->|has| ProvenanceRecord
+  Requirement -->|verifiedBy| AcceptanceCriterion
+  Risk -->|mitigatedBy| Control
+  Hazard -->|controlledBy| Control
+  Metric -->|measures| Goal
+  Policy -->|constrains| Requirement
+```
+
+### Visual reference examples
+
+image_group{"layout":"carousel","aspect_ratio":"16:9","query":["product knowledge graph ontology diagram","SHACL shapes constraint language diagram","Bayesian network example diagram","assurance case GSN diagram"],"num_per_query":1}
+
+## Formal logical frameworks and notations for product reasoning
+
+A corpus is strongest when it treats “logic” as a **toolbox**, not a monolith. Below are the major formalisms requested and their product-knowledge role, with primary-source anchors.
+
+### Comparative table of logical frameworks
+
+| Framework | Core notion | Best product use | Typical representation | Key strengths | Key pitfalls |
+|---|---|---|---|---|---|
+| Propositional logic | truth of atomic propositions with connectives | simple gating rules; consistency checks | formulas over booleans | simple, automatable | limited expressiveness |
+| First-order predicate logic | quantified statements about objects/relations | formalizing requirements over entities (“for all users…”) | predicates + ∀/∃ | expressive and precise | can be hard to keep usable |
+| Modal logic | necessity/possibility across possible worlds | “must/can” semantics; capability vs guarantee | □P, ◇P; Kripke frames | formal access to “necessity” | ambiguity if “worlds” unclear citeturn7search0turn12search2 |
+| Deontic logic | obligation/permission/prohibition | policy & compliance; authorization; governance rules | O(P), P(P), F(P) | matches normative language | paradoxes; needs careful modeling citeturn12search1turn12search13 |
+| Probabilistic logic / probability theory | measures over events | uncertainty in outcomes; reliability modeling | P(A), distributions | principled uncertainty | requires calibration & data citeturn8search13turn8search5 |
+| Bayesian inference | updating beliefs with evidence | experiment interpretation; diagnosis; forecasting | posterior ∝ prior×likelihood | explicit learning from data | priors and model misspecification citeturn8search0 |
+| Bayesian networks | graphical factorization of probability | risk models, funnel conversion, failure diagnosis | DAG with CPTs | interpretable structure | assumes conditional independencies citeturn12search3turn12search11 |
+| Causal models | effect of interventions vs observations | “what if we change X?” product causality | SCM; do(·) calculus | distinguishes correlation/causation | needs causal assumptions citeturn8search3turn13search2 |
+| Decision theory (subjective expected utility) | rational choice under uncertainty | trade-offs; roadmap bets; portfolio selection | maximize E[U] | coherent preferences and choice | human values & utilities hard to elicit citeturn13search29turn8search2 |
+| Temporal logic / model checking | reasoning over time/behaviors | concurrency, protocols, liveness/safety properties | LTL/CTL; invariants | finds counterexamples early | modeling overhead citeturn6search0 |
+| Formal specification (TLA+) | set theory + first-order + temporal actions | protocol/system specs; invariants & refinement | TLA+ modules/specs | executable checking mindset | requires discipline & training citeturn6search1turn6search29 |
+| Alloy (relational modeling + SAT) | bounded model finding | data model constraints; invariants | signatures/relations | fast counterexamples | bounded scope may miss issues citeturn6search6turn6search2 |
+
+### Normative notation for requirements
+
+Because product documentation often mixes descriptive and normative language, the corpus should standardize normative strength using RFC-style keywords: RFC 2119 defines the intended meanings and RFC 8174 clarifies capitalization rules, enabling automatic parsing/validation of “MUST/SHOULD/MAY” requirements in specs. citeturn0search2turn13search3
+
+### Where the semantic-web stack fits
+
+The above logics answer “how do we reason?”, while the semantic-web standards answer “how do we represent and validate what we know?”:
+- RDF graphs (triples) are the shared substrate. citeturn1search0  
+- OWL encodes class/property semantics (e.g., disjointness, subclassing). citeturn1search1  
+- SHACL validates instance data against shapes (“every Requirement must have an owner, priority, verification method”). citeturn10search3turn0search3  
+- SKOS layers controlled vocabularies for categories like “risk type,” “requirement type,” “evidence type.” citeturn10search2  
+- PROV-O captures provenance for evidence and claims. citeturn1search3  
+- JSON-LD enables integration with typical JSON-first systems. citeturn1search6
+
+## Philosophical foundations mapped to product practice
+
+This section provides the “philosophy → product practice” map, focusing on epistemology, ontology, ethics, and philosophy of science, and showing how each becomes corpus content and constraints.
+
+### Mapping table: philosophy to product operations
+
+| Philosophical area | Core question | Operational product interpretation | Corpus encoding pattern | Primary anchors |
+|---|---|---|---|---|
+| Epistemology | What counts as knowledge/justification? | Separate *belief*, *evidence*, *assumption*, *defeater*; require “why we believe this” links | Claim–Evidence–Assumption graph; provenance; confidence; defeaters | entity["people","Edmund Gettier","philosopher epistemology"] on weaknesses of “JTB,” motivating explicit justification tracking citeturn9search0turn9search16 |
+| Ontology | What entities exist in the domain? | Define stable concept types (Requirement, Decision, Metric) and relations; avoid category errors | OWL class/property model + SKOS concept schemes | “Ontology as shared vocabulary specification” in entity["people","Thomas R. Gruber","computer scientist ontology"] citeturn10search0turn10search4 |
+| Ethics | What ought we do? What harms are acceptable? | Encode obligations (privacy, fairness, consent), and record ethical trade-offs | Deontic rules; risk/impact assessments; governance artifacts | entity["organization","Association for Computing Machinery","professional society"] Code emphasizes public good and ethical responsibility citeturn5search0; entity["organization","U.S. Department of Health and Human Services","federal agency"] Belmont principles for human-subject research ethics citeturn5search2turn5search6 |
+| Philosophy of science | How do we test/learn? What is evidence? | Treat roadmap bets as hypotheses; require falsifiability criteria; manage paradigm shifts | Experiment objects; hypothesis registry; Bayesian updates; change logs | entity["people","Karl Popper","philosopher of science"] on falsifiability/demarcation citeturn9search1turn9search9; entity["people","Thomas S. Kuhn","philosopher of science"] on paradigms/normal science shifts citeturn9search2turn9search10; entity["people","Imre Lakatos","philosopher of science"] on research programmes/progressive vs degenerating shifts citeturn9search3turn9search15 |
+
+### Ethics and AI risk as corpus modules
+
+For products involving AI (or significant automated decisioning), map ethics into explicit risk controls and governance checks. The entity["organization","National Institute of Standards and Technology","us standards agency"] AI Risk Management Framework is explicitly designed as a practical resource to manage AI risks and is expected to evolve over time—making it a natural “external standard reference module” for the corpus. citeturn5search3turn5search19
+
+Similarly, ISO 31000 provides general principles/guidelines for risk management across identifying, analyzing, treating, monitoring, and communicating risks—useful as the general risk module. citeturn2search2turn2search6
+
+## Templates, formal specifications, and worked examples
+
+This section provides (a) reusable templates/formal specs and (b) three scenario worked formalizations: consumer app, enterprise SaaS, and safety-critical system.
+
+### Template set for the corpus
+
+#### Requirement (machine-checkable record)
+
+```yaml
+id: REQ-<unique>
+type: functional | quality | regulatory | constraint
+statement: "The system MUST ..."
+normative_basis:
+  keywords_standard: "RFC2119/8174"
+rationale:
+  goal_links: [GOAL-...]
+  stakeholder_links: [STK-...]
+verification:
+  method: test | analysis | inspection | demonstration
+  acceptance_criteria_ids: [AC-...]
+traceability:
+  derived_from: [NEED-..., POLICY-...]
+  refined_by: [SPEC-..., DESIGN-...]
+quality_attributes:
+  - name: <e.g., reliability, security>
+    reference_model: "ISO/IEC 25010"
+risk_links: [RISK-...]
+status: proposed | approved | deprecated
+version: <semver>
+provenance:
+  created_by: <agent>
+  created_at: <timestamp>
+```
+
+Why these fields: ISO/IEC/IEEE 29148 emphasizes requirements engineering processes/products and characteristics of “good requirements,” while RFC 2119/8174 provides normative keyword semantics; ISO/IEC 25010 provides a quality characteristic model usable as a reference taxonomy for quality requirements. citeturn0search5turn0search1turn0search2turn13search3turn11search3turn11search34
+
+#### User story (human-friendly, ontology-linked)
+
+```yaml
+id: US-<unique>
+role: <persona or stakeholder role>
+capability: <what they can do>
+value: <why it matters>
+linked_goals: [GOAL-...]
+linked_requirements: [REQ-...]
+assumptions: [ASM-...]
+evidence: [EVD-...]   # research that motivates it
+```
+
+#### Acceptance criteria (executable specification style)
+
+Use Gherkin when you want a bridge from product criteria to automated tests.
+
+```gherkin
+Feature: <feature name>
+  Scenario: <scenario name>
+    Given <context>
+    When <action>
+    Then <expected outcome>
+```
+
+The Gherkin grammar is documented in Cucumber’s reference, including structural keywords like `Feature` and scenario organization. citeturn4search3turn4search7
+
+#### Risk and uncertainty model (probability + impact)
+
+```yaml
+id: RISK-<unique>
+event: <undesired event>
+context: <system boundary>
+likelihood:
+  model: qualitative | quantitative
+  value: <e.g., 0.02 per month>
+impact:
+  dimensions: [safety, financial, legal, user_trust]
+  severity: <scale or quantified>
+risk_response:
+  strategy: avoid | mitigate | transfer | accept
+  controls: [CTRL-...]
+evidence_and_provenance:
+  inputs: [EVD-..., DATASET-...]
+  method_notes: <assumptions, model form>
+monitoring:
+  indicators: [MET-...]
+  review_interval: <period>
+```
+
+This is aligned with the general process framing of ISO 31000 (identify/analyze/evaluate/treat/monitor) and with NIST SP 800-30’s focus on systematic risk assessment guidance. citeturn2search2turn2search7turn2search3
+
+#### Trade-off analysis (decision-theoretic)
+
+```yaml
+id: DEC-<unique>
+decision_question: <what choice?>
+alternatives:
+  - id: ALT-A
+  - id: ALT-B
+criteria:
+  - name: <criterion>
+    weight: <0..1>
+    utility_function: <definition>
+uncertainty_model:
+  type: bayesian_net | scenario_tree | monte_carlo
+  artifact: <link/model id>
+decision_rule: "maximize expected utility"
+rationale_links:
+  evidence: [EVD-...]
+  assumptions: [ASM-...]
+  risks: [RISK-...]
+approval:
+  owner: <role>
+  date: <timestamp>
+```
+
+This is grounded in subjective expected utility traditions (von Neumann–Morgenstern utility axioms; Savage’s foundations for personal probability/decision under uncertainty). citeturn13search29turn8search2
+
+#### Governance record (assurance-ready)
+
+For high assurance, represent structured arguments linking claims to evidence and assumptions.
+
+```yaml
+id: ASR-<unique>
+top_claim: "System/property X holds in context C"
+argument_structure: gsn | structured_text
+subclaims: [CLM-...]
+evidence: [EVD-...]
+assumptions: [ASM-...]
+confidence_notes: <known gaps, limitations>
+status: draft | reviewed | accepted
+```
+
+ISO/IEC 15026-2 defines assurance cases as claims + argumentation + evidence + explicit assumptions. citeturn14search2turn14search14
+
+### Worked scenario consumer app
+
+**Scenario.** A consumer mobile app introduces “smart reminders” to improve weekly retention while minimizing annoyance and respecting user preferences.
+
+**Ontology instantiation (selected).**
+
+```json
+{
+  "Goal": {"id":"GOAL-RET-01","text":"Increase 7-day retention by 3% without increasing opt-out rate"},
+  "Requirement": {"id":"REQ-NOTIF-01","statement":"The app MUST allow disabling reminders at any time"},
+  "Metric": [{"id":"MET-RET-7D","name":"7-day retention"},{"id":"MET-OPTOUT","name":"reminder opt-out rate"}],
+  "Risk": {"id":"RISK-UX-01","event":"Reminders increase user annoyance and churn"},
+  "Decision": {"id":"DEC-REM-01","question":"Enable smart reminders by default?","alts":["ALT-ON","ALT-OFF"]}
+}
+```
+
+**Formalization highlights.**
+- **Deontic layer (policy-like):**  
+  O(user_can_disable_reminders_anytime)  
+  This expresses an obligation aligned with user autonomy and consent-style norms; deontic logic formalizes obligation/permission/prohibition. citeturn12search1turn12search13  
+- **Probabilistic layer (uncertainty):** represent belief about “smart reminders improve retention” as a hypothesis with priors, updated via A/B tests. Bayesian reasoning originates in Bayes’ work and is grounded in modern probability axioms formalized by Kolmogorov. citeturn8search0turn8search13  
+- **Validation layer:** SHACL constraints ensure every reminder-related requirement has an opt-out path and acceptance tests; SHACL is explicitly defined as a language for validating RDF graphs against conditions. citeturn0search3turn10search3
+
+**Acceptance criteria (Gherkin).**
+
+```gherkin
+Feature: Reminder controls
+  Scenario: User disables reminders
+    Given reminders are enabled
+    When the user toggles reminders off
+    Then the app stops sending reminders within 5 minutes
+```
+
+Cucumber documents `Feature` structure and keyword usage in its reference. citeturn4search3
+
+### Worked scenario enterprise SaaS
+
+**Scenario.** Enterprise SaaS introduces a new “audit export API” to satisfy compliance teams (e.g., data access logs) while meeting SLA performance and authorization constraints.
+
+**Key corpus moves.**
+- **Requirements as normative specs**: use RFC 2119/8174 keywords consistently for API requirements (“The API MUST return…”). citeturn0search2turn13search3  
+- **Quality requirements**: categorize nonfunctional requirements using ISO/IEC 25010 quality characteristics (e.g., security, reliability, performance efficiency). citeturn11search3turn11search34  
+- **API as a formal artifact**: define the API using OpenAPI, described as a language-agnostic interface description for HTTP APIs enabling humans and computers to understand service capabilities. citeturn2search0turn2search32  
+- **Life-cycle documentation**: treat “audit export spec,” “threat model,” and “test plan” as managed information items as per documentation guidance standards. citeturn11search0turn11search4
+
+**A minimal deontic + predicate formalization.**
+- Let `Authorized(u, tenant, scope)` be a predicate.  
+- Requirement (authorization):  
+  ∀u,tenant. Request(u,tenant) → (Authorized(u,tenant,"audit:read") ⇒ Permit(Export(u,tenant)))  
+  and (¬Authorized(u,tenant,"audit:read") ⇒ Forbid(Export(u,tenant))))
+
+The deontic foundation is formally treated in von Wright’s work; the practical surface form is enforced using normative keywords and automated policy tests. citeturn12search1turn0search2
+
+### Worked scenario safety-critical system
+
+**Scenario.** A safety-critical controller (e.g., an automated dosing controller or industrial safety function) must satisfy functional safety and produce evidence that the system is acceptably safe for specified contexts.
+
+**Standards anchoring (why they matter in the corpus).**
+- IEC 61508 provides a cross-sector functional safety framework emphasizing risk-based determination of required safety function performance across the safety lifecycle. citeturn14search3turn3search28  
+- ISO 26262 addresses hazards from malfunctioning behavior of E/E safety-related systems for road vehicles. citeturn3search1  
+- DO-178C is the core document for airborne software design/product assurance; FAA guidance recognizes DO-178C as an acceptable means for compliance in civil aviation software assurance contexts. citeturn3search6turn3search30  
+- Assurance cases: ISO/IEC 15026-2 defines structure terminology and the claim–argument–evidence pattern. citeturn14search2turn14search14  
+- GSN provides a structured argument notation used in safety case documentation, described in the GSN community standard. citeturn14search13
+
+**Formalization pattern.**
+1. **Hazard → safety requirement → verification link**  
+   - Hazard: “overdose occurs under sensor fault.”  
+   - Safety requirement: “If sensor fault detected, system MUST enter safe mode within T.” (normative keyword + temporal property) citeturn0search2turn13search3  
+2. **Temporal logic property**  
+   - Example (informal LTL): G(fault_detected → F≤T safe_mode)  
+   Temporal logic of programs is a canonical foundation for specifying time-dependent program properties. citeturn6search0  
+3. **Model checking / formal spec artifact**  
+   - Use TLA+ to specify actions/invariants; it is explicitly a specification language for describing computer system behaviors and supporting checking. citeturn6search1turn6search29  
+4. **Assurance case (claim–argument–evidence)**  
+   - Claim: “System maintains safe dosing under defined hazard model.”  
+   - Evidence: verified fault-detection tests, formal model checks, failure rate analysis.  
+   ISO/IEC 15026-2 defines the assurance case structure elements. citeturn14search2
+
+**GSN-style argument skeleton (illustrative).**
+
+```mermaid
+graph TD
+  G0["Goal: System is acceptably safe in context C"] --> S1["Strategy: Argue by hazards and mitigations"]
+  S1 --> G1["Goal: Hazard H1 is controlled"]
+  G1 --> Sn1["Solution: Evidence set E1 (tests, analyses, proofs)"]
+  S1 --> G2["Goal: Hazard H2 is controlled"]
+  G2 --> Sn2["Solution: Evidence set E2"]
+```
+
+This aligns with the idea of explicitly linking claims to evidence and assumptions as standardized for assurance case structure. citeturn14search2turn14search13
+
+## Implementation, evaluation, maintenance, and governance
+
+### Tooling and architecture guidance
+
+A practical implementation under “no specific constraints” should support both:
+- **Graph-native knowledge management** (for ontology instances, traceability, and provenance), and
+- **Document-native authoring** (for human-readable specs and templates), with synchronization.
+
+**Recommended standards-based architecture.**
+- **Knowledge layer:** RDF as the underlying data model for knowledge graphs. citeturn1search0  
+- **Ontology layer:** OWL (for class/property semantics) + SKOS (for controlled vocabularies and taxonomy publishing). citeturn1search1turn10search2  
+- **Validation + linting:** SHACL shapes ensure every artifact conforms (e.g., “every Requirement has a verification method”). SHACL is explicitly defined for validating RDF graphs. citeturn10search3turn0search3  
+- **Provenance:** PROV-O for “who/what/when/how” evidence and claims were produced. citeturn1search3  
+- **Interchange:** JSON-LD for integrating the corpus with typical JSON services and storing linked data in JSON-based engines. citeturn1search6  
+- **API access:**  
+  - REST/HTTP interface described with OpenAPI (latest spec is maintained as a standard, language-agnostic interface description). citeturn2search0turn2search32  
+  - Optionally a query layer using GraphQL (formal specification defines schema and execution/validation). citeturn2search1turn2search9  
+
+### Data schemas and APIs
+
+**Resource model suggestion (API-facing).** Expose stable resources:
+- `/claims`, `/evidence`, `/requirements`, `/decisions`, `/risks`, `/metrics`, `/policies`, `/provenance`
+
+**Schema suggestion.** Treat each resource as:
+- JSON-LD payload for interoperability, backed by RDF storage; JSON-LD explicitly targets interoperable web services and provides an upgrade path from JSON to linked data. citeturn1search6  
+- SHACL shapes published as “schema contracts” for each resource type. citeturn10search3  
+- OpenAPI as the canonical API contract document. citeturn2search0turn2search32
+
+### Evaluation metrics and validation methods
+
+A rigorous corpus needs both **formal correctness metrics** and **organizational utility metrics**.
+
+**Formal/technical validation.**
+- **Shape conformance rate:** % of entities passing SHACL validation; SHACL is designed for validation against a shapes graph. citeturn0search3turn10search3  
+- **Ontology consistency checks:** OWL reasoners detect inconsistent class axioms or conflicting assertions; OWL is defined as a formal ontology language. citeturn1search1  
+- **Provenance completeness:** % of high-impact claims with PROV-O links (agent/activity/entity) supporting auditability. citeturn1search3  
+- **Spec ambiguity linting:** % of requirements that conform to RFC 2119/8174 keyword usage and avoid lowercase ambiguity. citeturn0search2turn13search3  
+- **Formal-method coverage (where applicable):** number of critical invariants checked via temporal logic/model checking foundations. citeturn6search0turn6search1
+
+**Decision and product outcome evaluation.**
+- **Traceability coverage:** % of decisions linked to (a) alternatives, (b) criteria, (c) evidence, (d) assumptions, and (e) risk entries—aligned with assurance-case thinking linking claims to evidence/assumptions. citeturn14search2  
+- **Forecast calibration:** Brier score or calibration curves for probabilistic product predictions (e.g., “70% chance KPI achieved”), reflecting probability-theoretic discipline (Kolmogorov foundation; Bayesian updating). citeturn8search13turn8search0  
+- **Documentation effectiveness:** defect escape rate attributable to requirement ambiguity; ISO/IEC/IEEE requirements engineering standards emphasize good requirements and iterative life-cycle application. citeturn0search5turn0search1  
+- **Risk control effectiveness:** reduction in realized incidents vs predicted; supports ISO 31000’s monitoring/communication orientation and NIST risk assessment practice. citeturn2search2turn2search7
+
+### Maintenance, versioning, and governance
+
+**Why governance must be explicit.** A corpus is a “shared epistemic artifact,” so governance is part of correctness: uncontrolled change destroys meaning, provenance, and trust.
+
+**Recommended governance model.**
+- **Corpus steering group** (cross-functional): product, engineering, design/research, risk/compliance.  
+- **Release model aligned to life-cycle documentation management:** ISO/IEC/IEEE 15289 explicitly frames life-cycle information items (documentation) with specified purpose/content, reinforcing the idea that documents are managed artifacts. citeturn11search0turn11search4  
+- **Change control:** every ontology change recorded as a GovernanceArtifact with backward-compat notes and migration steps.  
+- **Provenance and audit:** require PROV-O metadata for new claims/evidence and for automated imports from tools. citeturn1search3  
+- **Domain-specific overlays:** safety-critical overlays include assurance case modules (ISO/IEC 15026-2) and safety lifecycle mapping to relevant standards (IEC 61508, ISO 26262, DO-178C contexts). citeturn14search2turn3search28turn3search1turn3search6  
+
+### Process flow diagram for corpus operation
+
+```mermaid
+flowchart TD
+  A[Capture artifact: requirement, decision, evidence] --> B[Normalize to ontology terms]
+  B --> C[Attach provenance + epistemic status]
+  C --> D[Validate with SHACL + lint normative keywords]
+  D --> E{Pass?}
+  E -- No --> F[Return errors + fix guidance]
+  E -- Yes --> G[Publish to knowledge graph + docs]
+  G --> H[Run reasoning: queries, risk models, decision eval]
+  H --> I[Review + governance approval]
+  I --> J[Version release + communicate changes]
+  J --> A
+```
+
+This loop operationalizes (1) validation as a first-class feature (SHACL), (2) provenance as mandatory metadata (PROV-O), and (3) versioned documentation practice consistent with life-cycle information item management. citeturn10search3turn1search3turn11search0

--- a/knowledge-corpus/data/mojosolo_operating_brain.json
+++ b/knowledge-corpus/data/mojosolo_operating_brain.json
@@ -1,0 +1,721 @@
+{
+  "schema": {
+    "name": "mojosolo_operating_brain",
+    "version": "1.0.0",
+    "generated_on": "2026-03-12",
+    "target_company": "MojoSolo",
+    "target_domain": "mojosolo_internal",
+    "capture_scope": "internal_operating_context_and_repo_configuration",
+    "status": "active_canonical_brain"
+  },
+  "source_registry": [
+    {
+      "id": "src_repo_memory_email_personas",
+      "title": "Email Personas Memory",
+      "organization": "MojoSolo",
+      "url": "memory/context/email-personas.md",
+      "source_class": "internal_memory",
+      "role_in_corpus": "canonical_account_role_context",
+      "trust_level": "high"
+    },
+    {
+      "id": "src_repo_claude_memory",
+      "title": "Repo Hot Memory",
+      "organization": "MojoSolo",
+      "url": "CLAUDE.md",
+      "source_class": "internal_memory",
+      "role_in_corpus": "hot_cache_summary",
+      "trust_level": "high"
+    },
+    {
+      "id": "src_mail_intelligence_package",
+      "title": "Apple Mail Intelligence MCP Package",
+      "organization": "MojoSolo",
+      "url": "mail-intelligence/src",
+      "source_class": "repo_implementation",
+      "role_in_corpus": "live_sensor_and_brief_generation_layer",
+      "trust_level": "high"
+    },
+    {
+      "id": "src_knowledge_corpus_package",
+      "title": "Knowledge Corpus MCP Package",
+      "organization": "MojoSolo",
+      "url": "knowledge-corpus/src",
+      "source_class": "repo_implementation",
+      "role_in_corpus": "canonical_brain_query_layer",
+      "trust_level": "high"
+    }
+  ],
+  "epistemic_contract": {
+    "primary_rule": "knowledge_corpus_is_canonical_brain",
+    "secondary_rule": "mail_intelligence_is_live_sensor_layer",
+    "tertiary_rule": "laravel_is_primary_application_and_api_layer",
+    "notes_are_output_not_source_of_truth": true,
+    "memory_files_are_hot_cache_not_canonical_database": true
+  },
+  "canonical_profile": {
+    "brand_name": "MojoSolo",
+    "operating_frame": [
+      "creative_studio",
+      "operator_led_business",
+      "multi_persona_email_intelligence_system"
+    ],
+    "public_identity_summary": "MojoSolo operates distinct email personas for creative intake, human operator communication, and automated campaign or client workflow intake.",
+    "canonical_brain_location": "knowledge-corpus/data/mojosolo_operating_brain.json",
+    "primary_application_layer": "laravel",
+    "primary_output_layer": "apple_notes_daily_intel"
+  },
+  "persona_architecture": {
+    "evidence_source_ids": [
+      "src_repo_memory_email_personas",
+      "src_repo_claude_memory"
+    ],
+    "status": "explicit_internal_design",
+    "personas": [
+      {
+        "persona_id": "author",
+        "persona": "The Author",
+        "account": "iCloud",
+        "canonical_email": "mojosolo@mac.com",
+        "role": "Curated creative and intellectual intake",
+        "default_lane": "creative_intake",
+        "primary_reply_from": false,
+        "catch_all": false,
+        "notes": [
+          "This is the reading list and author persona.",
+          "Use for Superhuman style intake, Glasp, Seeking Alpha, and broader inspiration."
+        ]
+      },
+      {
+        "persona_id": "operator",
+        "persona": "The Operator",
+        "account": "david@mojosolo.com",
+        "canonical_email": "david@mojosolo.com",
+        "role": "Primary human facing reply from account",
+        "default_lane": "human_replies_required",
+        "primary_reply_from": true,
+        "catch_all": false,
+        "notes": [
+          "This is the account David gives to people.",
+          "Bias toward real humans, clients, partnerships, and dev operations."
+        ]
+      },
+      {
+        "persona_id": "machine",
+        "persona": "The Machine",
+        "account": "info@mojosolo.com",
+        "canonical_email": "info@mojosolo.com",
+        "role": "Catch all campaigns, client workflows, and automated signals",
+        "default_lane": "machine_signals",
+        "primary_reply_from": false,
+        "catch_all": true,
+        "notes": [
+          "This inbox intentionally receives creative alias traffic.",
+          "It contains active client work, meeting transcripts, and machine generated signals."
+        ]
+      }
+    ]
+  },
+  "signal_domains": {
+    "status": "active",
+    "domains": [
+      {
+        "name": "AI/Tech",
+        "matches": [
+          "ai",
+          "llm",
+          "superhuman",
+          "glasp",
+          "replit",
+          "whattheai",
+          "simple.ai",
+          "github copilot",
+          "openai"
+        ]
+      },
+      {
+        "name": "Market/Finance",
+        "matches": [
+          "seeking alpha",
+          "wall street",
+          "binance",
+          "business insider",
+          "market",
+          "finance",
+          "earnings",
+          "stocks"
+        ]
+      },
+      {
+        "name": "Industry/Benefits",
+        "matches": [
+          "employee benefit news",
+          "benefits",
+          "credit union",
+          "fcu",
+          "insurance",
+          "hr"
+        ]
+      },
+      {
+        "name": "Creative/Strategic",
+        "matches": [
+          "donald miller",
+          "medium",
+          "masterclass",
+          "apple news",
+          "storybrand",
+          "writing",
+          "creative"
+        ]
+      },
+      {
+        "name": "Dev Ops",
+        "matches": [
+          "github",
+          "ci/cd",
+          "deploy",
+          "deployment",
+          "build failed",
+          "workflow",
+          "replit",
+          "mojoos",
+          "voyani-brain"
+        ]
+      },
+      {
+        "name": "Client Work",
+        "matches": [
+          "elanpresentation",
+          "appalachian community fcu",
+          "fedchoice fcu",
+          "presentation",
+          "client deliverable"
+        ]
+      },
+      {
+        "name": "Meeting Intel",
+        "matches": [
+          "otter",
+          "standup",
+          "transcript",
+          "meeting summary",
+          "mojo standup"
+        ]
+      },
+      {
+        "name": "Platform Alerts",
+        "matches": [
+          "mojomosaicxyz",
+          "platform alert",
+          "outage",
+          "incident",
+          "status"
+        ]
+      },
+      {
+        "name": "Regulatory",
+        "matches": [
+          "wisconsin department of agriculture",
+          "dept of agriculture",
+          "regulatory",
+          "compliance",
+          "policy update"
+        ]
+      }
+    ]
+  },
+  "mail_intelligence": {
+    "notes": {
+      "folder": "Daily Intel",
+      "titlePrefix": "Daily Intel",
+      "defaultLookbackDays": 1,
+      "defaultLimitPerAccount": 20
+    },
+    "scoring": {
+      "urgentSubjectKeywords": [
+        "action required",
+        "urgent",
+        "alert",
+        "failed",
+        "failure",
+        "error",
+        "standup",
+        "summary",
+        "presentation",
+        "client",
+        "approval",
+        "invoice"
+      ],
+      "automatedSenderKeywords": [
+        "noreply",
+        "no-reply",
+        "notifications",
+        "notification",
+        "news@",
+        "updates@",
+        "hello@",
+        "support@",
+        "alerts@",
+        "github",
+        "otter",
+        "superhuman",
+        "seeking alpha",
+        "business insider",
+        "glasp"
+      ],
+      "newsletterKeywords": [
+        "newsletter",
+        "daily",
+        "weekly",
+        "digest",
+        "edition",
+        "briefing",
+        "roundup"
+      ],
+      "humanReplyKeywords": [
+        "re:",
+        "reply",
+        "following up",
+        "checking in",
+        "intro",
+        "introduction",
+        "meeting",
+        "proposal",
+        "partnership",
+        "client"
+      ]
+    },
+    "domains": [
+      {
+        "name": "AI/Tech",
+        "matches": [
+          "ai",
+          "llm",
+          "superhuman",
+          "glasp",
+          "replit",
+          "whattheai",
+          "simple.ai",
+          "github copilot",
+          "openai"
+        ]
+      },
+      {
+        "name": "Market/Finance",
+        "matches": [
+          "seeking alpha",
+          "wall street",
+          "binance",
+          "business insider",
+          "market",
+          "finance",
+          "earnings",
+          "stocks"
+        ]
+      },
+      {
+        "name": "Industry/Benefits",
+        "matches": [
+          "employee benefit news",
+          "benefits",
+          "credit union",
+          "fcu",
+          "insurance",
+          "hr"
+        ]
+      },
+      {
+        "name": "Creative/Strategic",
+        "matches": [
+          "donald miller",
+          "medium",
+          "masterclass",
+          "apple news",
+          "storybrand",
+          "writing",
+          "creative"
+        ]
+      },
+      {
+        "name": "Dev Ops",
+        "matches": [
+          "github",
+          "ci/cd",
+          "deploy",
+          "deployment",
+          "build failed",
+          "workflow",
+          "replit",
+          "mojoos",
+          "voyani-brain"
+        ]
+      },
+      {
+        "name": "Client Work",
+        "matches": [
+          "elanpresentation",
+          "appalachian community fcu",
+          "fedchoice fcu",
+          "presentation",
+          "client deliverable"
+        ]
+      },
+      {
+        "name": "Meeting Intel",
+        "matches": [
+          "otter",
+          "standup",
+          "transcript",
+          "meeting summary",
+          "mojo standup"
+        ]
+      },
+      {
+        "name": "Platform Alerts",
+        "matches": [
+          "mojomosaicxyz",
+          "platform alert",
+          "outage",
+          "incident",
+          "status"
+        ]
+      },
+      {
+        "name": "Regulatory",
+        "matches": [
+          "wisconsin department of agriculture",
+          "dept of agriculture",
+          "regulatory",
+          "compliance",
+          "policy update"
+        ]
+      }
+    ],
+    "accounts": [
+      {
+        "account": "iCloud",
+        "mailbox": "INBOX",
+        "personaId": "author",
+        "persona": "The Author",
+        "role": "Curated creative and intellectual intake",
+        "summary": "Reading list and idea intake for the creative and intellectual persona.",
+        "primaryReplyFrom": false,
+        "catchAll": false,
+        "defaultLane": "creative_intake",
+        "sourceRules": [
+          {
+            "label": "Seeking Alpha",
+            "matches": [
+              "seeking alpha",
+              "wall street breakfast"
+            ],
+            "domain": "Market/Finance",
+            "lane": "creative_intake",
+            "priority": "normal"
+          },
+          {
+            "label": "AI Builder Club",
+            "matches": [
+              "ai builder club"
+            ],
+            "domain": "AI/Tech",
+            "lane": "creative_intake",
+            "priority": "normal"
+          },
+          {
+            "label": "Superhuman AI",
+            "matches": [
+              "superhuman ai",
+              "superhuman"
+            ],
+            "domain": "AI/Tech",
+            "lane": "creative_intake",
+            "priority": "high"
+          },
+          {
+            "label": "Glasp",
+            "matches": [
+              "glasp"
+            ],
+            "domain": "Creative/Strategic",
+            "lane": "creative_intake",
+            "priority": "normal"
+          },
+          {
+            "label": "Business Insider",
+            "matches": [
+              "business insider"
+            ],
+            "domain": "Market/Finance",
+            "lane": "creative_intake",
+            "priority": "normal"
+          },
+          {
+            "label": "Apple News",
+            "matches": [
+              "apple news"
+            ],
+            "domain": "Creative/Strategic",
+            "lane": "creative_intake",
+            "priority": "normal"
+          }
+        ]
+      },
+      {
+        "account": "david@mojosolo.com",
+        "mailbox": "INBOX",
+        "personaId": "operator",
+        "persona": "The Operator",
+        "role": "Primary human-facing reply-from account",
+        "summary": "Human relationships, deals, dev operations, and the primary outward identity.",
+        "primaryReplyFrom": true,
+        "catchAll": false,
+        "defaultLane": "human_replies_required",
+        "sourceRules": [
+          {
+            "label": "GitHub",
+            "matches": [
+              "github",
+              "mojoos",
+              "voyani-brain"
+            ],
+            "domain": "Dev Ops",
+            "lane": "ops_signals",
+            "priority": "high"
+          },
+          {
+            "label": "Replit",
+            "matches": [
+              "replit"
+            ],
+            "domain": "Dev Ops",
+            "lane": "ops_signals",
+            "priority": "normal"
+          },
+          {
+            "label": "LinkedIn",
+            "matches": [
+              "linkedin"
+            ],
+            "domain": "Creative/Strategic",
+            "lane": "human_replies_required",
+            "priority": "normal"
+          },
+          {
+            "label": "Binance",
+            "matches": [
+              "binance"
+            ],
+            "domain": "Market/Finance",
+            "lane": "ops_signals",
+            "priority": "normal"
+          },
+          {
+            "label": "Employee Benefit News",
+            "matches": [
+              "employee benefit news"
+            ],
+            "domain": "Industry/Benefits",
+            "lane": "signal_watch",
+            "priority": "normal"
+          },
+          {
+            "label": "Axios",
+            "matches": [
+              "axios"
+            ],
+            "domain": "Creative/Strategic",
+            "lane": "signal_watch",
+            "priority": "normal"
+          },
+          {
+            "label": "TechCrunch",
+            "matches": [
+              "techcrunch"
+            ],
+            "domain": "AI/Tech",
+            "lane": "signal_watch",
+            "priority": "normal"
+          },
+          {
+            "label": "Donald Miller",
+            "matches": [
+              "donald miller",
+              "storybrand"
+            ],
+            "domain": "Creative/Strategic",
+            "lane": "signal_watch",
+            "priority": "normal"
+          }
+        ]
+      },
+      {
+        "account": "info@mojosolo.com",
+        "mailbox": "INBOX",
+        "personaId": "machine",
+        "persona": "The Machine",
+        "role": "Catch-all campaigns, client workflows, and automated signals",
+        "summary": "Campaign aliases, client delivery, meeting intel, and platform notifications.",
+        "primaryReplyFrom": false,
+        "catchAll": true,
+        "defaultLane": "machine_signals",
+        "sourceRules": [
+          {
+            "label": "ElanPresentation",
+            "matches": [
+              "elanpresentation",
+              "appalachian community fcu",
+              "fedchoice fcu",
+              "credit union"
+            ],
+            "domain": "Client Work",
+            "lane": "client_work",
+            "priority": "high"
+          },
+          {
+            "label": "Otter.ai",
+            "matches": [
+              "otter",
+              "mojo standup",
+              "meeting summary",
+              "transcript"
+            ],
+            "domain": "Meeting Intel",
+            "lane": "meeting_intel",
+            "priority": "high"
+          },
+          {
+            "label": "MojoMosaicXYZ",
+            "matches": [
+              "mojomosaicxyz",
+              "platform alert",
+              "incident",
+              "status page"
+            ],
+            "domain": "Platform Alerts",
+            "lane": "platform_alerts",
+            "priority": "high"
+          },
+          {
+            "label": "Wisconsin Dept of Agriculture",
+            "matches": [
+              "wisconsin department of agriculture",
+              "dept of agriculture",
+              "wisconsin department"
+            ],
+            "domain": "Regulatory",
+            "lane": "regulatory_updates",
+            "priority": "normal"
+          },
+          {
+            "label": "WhatTheAI",
+            "matches": [
+              "whattheai"
+            ],
+            "domain": "AI/Tech",
+            "lane": "machine_signals",
+            "priority": "normal"
+          },
+          {
+            "label": "simple.ai",
+            "matches": [
+              "simple.ai",
+              "simple ai"
+            ],
+            "domain": "AI/Tech",
+            "lane": "machine_signals",
+            "priority": "normal"
+          }
+        ]
+      }
+    ]
+  },
+  "client_workflows": {
+    "status": "active",
+    "items": [
+      {
+        "workflow": "elanpresentation_credit_union_presentations",
+        "primary_inbox": "info@mojosolo.com",
+        "priority": "high",
+        "notes": "This is active client work and should not be treated as generic automation."
+      },
+      {
+        "workflow": "otter_meeting_intel",
+        "primary_inbox": "info@mojosolo.com",
+        "priority": "high",
+        "notes": "Standup and meeting transcripts should feed the daily intelligence layer."
+      }
+    ]
+  },
+  "output_targets": {
+    "status": "active",
+    "targets": [
+      {
+        "name": "daily_intel_notes",
+        "type": "apple_notes",
+        "destination": "Daily Intel",
+        "role": "default_brief_output"
+      },
+      {
+        "name": "laravel_brain_api",
+        "type": "laravel",
+        "destination": "config_brain_plus_database_projection",
+        "role": "primary_application_layer"
+      }
+    ]
+  },
+  "laravel_application": {
+    "status": "intended_primary_app_layer",
+    "config_namespace": "brain",
+    "suggested_models": [
+      "BrainPersona",
+      "BrainDomain",
+      "BrainSourceRule",
+      "BrainOutputTarget"
+    ],
+    "suggested_tables": [
+      "brain_personas",
+      "brain_domains",
+      "brain_source_rules",
+      "brain_output_targets"
+    ],
+    "suggested_routes": [
+      "/api/brain/overview",
+      "/api/brain/personas",
+      "/api/brain/domains",
+      "/api/brain/source-rules",
+      "/api/brain/output-targets"
+    ],
+    "notes": [
+      "Laravel should be the canonical application and API layer for this brain.",
+      "The corpus remains the source of truth; Laravel projects it into config, database, and HTTP surfaces."
+    ]
+  },
+  "machine_ingest_index": {
+    "entity_names": [
+      "MojoSolo",
+      "The Author",
+      "The Operator",
+      "The Machine",
+      "Daily Intel",
+      "ElanPresentation",
+      "Otter.ai"
+    ],
+    "domain_tags": [
+      "email_intelligence",
+      "creative_intake",
+      "client_work",
+      "meeting_intel",
+      "campaign_aliases",
+      "laravel_application_layer"
+    ],
+    "output_tags": [
+      "daily_briefs",
+      "notes",
+      "laravel_api",
+      "seed_data",
+      "operator_dashboard"
+    ]
+  }
+}

--- a/knowledge-corpus/data/mojosolo_operating_brain_report.md
+++ b/knowledge-corpus/data/mojosolo_operating_brain_report.md
@@ -1,0 +1,36 @@
+# MojoSolo Operating Brain
+
+## Executive Summary
+
+This corpus is the canonical operating brain for MojoSolo.
+
+It defines:
+
+- the three inbox personas
+- the signal domains and source rules used for mail intelligence
+- the output targets for Daily Intel
+- Laravel as the primary application and API layer
+
+## Layer Model
+
+1. `knowledge-corpus` is the source of truth.
+2. `mail-intelligence` is the live sensor layer that reads Apple Mail and writes Daily Intel.
+3. Laravel is the primary application layer that should expose the brain through config, database tables, and HTTP routes.
+4. Apple Notes is the default output sink for daily briefs, not the canonical database.
+
+## Personas
+
+- The Author: curated creative and intellectual intake via `mojosolo@mac.com` on the `iCloud` Mail account.
+- The Operator: primary human-facing account via `david@mojosolo.com`.
+- The Machine: catch-all workflow and campaign account via `info@mojosolo.com`.
+
+## Laravel Role
+
+Laravel should project this brain into:
+
+- `config/brain.php`
+- database tables for personas, domains, source rules, and output targets
+- seeders so the brain can be hydrated deterministically
+- HTTP routes for overview, personas, domains, source rules, and output targets
+
+The corpus stays authoritative; Laravel consumes and serves it.

--- a/knowledge-corpus/package-lock.json
+++ b/knowledge-corpus/package-lock.json
@@ -1,32 +1,33 @@
 {
-  "name": "@griches/apple-messages-mcp",
+  "name": "@griches/knowledge-corpus-mcp",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@griches/apple-messages-mcp",
+      "name": "@griches/knowledge-corpus-mcp",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "yaml": "^2.8.1",
         "zod": "^3.24.4"
       },
       "bin": {
-        "apple-messages-mcp": "build/index.js"
+        "knowledge-corpus-mcp": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.15.3",
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -76,9 +77,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
-      "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -429,12 +430,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -590,9 +591,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -641,9 +642,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -671,9 +672,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -1158,6 +1159,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/knowledge-corpus/package.json
+++ b/knowledge-corpus/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@griches/knowledge-corpus-mcp",
+  "version": "1.0.0",
+  "description": "MCP server for querying a bundled knowledge corpus and research report",
+  "main": "build/index.js",
+  "bin": {
+    "knowledge-corpus-mcp": "build/index.js"
+  },
+  "files": [
+    "build/**/*.js",
+    "build/**/*.d.ts",
+    "data/**/*",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node build/index.js",
+    "export:laravel": "npm run build && node build/export-laravel.js",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "knowledge-corpus",
+    "yaml",
+    "research"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/griches/apple-mcp.git",
+    "directory": "knowledge-corpus"
+  },
+  "homepage": "https://github.com/griches/apple-mcp/tree/main/knowledge-corpus",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "yaml": "^2.8.1",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.3",
+    "typescript": "^5.8.3"
+  }
+}

--- a/knowledge-corpus/src/corpus.ts
+++ b/knowledge-corpus/src/corpus.ts
@@ -1,0 +1,553 @@
+import fs from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+
+type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+export type JsonObject = { [key: string]: JsonValue };
+
+export interface MarkdownSection {
+  title: string;
+  slug: string;
+  level: number;
+  content: string;
+}
+
+export interface SearchResult {
+  scope: "corpus" | "report";
+  section: string;
+  location: string;
+  snippet: string;
+  score: number;
+}
+
+interface CorpusBundle {
+  corpus: JsonObject;
+  report: string | null;
+  reportSections: MarkdownSection[];
+  corpusPath: string;
+  reportPath: string | null;
+}
+
+let cache: CorpusBundle | null = null;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asJsonValue(value: unknown): JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => asJsonValue(item));
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, asJsonValue(child)])
+    );
+  }
+
+  return String(value);
+}
+
+function runtimeRoot(): string {
+  return path.resolve(__dirname, "..");
+}
+
+function resolveCorpusPath(): string {
+  return process.env.KNOWLEDGE_CORPUS_PATH
+    ? path.resolve(process.env.KNOWLEDGE_CORPUS_PATH)
+    : path.join(runtimeRoot(), "data", "mojosolo_operating_brain.json");
+}
+
+function resolveReportPath(): string | null {
+  const configuredPath = process.env.KNOWLEDGE_REPORT_PATH;
+  if (configuredPath) {
+    return path.resolve(configuredPath);
+  }
+
+  const defaultReportPath = path.join(runtimeRoot(), "data", "mojosolo_operating_brain_report.md");
+  if (fs.existsSync(defaultReportPath)) {
+    return defaultReportPath;
+  }
+
+  const bundledPath = path.join(runtimeRoot(), "data", "deep-research-report.md");
+  return fs.existsSync(bundledPath) ? bundledPath : null;
+}
+
+function parseStructuredCorpus(filePath: string): JsonObject {
+  const raw = fs.readFileSync(filePath, "utf8");
+  const extension = path.extname(filePath).toLowerCase();
+  const parsed = extension === ".json" ? JSON.parse(raw) : parseYaml(raw);
+
+  if (!isRecord(parsed)) {
+    throw new Error(`Structured corpus at ${filePath} must parse to a top-level object.`);
+  }
+
+  return asJsonValue(parsed) as JsonObject;
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function extractMarkdownSections(markdown: string): MarkdownSection[] {
+  const lines = markdown.split(/\r?\n/);
+  const sections: MarkdownSection[] = [];
+  let currentTitle = "Introduction";
+  let currentLevel = 1;
+  let currentContent: string[] = [];
+
+  const pushSection = () => {
+    const content = currentContent.join("\n").trim();
+    if (!content && currentTitle === "Introduction") {
+      return;
+    }
+
+    sections.push({
+      title: currentTitle,
+      slug: slugify(currentTitle),
+      level: currentLevel,
+      content,
+    });
+  };
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      pushSection();
+      currentLevel = headingMatch[1].length;
+      currentTitle = headingMatch[2].trim();
+      currentContent = [];
+      continue;
+    }
+
+    currentContent.push(line);
+  }
+
+  pushSection();
+  return sections;
+}
+
+function loadBundle(): CorpusBundle {
+  if (cache) {
+    return cache;
+  }
+
+  const corpusPath = resolveCorpusPath();
+  const reportPath = resolveReportPath();
+  const corpus = parseStructuredCorpus(corpusPath);
+  const report = reportPath ? fs.readFileSync(reportPath, "utf8") : null;
+
+  cache = {
+    corpus,
+    report,
+    reportSections: report ? extractMarkdownSections(report) : [],
+    corpusPath,
+    reportPath,
+  };
+
+  return cache;
+}
+
+function normalizeText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function buildSnippet(value: string, query: string, maxLength = 180): string {
+  const normalizedValue = normalizeText(value);
+  if (!normalizedValue) {
+    return normalizedValue;
+  }
+
+  const normalizedQuery = query.toLowerCase();
+  const index = normalizedValue.toLowerCase().indexOf(normalizedQuery);
+  if (index === -1) {
+    return normalizedValue.length <= maxLength
+      ? normalizedValue
+      : `${normalizedValue.slice(0, maxLength - 3).trim()}...`;
+  }
+
+  const start = Math.max(0, index - Math.floor((maxLength - query.length) / 2));
+  const end = Math.min(normalizedValue.length, start + maxLength);
+
+  return `${start > 0 ? "..." : ""}${normalizedValue.slice(start, end).trim()}${end < normalizedValue.length ? "..." : ""}`;
+}
+
+function previewValue(value: JsonValue): string {
+  if (value === null) {
+    return "null";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `Array(${value.length})`;
+  }
+
+  const keys = Object.keys(value);
+  const preview = Object.fromEntries(keys.slice(0, 4).map((key) => [key, value[key]]));
+  return JSON.stringify(preview);
+}
+
+function getSectionNames(): string[] {
+  return Object.keys(loadBundle().corpus);
+}
+
+function resolveSectionName(requestedName: string): string {
+  const names = getSectionNames();
+  const exact = names.find((name) => name === requestedName);
+  if (exact) {
+    return exact;
+  }
+
+  const normalized = requestedName.toLowerCase();
+  const caseInsensitive = names.find((name) => name.toLowerCase() === normalized);
+  if (caseInsensitive) {
+    return caseInsensitive;
+  }
+
+  throw new Error(
+    `Unknown corpus section "${requestedName}". Available sections: ${names.join(", ")}`
+  );
+}
+
+function getSources(): JsonObject[] {
+  const raw = loadBundle().corpus.source_registry;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw.filter((item): item is JsonObject => isRecord(item)).map((item) => item as JsonObject);
+}
+
+function resolveSourceId(requestedId: string): JsonObject {
+  const sources = getSources();
+  const exact = sources.find((source) => source.id === requestedId);
+  if (exact) {
+    return exact;
+  }
+
+  const normalized = requestedId.toLowerCase();
+  const caseInsensitive = sources.find(
+    (source) => typeof source.id === "string" && source.id.toLowerCase() === normalized
+  );
+
+  if (!caseInsensitive) {
+    const availableIds = sources
+      .map((source) => source.id)
+      .filter((id): id is string => typeof id === "string");
+    throw new Error(`Unknown source id "${requestedId}". Available ids: ${availableIds.join(", ")}`);
+  }
+
+  return caseInsensitive;
+}
+
+function resolveReportSection(requestedTitle: string): MarkdownSection {
+  const sections = loadBundle().reportSections;
+  if (!sections.length) {
+    throw new Error("No research report is configured for this corpus.");
+  }
+
+  const requestedSlug = slugify(requestedTitle);
+  const exact = sections.find(
+    (section) => section.title === requestedTitle || section.slug === requestedSlug
+  );
+  if (exact) {
+    return exact;
+  }
+
+  const normalized = requestedTitle.toLowerCase();
+  const partial = sections.find(
+    (section) =>
+      section.title.toLowerCase() === normalized ||
+      section.title.toLowerCase().includes(normalized) ||
+      section.slug.includes(requestedSlug)
+  );
+
+  if (!partial) {
+    const titles = sections.map((section) => section.title);
+    throw new Error(
+      `Unknown report section "${requestedTitle}". Available sections: ${titles.join(", ")}`
+    );
+  }
+
+  return partial;
+}
+
+function scoreMatch(location: string, section: string, query: string, inValue: boolean): number {
+  let score = 0;
+  const normalizedQuery = query.toLowerCase();
+  if (section.toLowerCase().includes(normalizedQuery)) {
+    score += 2;
+  }
+  if (location.toLowerCase().includes(normalizedQuery)) {
+    score += 3;
+  }
+  if (inValue) {
+    score += 2;
+  }
+  return score;
+}
+
+function addMatch(map: Map<string, SearchResult>, result: SearchResult): void {
+  const key = `${result.scope}:${result.section}:${result.location}`;
+  const existing = map.get(key);
+  if (!existing || result.score > existing.score) {
+    map.set(key, result);
+  }
+}
+
+function searchCorpusValue(
+  value: JsonValue,
+  sectionName: string,
+  currentPath: string,
+  query: string,
+  matches: Map<string, SearchResult>
+): void {
+  const normalizedQuery = query.toLowerCase();
+
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    const text = String(value);
+    const locationMatches = currentPath.toLowerCase().includes(normalizedQuery);
+    const valueMatches = text.toLowerCase().includes(normalizedQuery);
+
+    if (locationMatches || valueMatches) {
+      addMatch(matches, {
+        scope: "corpus",
+        section: sectionName,
+        location: currentPath,
+        snippet: buildSnippet(valueMatches ? text : previewValue(value), query),
+        score: scoreMatch(currentPath, sectionName, query, valueMatches),
+      });
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    const locationMatches = currentPath.toLowerCase().includes(normalizedQuery);
+    if (locationMatches) {
+      addMatch(matches, {
+        scope: "corpus",
+        section: sectionName,
+        location: currentPath,
+        snippet: previewValue(value),
+        score: scoreMatch(currentPath, sectionName, query, false),
+      });
+    }
+
+    value.forEach((item, index) => {
+      searchCorpusValue(item, sectionName, `${currentPath}[${index}]`, query, matches);
+    });
+    return;
+  }
+
+  const locationMatches = currentPath.toLowerCase().includes(normalizedQuery);
+  if (locationMatches) {
+    addMatch(matches, {
+      scope: "corpus",
+      section: sectionName,
+      location: currentPath,
+      snippet: previewValue(value),
+      score: scoreMatch(currentPath, sectionName, query, false),
+    });
+  }
+
+  Object.entries(value).forEach(([key, child]) => {
+    const childPath = currentPath ? `${currentPath}.${key}` : key;
+    searchCorpusValue(child, sectionName, childPath, query, matches);
+  });
+}
+
+export function getCorpusOverview(): JsonObject {
+  const bundle = loadBundle();
+  const schema = isRecord(bundle.corpus.schema) ? (bundle.corpus.schema as JsonObject) : {};
+  const machineIngestIndex = isRecord(bundle.corpus.machine_ingest_index)
+    ? (bundle.corpus.machine_ingest_index as JsonObject)
+    : {};
+  const entityNames = Array.isArray(machineIngestIndex.entity_names)
+    ? machineIngestIndex.entity_names.slice(0, 10)
+    : [];
+
+  return {
+    corpus_name: schema.name ?? null,
+    corpus_version: schema.version ?? null,
+    generated_on: schema.generated_on ?? null,
+    target_company: schema.target_company ?? null,
+    target_domain: schema.target_domain ?? null,
+    section_count: getSectionNames().length,
+    sections: getSectionNames(),
+    source_count: getSources().length,
+    report_available: bundle.report !== null,
+    report_section_count: bundle.reportSections.length,
+    machine_ingest_entities: entityNames,
+    corpus_path: bundle.corpusPath,
+    report_path: bundle.reportPath,
+  };
+}
+
+export function listCorpusSections(): JsonObject[] {
+  const corpus = loadBundle().corpus;
+
+  return getSectionNames().map((name) => {
+    const value = corpus[name];
+    const summary: JsonObject = {
+      section: name,
+      type: Array.isArray(value) ? "array" : typeof value,
+    };
+
+    if (Array.isArray(value)) {
+      summary.item_count = value.length;
+      summary.preview = previewValue(value);
+      return summary;
+    }
+
+    if (isRecord(value)) {
+      const keys = Object.keys(value);
+      summary.key_count = keys.length;
+      summary.keys = keys.slice(0, 8);
+
+      if (typeof value.status === "string") {
+        summary.status = value.status;
+      }
+
+      if (Array.isArray(value.evidence_source_ids)) {
+        summary.evidence_source_count = value.evidence_source_ids.length;
+      }
+
+      if (Array.isArray(value.items)) {
+        summary.item_count = value.items.length;
+      }
+
+      if (Array.isArray(value.templates)) {
+        summary.template_count = value.templates.length;
+      }
+
+      if (Array.isArray(value.products)) {
+        summary.product_count = value.products.length;
+      }
+
+      return summary;
+    }
+
+    summary.preview = value ?? null;
+    return summary;
+  });
+}
+
+export function getCorpusSection(sectionName: string): JsonValue {
+  const resolvedName = resolveSectionName(sectionName);
+  return loadBundle().corpus[resolvedName];
+}
+
+export function getObjectSection(sectionName: string): JsonObject {
+  const value = getCorpusSection(sectionName);
+  if (!isRecord(value)) {
+    throw new Error(`Corpus section "${sectionName}" is not an object.`);
+  }
+  return value as JsonObject;
+}
+
+export function getMailIntelligenceConfig(): JsonObject {
+  const value = getCorpusSection("mail_intelligence");
+  if (!isRecord(value)) {
+    throw new Error('Corpus section "mail_intelligence" is not an object.');
+  }
+  return value as JsonObject;
+}
+
+export function searchCorpus(
+  query: string,
+  options?: { scope?: "corpus" | "report" | "all"; section?: string; limit?: number }
+): SearchResult[] {
+  const scope = options?.scope ?? "all";
+  const limit = options?.limit ?? 10;
+  const matches = new Map<string, SearchResult>();
+
+  if (scope === "all" || scope === "corpus") {
+    const sectionNames = options?.section
+      ? [resolveSectionName(options.section)]
+      : getSectionNames();
+
+    sectionNames.forEach((sectionName) => {
+      const sectionValue = loadBundle().corpus[sectionName];
+      searchCorpusValue(sectionValue, sectionName, sectionName, query, matches);
+    });
+  }
+
+  if (scope === "all" || scope === "report") {
+    loadBundle().reportSections.forEach((section) => {
+      const titleMatches = section.title.toLowerCase().includes(query.toLowerCase());
+      const contentMatches = section.content.toLowerCase().includes(query.toLowerCase());
+
+      if (titleMatches || contentMatches) {
+        addMatch(matches, {
+          scope: "report",
+          section: section.title,
+          location: section.title,
+          snippet: buildSnippet(
+            titleMatches ? `${section.title}\n${section.content}` : section.content,
+            query
+          ),
+          score: (titleMatches ? 5 : 0) + (contentMatches ? 2 : 0) + Math.max(0, 3 - section.level),
+        });
+      }
+    });
+  }
+
+  return Array.from(matches.values())
+    .sort((left, right) => right.score - left.score || left.location.localeCompare(right.location))
+    .slice(0, limit);
+}
+
+export function listSources(): JsonObject[] {
+  return getSources().map((source) => ({
+    id: source.id ?? null,
+    title: source.title ?? null,
+    organization: source.organization ?? null,
+    source_class: source.source_class ?? null,
+    role_in_corpus: source.role_in_corpus ?? null,
+    trust_level: source.trust_level ?? null,
+    url: source.url ?? null,
+  }));
+}
+
+export function getSource(sourceId: string): JsonObject {
+  return resolveSourceId(sourceId);
+}
+
+export function listReportSections(): JsonObject[] {
+  return loadBundle().reportSections.map((section) => ({
+    title: section.title,
+    slug: section.slug,
+    level: section.level,
+    word_count: section.content ? section.content.split(/\s+/).filter(Boolean).length : 0,
+  }));
+}
+
+export function getReportSection(title: string): JsonObject {
+  const section = resolveReportSection(title);
+  return {
+    title: section.title,
+    slug: section.slug,
+    level: section.level,
+    content: section.content,
+  };
+}

--- a/knowledge-corpus/src/export-laravel.ts
+++ b/knowledge-corpus/src/export-laravel.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { exportLaravelBrainPack } from "./laravel.js";
+
+const targetDir = process.argv[2]
+  ? path.resolve(process.argv[2])
+  : path.resolve(process.cwd(), "laravel-brain-pack");
+
+const result = exportLaravelBrainPack(targetDir);
+console.log(JSON.stringify(result, null, 2));

--- a/knowledge-corpus/src/index.ts
+++ b/knowledge-corpus/src/index.ts
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import {
+  getCorpusOverview,
+  getCorpusSection,
+  getMailIntelligenceConfig,
+  getReportSection,
+  getSource,
+  listCorpusSections,
+  listReportSections,
+  listSources,
+  searchCorpus,
+} from "./corpus.js";
+import { exportLaravelBrainPack, getLaravelBrainBlueprint } from "./laravel.js";
+
+const server = new McpServer({
+  name: "knowledge-corpus",
+  version: "1.0.0",
+});
+
+function jsonResponse(value: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }] };
+}
+
+function errorResponse(error: unknown) {
+  return {
+    content: [{ type: "text" as const, text: `Error: ${(error as Error).message}` }],
+    isError: true,
+  };
+}
+
+server.registerTool(
+  "get_corpus_overview",
+  {
+    description:
+      "Return corpus metadata, the available top-level sections, source counts, and report availability.",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      return jsonResponse(getCorpusOverview());
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "list_corpus_sections",
+  {
+    description: "List the top-level sections in the structured corpus with lightweight summaries.",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      return jsonResponse(listCorpusSections());
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "get_corpus_section",
+  {
+    description: "Get a full top-level section from the structured corpus by name.",
+    inputSchema: z.object({
+      section: z.string().describe("Top-level section name, for example canonical_profile or source_registry."),
+    }),
+  },
+  async ({ section }) => {
+    try {
+      return jsonResponse(getCorpusSection(section));
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "get_mail_intelligence_config",
+  {
+    description: "Return the mail-intelligence configuration embedded inside the canonical brain corpus.",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      return jsonResponse(getMailIntelligenceConfig());
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "search_corpus",
+  {
+    description:
+      "Search the structured corpus, the attached research report, or both. Returns ranked snippets and locations.",
+    inputSchema: z.object({
+      query: z.string().describe("Case-insensitive text to search for."),
+      scope: z
+        .enum(["corpus", "report", "all"])
+        .default("all")
+        .describe("Choose whether to search only the structured corpus, only the report, or both."),
+      section: z
+        .string()
+        .optional()
+        .describe("Optional top-level corpus section filter. Only applies when searching the structured corpus."),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(25)
+        .default(10)
+        .describe("Maximum number of matches to return."),
+    }),
+  },
+  async ({ query, scope, section, limit }) => {
+    try {
+      return jsonResponse({
+        query,
+        scope,
+        section: section ?? null,
+        results: searchCorpus(query, { scope, section, limit }),
+      });
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "get_laravel_brain_blueprint",
+  {
+    description: "Return a Laravel-ready projection of the canonical brain, including tables, routes, and seed data.",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      return jsonResponse(getLaravelBrainBlueprint());
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "export_laravel_brain_pack",
+  {
+    description: "Write a Laravel integration pack for the canonical brain into a target directory.",
+    inputSchema: z.object({
+      target_dir: z.string().describe("Directory where Laravel config, migrations, seeders, controller, and routes should be written."),
+    }),
+  },
+  async ({ target_dir }) => {
+    try {
+      return jsonResponse(exportLaravelBrainPack(target_dir));
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "list_sources",
+  {
+    description: "List the sources referenced by the corpus, including ids, URLs, and trust levels.",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      return jsonResponse(listSources());
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "get_source",
+  {
+    description: "Return a single source entry from source_registry by id.",
+    inputSchema: z.object({
+      source_id: z.string().describe("Source identifier from source_registry, for example src_aaru_home."),
+    }),
+  },
+  async ({ source_id }) => {
+    try {
+      return jsonResponse(getSource(source_id));
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "list_report_sections",
+  {
+    description: "List the markdown report sections that were bundled with the knowledge corpus.",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      return jsonResponse(listReportSections());
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "get_report_section",
+  {
+    description: "Return a section from the bundled markdown research report by title or slug.",
+    inputSchema: z.object({
+      title: z.string().describe("Report section title or slug, for example executive-summary."),
+    }),
+  },
+  async ({ title }) => {
+    try {
+      return jsonResponse(getReportSection(title));
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("Knowledge Corpus MCP server running on stdio");
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/knowledge-corpus/src/laravel.ts
+++ b/knowledge-corpus/src/laravel.ts
@@ -1,0 +1,403 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  getCorpusOverview,
+  getMailIntelligenceConfig,
+  getObjectSection,
+  type JsonObject,
+  type JsonValue,
+} from "./corpus.js";
+
+interface LaravelTableBlueprint {
+  table: string;
+  columns: Array<{ name: string; type: string; nullable?: boolean; unique?: boolean }>;
+}
+
+function isRecord(value: JsonValue | undefined): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asObject(value: JsonValue | undefined, label: string): JsonObject {
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value;
+}
+
+function asArray(value: JsonValue | undefined, label: string): JsonValue[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array.`);
+  }
+  return value;
+}
+
+function jsonToPhp(value: JsonValue, indent = 0): string {
+  const space = " ".repeat(indent);
+  const next = indent + 4;
+
+  if (value === null) {
+    return "null";
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+
+  if (typeof value === "number") {
+    return String(value);
+  }
+
+  if (typeof value === "string") {
+    return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+  }
+
+  if (Array.isArray(value)) {
+    if (!value.length) {
+      return "[]";
+    }
+
+    const items = value
+      .map((item) => `${" ".repeat(next)}${jsonToPhp(item, next)},`)
+      .join("\n");
+    return `[\n${items}\n${space}]`;
+  }
+
+  const entries = Object.entries(value);
+  if (!entries.length) {
+    return "[]";
+  }
+
+  const lines = entries
+    .map(([key, child]) => `${" ".repeat(next)}'${key}' => ${jsonToPhp(child, next)},`)
+    .join("\n");
+  return `[\n${lines}\n${space}]`;
+}
+
+function getPersonaSeedData(): JsonObject[] {
+  const mailConfig = getMailIntelligenceConfig();
+  const accounts = asArray(mailConfig.accounts, "mail_intelligence.accounts");
+  return accounts.map((accountValue) => {
+    const account = asObject(accountValue, "mail_intelligence.accounts[]");
+    const sourceRules = Array.isArray(account.sourceRules) ? account.sourceRules.length : 0;
+    return {
+      persona_id: account.personaId ?? null,
+      account: account.account ?? null,
+      mailbox: account.mailbox ?? null,
+      persona: account.persona ?? null,
+      role: account.role ?? null,
+      summary: account.summary ?? null,
+      primary_reply_from: account.primaryReplyFrom ?? false,
+      catch_all: account.catchAll ?? false,
+      default_lane: account.defaultLane ?? null,
+      metadata: {
+        source_rule_count: sourceRules,
+      },
+    };
+  });
+}
+
+function getDomainSeedData(): JsonObject[] {
+  const mailConfig = getMailIntelligenceConfig();
+  const domains = asArray(mailConfig.domains, "mail_intelligence.domains");
+  return domains.map((domainValue) => {
+    const domain = asObject(domainValue, "mail_intelligence.domains[]");
+    return {
+      name: domain.name ?? null,
+      matches: domain.matches ?? [],
+    };
+  });
+}
+
+function getSourceRuleSeedData(): JsonObject[] {
+  const mailConfig = getMailIntelligenceConfig();
+  const accounts = asArray(mailConfig.accounts, "mail_intelligence.accounts");
+  return accounts.flatMap((accountValue) => {
+    const account = asObject(accountValue, "mail_intelligence.accounts[]");
+    const rules = Array.isArray(account.sourceRules) ? account.sourceRules : [];
+    return rules.map((ruleValue) => {
+      const rule = asObject(ruleValue as JsonObject, "mail_intelligence.accounts[].sourceRules[]");
+      return {
+        persona_id: account.personaId ?? null,
+        label: rule.label ?? null,
+        matches: rule.matches ?? [],
+        domain: rule.domain ?? null,
+        lane: rule.lane ?? null,
+        priority: rule.priority ?? "normal",
+      };
+    });
+  });
+}
+
+function getOutputTargetSeedData(): JsonObject[] {
+  const outputTargets = getObjectSection("output_targets");
+  const targets = asArray(outputTargets.targets, "output_targets.targets");
+  return targets.map((targetValue) => {
+    const target = asObject(targetValue, "output_targets.targets[]");
+    return {
+      name: target.name ?? null,
+      type: target.type ?? null,
+      destination: target.destination ?? null,
+      role: target.role ?? null,
+      settings: {},
+    };
+  });
+}
+
+function getTableBlueprints(): LaravelTableBlueprint[] {
+  return [
+    {
+      table: "brain_personas",
+      columns: [
+        { name: "id", type: "id" },
+        { name: "persona_id", type: "string", unique: true },
+        { name: "account", type: "string" },
+        { name: "mailbox", type: "string" },
+        { name: "persona", type: "string" },
+        { name: "role", type: "string" },
+        { name: "summary", type: "text", nullable: true },
+        { name: "primary_reply_from", type: "boolean" },
+        { name: "catch_all", type: "boolean" },
+        { name: "default_lane", type: "string" },
+        { name: "metadata", type: "json", nullable: true }
+      ]
+    },
+    {
+      table: "brain_domains",
+      columns: [
+        { name: "id", type: "id" },
+        { name: "name", type: "string", unique: true },
+        { name: "matches", type: "json" }
+      ]
+    },
+    {
+      table: "brain_source_rules",
+      columns: [
+        { name: "id", type: "id" },
+        { name: "persona_id", type: "string" },
+        { name: "label", type: "string" },
+        { name: "matches", type: "json" },
+        { name: "domain", type: "string" },
+        { name: "lane", type: "string" },
+        { name: "priority", type: "string" }
+      ]
+    },
+    {
+      table: "brain_output_targets",
+      columns: [
+        { name: "id", type: "id" },
+        { name: "name", type: "string", unique: true },
+        { name: "type", type: "string" },
+        { name: "destination", type: "string" },
+        { name: "role", type: "string" },
+        { name: "settings", type: "json", nullable: true }
+      ]
+    }
+  ];
+}
+
+export function getLaravelBrainBlueprint(): JsonObject {
+  const schema = getObjectSection("schema");
+  const profile = getObjectSection("canonical_profile");
+  const laravel = getObjectSection("laravel_application");
+
+  return {
+    corpus: getCorpusOverview(),
+    config_namespace: laravel.config_namespace ?? "brain",
+    package_name: schema.name ?? null,
+    application_role: profile.primary_application_layer ?? null,
+    tables: getTableBlueprints() as unknown as JsonValue,
+    seed_data: {
+      personas: getPersonaSeedData(),
+      domains: getDomainSeedData(),
+      source_rules: getSourceRuleSeedData(),
+      output_targets: getOutputTargetSeedData(),
+    },
+    routes: laravel.suggested_routes ?? [],
+    models: laravel.suggested_models ?? [],
+  };
+}
+
+function renderMigration(): string {
+  return `<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('brain_personas', function (Blueprint $table): void {
+            $table->id();
+            $table->string('persona_id')->unique();
+            $table->string('account');
+            $table->string('mailbox');
+            $table->string('persona');
+            $table->string('role');
+            $table->text('summary')->nullable();
+            $table->boolean('primary_reply_from')->default(false);
+            $table->boolean('catch_all')->default(false);
+            $table->string('default_lane');
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('brain_domains', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name')->unique();
+            $table->json('matches');
+            $table->timestamps();
+        });
+
+        Schema::create('brain_source_rules', function (Blueprint $table): void {
+            $table->id();
+            $table->string('persona_id');
+            $table->string('label');
+            $table->json('matches');
+            $table->string('domain');
+            $table->string('lane');
+            $table->string('priority')->default('normal');
+            $table->timestamps();
+        });
+
+        Schema::create('brain_output_targets', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('type');
+            $table->string('destination');
+            $table->string('role');
+            $table->json('settings')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('brain_output_targets');
+        Schema::dropIfExists('brain_source_rules');
+        Schema::dropIfExists('brain_domains');
+        Schema::dropIfExists('brain_personas');
+    }
+};
+`;
+}
+
+function renderSeeder(): string {
+  const blueprint = getLaravelBrainBlueprint();
+  const seedData = asObject(blueprint.seed_data, "seed_data");
+
+  return `<?php
+
+namespace Database\\Seeders;
+
+use Illuminate\\Database\\Seeder;
+use Illuminate\\Support\\Facades\\DB;
+
+class BrainSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('brain_personas')->truncate();
+        DB::table('brain_domains')->truncate();
+        DB::table('brain_source_rules')->truncate();
+        DB::table('brain_output_targets')->truncate();
+
+        DB::table('brain_personas')->insert(${jsonToPhp(seedData.personas ?? [], 8)});
+        DB::table('brain_domains')->insert(${jsonToPhp(seedData.domains ?? [], 8)});
+        DB::table('brain_source_rules')->insert(${jsonToPhp(seedData.source_rules ?? [], 8)});
+        DB::table('brain_output_targets')->insert(${jsonToPhp(seedData.output_targets ?? [], 8)});
+    }
+}
+`;
+}
+
+function renderConfig(): string {
+  const blueprint = getLaravelBrainBlueprint();
+  return `<?php
+
+return ${jsonToPhp(blueprint, 0)};
+`;
+}
+
+function renderController(): string {
+  return `<?php
+
+namespace App\\Http\\Controllers;
+
+use Illuminate\\Http\\JsonResponse;
+use Illuminate\\Support\\Facades\\Config;
+use Illuminate\\Support\\Facades\\DB;
+
+class BrainController extends Controller
+{
+    public function overview(): JsonResponse
+    {
+        return response()->json(Config::get('brain'));
+    }
+
+    public function personas(): JsonResponse
+    {
+        return response()->json(DB::table('brain_personas')->orderBy('persona')->get());
+    }
+
+    public function domains(): JsonResponse
+    {
+        return response()->json(DB::table('brain_domains')->orderBy('name')->get());
+    }
+
+    public function sourceRules(): JsonResponse
+    {
+        return response()->json(DB::table('brain_source_rules')->orderBy('persona_id')->orderBy('label')->get());
+    }
+
+    public function outputTargets(): JsonResponse
+    {
+        return response()->json(DB::table('brain_output_targets')->orderBy('name')->get());
+    }
+}
+`;
+}
+
+function renderRoutes(): string {
+  return `<?php
+
+use App\\Http\\Controllers\\BrainController;
+use Illuminate\\Support\\Facades\\Route;
+
+Route::prefix('brain')->group(function (): void {
+    Route::get('overview', [BrainController::class, 'overview']);
+    Route::get('personas', [BrainController::class, 'personas']);
+    Route::get('domains', [BrainController::class, 'domains']);
+    Route::get('source-rules', [BrainController::class, 'sourceRules']);
+    Route::get('output-targets', [BrainController::class, 'outputTargets']);
+});
+`;
+}
+
+function writeFile(targetPath: string, contents: string): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, contents, "utf8");
+}
+
+export function exportLaravelBrainPack(targetDir: string): JsonObject {
+  const resolvedTarget = path.resolve(targetDir);
+  const writtenFiles = [
+    path.join(resolvedTarget, "config", "brain.php"),
+    path.join(resolvedTarget, "database", "migrations", "2026_03_12_000000_create_brain_tables.php"),
+    path.join(resolvedTarget, "database", "seeders", "BrainSeeder.php"),
+    path.join(resolvedTarget, "app", "Http", "Controllers", "BrainController.php"),
+    path.join(resolvedTarget, "routes", "brain.php"),
+  ];
+
+  writeFile(writtenFiles[0], renderConfig());
+  writeFile(writtenFiles[1], renderMigration());
+  writeFile(writtenFiles[2], renderSeeder());
+  writeFile(writtenFiles[3], renderController());
+  writeFile(writtenFiles[4], renderRoutes());
+
+  return {
+    target_dir: resolvedTarget,
+    written_files: writtenFiles,
+  };
+}

--- a/knowledge-corpus/tsconfig.json
+++ b/knowledge-corpus/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./build",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "build", "tests"]
+}

--- a/mail-intelligence/README.md
+++ b/mail-intelligence/README.md
@@ -1,0 +1,90 @@
+# Apple Mail Intelligence MCP Server
+
+An MCP server for the three-persona inbox architecture:
+
+- `mojosolo@mac.com` -> The Author
+- `david@mojosolo.com` -> The Operator
+- `info@mojosolo.com` -> The Machine
+
+It reads configured Apple Mail accounts, classifies signals into domains and lanes, and generates a Notes-first "Daily Intel" brief.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `discover_mail_accounts` | List Apple Mail account object names and email addresses present on the machine |
+| `get_persona_map` | Return the configured persona/account map and output settings |
+| `scan_persona_inboxes` | Scan recent mail and classify messages by persona, domain, lane, and priority |
+| `analyze_signal_trends` | Compare cumulative signal distributions across windows such as 30/60/90 days |
+| `generate_daily_brief` | Build the Daily Intel brief and optionally save it to Apple Notes |
+
+If Apple Notes automation is unavailable or slow on the local machine, `generate_daily_brief` still returns the brief HTML and summary with `note_status: "not_saved"` plus `note_error`.
+
+## Requirements
+
+- macOS
+- Node.js 18+
+- Apple Mail running with the configured accounts available
+- Apple Notes running if you want to save briefs there
+
+## Quick Start
+
+```bash
+cd mail-intelligence
+npm install
+npm run build
+node build/index.js
+```
+
+### Claude Code
+
+```bash
+claude mcp add apple-mail-intelligence -- node /absolute/path/to/apple-mcp/mail-intelligence/build/index.js
+```
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "apple-mail-intelligence": {
+      "command": "node",
+      "args": ["/absolute/path/to/apple-mcp/mail-intelligence/build/index.js"]
+    }
+  }
+}
+```
+
+## Configuration
+
+The server loads its defaults from the canonical brain at `knowledge-corpus/data/mojosolo_operating_brain.json`.
+
+Set `MAIL_INTELLIGENCE_CONFIG_PATH` to use a different config file or a different corpus file:
+
+```bash
+MAIL_INTELLIGENCE_CONFIG_PATH=/absolute/path/to/custom-mail-intel.json \
+node build/index.js
+```
+
+The canonical brain encodes the current three-persona model:
+
+- `mojosolo@mac.com` is curated creative intake.
+- `david@mojosolo.com` is the primary human-facing operator inbox.
+- `info@mojosolo.com` is the catch-all machine inbox for campaigns, client workflows, meeting intel, and alerts.
+
+If Apple Mail uses account object names like `iCloud` or `Google` instead of the raw email address, use `discover_mail_accounts` first. The server also tries to resolve configured accounts by matching either account name or one of the account's email addresses.
+
+The default mailbox for each persona is `INBOX`. If your Apple Mail setup uses a different mailbox object name, change the `mailbox` field in the config.
+
+## Default Output
+
+- Apple Notes folder: `Daily Intel`
+- Note title format: `Daily Intel - YYYY-MM-DD`
+
+## Example Queries
+
+- "Show me the persona map"
+- "Show me the Apple Mail accounts on this machine"
+- "Scan the last day of inbox intelligence"
+- "Compare signals over 30, 60, and 90 days"
+- "Generate today's Daily Intel and save it to Notes"

--- a/mail-intelligence/package-lock.json
+++ b/mail-intelligence/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@griches/apple-messages-mcp",
+  "name": "@griches/apple-mail-intelligence-mcp",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@griches/apple-messages-mcp",
+      "name": "@griches/apple-mail-intelligence-mcp",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -13,20 +13,20 @@
         "zod": "^3.24.4"
       },
       "bin": {
-        "apple-messages-mcp": "build/index.js"
+        "apple-mail-intelligence-mcp": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.15.3",
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
-      "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -429,12 +429,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -590,9 +590,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -641,9 +641,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -671,9 +671,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/mail-intelligence/package.json
+++ b/mail-intelligence/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@griches/apple-mail-intelligence-mcp",
+  "version": "1.0.0",
+  "description": "MCP server for three-persona mail intelligence briefs powered by Apple Mail and Apple Notes",
+  "main": "build/index.js",
+  "bin": {
+    "apple-mail-intelligence-mcp": "build/index.js"
+  },
+  "files": [
+    "build/**/*.js",
+    "build/**/*.d.ts",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node build/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "apple-mail",
+    "apple-notes",
+    "intelligence",
+    "email"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/griches/apple-mcp.git",
+    "directory": "mail-intelligence"
+  },
+  "homepage": "https://github.com/griches/apple-mcp/tree/main/mail-intelligence",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.3",
+    "typescript": "^5.8.3"
+  }
+}

--- a/mail-intelligence/src/config.ts
+++ b/mail-intelligence/src/config.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import path from "node:path";
+import { z } from "zod";
+
+const sourceRuleSchema = z.object({
+  label: z.string(),
+  matches: z.array(z.string()).min(1),
+  domain: z.string(),
+  lane: z.string(),
+  priority: z.enum(["high", "normal"]).default("normal"),
+});
+
+const accountSchema = z.object({
+  account: z.string(),
+  mailbox: z.string().default("INBOX"),
+  personaId: z.string(),
+  persona: z.string(),
+  role: z.string(),
+  summary: z.string(),
+  primaryReplyFrom: z.boolean().default(false),
+  catchAll: z.boolean().default(false),
+  defaultLane: z.string(),
+  sourceRules: z.array(sourceRuleSchema).default([]),
+});
+
+const domainSchema = z.object({
+  name: z.string(),
+  matches: z.array(z.string()).min(1),
+});
+
+const configSchema = z.object({
+  notes: z.object({
+    folder: z.string(),
+    titlePrefix: z.string(),
+    defaultLookbackDays: z.number().int().min(1).default(1),
+    defaultLimitPerAccount: z.number().int().min(1).default(20),
+  }),
+  scoring: z.object({
+    urgentSubjectKeywords: z.array(z.string()).default([]),
+    automatedSenderKeywords: z.array(z.string()).default([]),
+    newsletterKeywords: z.array(z.string()).default([]),
+    humanReplyKeywords: z.array(z.string()).default([]),
+  }),
+  domains: z.array(domainSchema),
+  accounts: z.array(accountSchema).min(1),
+});
+
+export type IntelligenceConfig = z.infer<typeof configSchema>;
+export type IntelligenceAccount = IntelligenceConfig["accounts"][number];
+export type SourceRule = IntelligenceAccount["sourceRules"][number];
+
+let cache: IntelligenceConfig | null = null;
+
+function runtimeRoot(): string {
+  return path.resolve(__dirname, "..");
+}
+
+function resolveConfigPath(): string {
+  return process.env.MAIL_INTELLIGENCE_CONFIG_PATH
+    ? path.resolve(process.env.MAIL_INTELLIGENCE_CONFIG_PATH)
+    : path.resolve(runtimeRoot(), "..", "knowledge-corpus", "data", "mojosolo_operating_brain.json");
+}
+
+export function loadConfig(): IntelligenceConfig {
+  if (cache) {
+    return cache;
+  }
+
+  const configPath = resolveConfigPath();
+  const raw = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  const candidate = raw.mail_intelligence ?? raw;
+  cache = configSchema.parse(candidate);
+  return cache;
+}
+
+export function getConfigSummary() {
+  const config = loadConfig();
+  return {
+    config_path: resolveConfigPath(),
+    note_output: config.notes,
+    accounts: config.accounts.map((account) => ({
+      account: account.account,
+      persona: account.persona,
+      persona_id: account.personaId,
+      role: account.role,
+      primary_reply_from: account.primaryReplyFrom,
+      catch_all: account.catchAll,
+      default_lane: account.defaultLane,
+      source_rule_count: account.sourceRules.length,
+    })),
+    domains: config.domains.map((domain) => domain.name),
+  };
+}

--- a/mail-intelligence/src/index.ts
+++ b/mail-intelligence/src/index.ts
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { getConfigSummary } from "./config.js";
+import { analyzeSignalTrends, generateDailyBrief, scanPersonaInboxes } from "./intelligence.js";
+import { listAccounts } from "./mail.js";
+
+const server = new McpServer({
+  name: "apple-mail-intelligence",
+  version: "1.0.0",
+});
+
+function jsonResponse(value: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }] };
+}
+
+function errorResponse(error: unknown) {
+  return {
+    content: [{ type: "text" as const, text: `Error: ${(error as Error).message}` }],
+    isError: true,
+  };
+}
+
+server.registerTool(
+  "discover_mail_accounts",
+  {
+    description:
+      "List Apple Mail account object names and their configured email addresses so persona config can be aligned to the local Mail setup.",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      return jsonResponse(await listAccounts());
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "get_persona_map",
+  {
+    description: "Return the configured three-persona inbox map, note output settings, and domain taxonomy.",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      return jsonResponse(getConfigSummary());
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "scan_persona_inboxes",
+  {
+    description:
+      "Read the configured Apple Mail accounts, classify recent messages by persona/domain/lane, and return ranked signals.",
+    inputSchema: z.object({
+      lookback_days: z.number().int().min(1).max(365).optional().describe("How many days back to scan."),
+      limit_per_account: z.number().int().min(1).max(250).optional().describe("Maximum messages to inspect per account."),
+      include_snippets: z.boolean().optional().describe("Fetch message content snippets for richer summaries."),
+    }),
+  },
+  async ({ lookback_days, limit_per_account, include_snippets }) => {
+    try {
+      return jsonResponse(
+        await scanPersonaInboxes({
+          lookbackDays: lookback_days,
+          limitPerAccount: limit_per_account,
+          includeSnippets: include_snippets,
+        })
+      );
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "analyze_signal_trends",
+  {
+    description:
+      "Compare cumulative signal distributions over multiple time windows such as 30, 60, and 90 days.",
+    inputSchema: z.object({
+      windows: z.array(z.number().int().min(1).max(365)).optional().describe("Time windows in days, for example [30, 60, 90]."),
+      limit_per_account: z.number().int().min(1).max(250).optional().describe("Maximum messages to inspect per account for each window."),
+    }),
+  },
+  async ({ windows, limit_per_account }) => {
+    try {
+      return jsonResponse(
+        await analyzeSignalTrends({
+          windows,
+          limitPerAccount: limit_per_account,
+        })
+      );
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+server.registerTool(
+  "generate_daily_brief",
+  {
+    description:
+      "Generate a Superhuman-style Daily Intel brief from the configured inbox personas and optionally save it to Apple Notes.",
+    inputSchema: z.object({
+      lookback_days: z.number().int().min(1).max(30).optional().describe("How many recent days to include in the brief."),
+      limit_per_account: z.number().int().min(1).max(100).optional().describe("Maximum messages to inspect per account."),
+      save_to_notes: z.boolean().optional().describe("If true or omitted, write the brief into Apple Notes."),
+    }),
+  },
+  async ({ lookback_days, limit_per_account, save_to_notes }) => {
+    try {
+      return jsonResponse(
+        await generateDailyBrief({
+          lookbackDays: lookback_days,
+          limitPerAccount: limit_per_account,
+          saveToNotes: save_to_notes,
+        })
+      );
+    } catch (error) {
+      return errorResponse(error);
+    }
+  }
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("Apple Mail Intelligence MCP server running on stdio");
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/mail-intelligence/src/intelligence.ts
+++ b/mail-intelligence/src/intelligence.ts
@@ -1,0 +1,539 @@
+import { loadConfig, type IntelligenceAccount, type SourceRule } from "./config.js";
+import { getMessageContent, listMessagesSince } from "./mail.js";
+import { upsertNote } from "./notes.js";
+
+export interface ClassifiedMessage {
+  account: string;
+  mailbox: string;
+  personaId: string;
+  persona: string;
+  role: string;
+  id: number;
+  subject: string;
+  sender: string;
+  senderName: string;
+  senderEmail: string | null;
+  date: string;
+  isRead: boolean;
+  snippet: string;
+  domain: string;
+  lane: string;
+  sourceLabel: string | null;
+  priority: "high" | "medium" | "low";
+  score: number;
+}
+
+interface ScanOptions {
+  lookbackDays?: number;
+  limitPerAccount?: number;
+  includeSnippets?: boolean;
+}
+
+interface LaneSummary {
+  lane: string;
+  count: number;
+  high_priority: number;
+  top_messages: ClassifiedMessage[];
+}
+
+interface PersonaSummary {
+  account: string;
+  persona: string;
+  persona_id: string;
+  role: string;
+  total_messages: number;
+  high_priority: number;
+  domains: { domain: string; count: number }[];
+  lanes: LaneSummary[];
+}
+
+export interface ScanSummary {
+  lookback_days: number;
+  limit_per_account: number;
+  total_messages: number;
+  personas: PersonaSummary[];
+  top_signals: ClassifiedMessage[];
+}
+
+interface RawScanResult {
+  scanned: Array<{ account: IntelligenceAccount; messages: ClassifiedMessage[] }>;
+  allMessages: ClassifiedMessage[];
+  options: Required<ScanOptions>;
+}
+
+export interface BriefResult {
+  note_title: string;
+  note_folder: string;
+  note_status: "created" | "updated" | "not_saved";
+  note_error?: string;
+  summary: ScanSummary;
+  html: string;
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&#39;/gi, "'")
+    .replace(/&quot;/gi, '"');
+}
+
+function toSnippet(value: string, maxLength = 220): string {
+  const normalized = normalizeWhitespace(stripHtml(value));
+  if (!normalized) {
+    return "";
+  }
+  return normalized.length <= maxLength
+    ? normalized
+    : `${normalized.slice(0, maxLength - 3).trim()}...`;
+}
+
+function parseSender(value: string): { name: string; email: string | null } {
+  const trimmed = normalizeWhitespace(value);
+  const angleMatch = trimmed.match(/^(.*?)(?:\s*<([^>]+)>)$/);
+  if (angleMatch) {
+    return {
+      name: angleMatch[1].trim() || angleMatch[2].trim(),
+      email: angleMatch[2].trim().toLowerCase(),
+    };
+  }
+
+  const plainEmailMatch = trimmed.match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+  if (plainEmailMatch) {
+    return { name: trimmed.replace(plainEmailMatch[0], "").trim() || plainEmailMatch[0], email: plainEmailMatch[0].toLowerCase() };
+  }
+
+  return { name: trimmed, email: null };
+}
+
+function includesAny(haystack: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => haystack.includes(pattern.toLowerCase()));
+}
+
+function findSourceRule(account: IntelligenceAccount, haystack: string): SourceRule | null {
+  return account.sourceRules.find((rule) => includesAny(haystack, rule.matches)) ?? null;
+}
+
+function inferDomain(account: IntelligenceAccount, haystack: string, sourceRule: SourceRule | null): string {
+  if (sourceRule) {
+    return sourceRule.domain;
+  }
+
+  const config = loadConfig();
+  const match = config.domains.find((domain) => includesAny(haystack, domain.matches));
+  if (match) {
+    return match.name;
+  }
+
+  if (account.personaId === "author") {
+    return "Creative/Strategic";
+  }
+  if (account.personaId === "operator") {
+    return "Human/Operations";
+  }
+  return "Machine Signals";
+}
+
+function inferLane(
+  account: IntelligenceAccount,
+  haystack: string,
+  sourceRule: SourceRule | null,
+  senderEmail: string | null
+): string {
+  if (sourceRule) {
+    return sourceRule.lane;
+  }
+
+  const config = loadConfig();
+  const senderText = `${haystack} ${senderEmail ?? ""}`;
+  const automated = includesAny(senderText, config.scoring.automatedSenderKeywords) || includesAny(haystack, config.scoring.newsletterKeywords);
+  const humanish = includesAny(haystack, config.scoring.humanReplyKeywords);
+
+  if (account.personaId === "author") {
+    return "creative_intake";
+  }
+
+  if (account.personaId === "operator") {
+    return automated && !humanish ? "ops_signals" : "human_replies_required";
+  }
+
+  return automated ? "machine_signals" : "campaign_inbound";
+}
+
+function scoreMessage(
+  account: IntelligenceAccount,
+  subject: string,
+  haystack: string,
+  sourceRule: SourceRule | null,
+  lane: string,
+  isRead: boolean
+): number {
+  const config = loadConfig();
+  let score = 0;
+
+  if (!isRead) {
+    score += 1;
+  }
+  if (sourceRule?.priority === "high") {
+    score += 3;
+  } else if (sourceRule) {
+    score += 1;
+  }
+  if (includesAny(subject.toLowerCase(), config.scoring.urgentSubjectKeywords)) {
+    score += 2;
+  }
+  if (account.primaryReplyFrom && lane === "human_replies_required") {
+    score += 2;
+  }
+  if (lane === "client_work" || lane === "meeting_intel" || lane === "platform_alerts") {
+    score += 2;
+  }
+  return score;
+}
+
+function toPriority(score: number): "high" | "medium" | "low" {
+  if (score >= 6) {
+    return "high";
+  }
+  if (score >= 3) {
+    return "medium";
+  }
+  return "low";
+}
+
+function sortMessages(messages: ClassifiedMessage[]): ClassifiedMessage[] {
+  return [...messages].sort((left, right) => right.score - left.score || left.subject.localeCompare(right.subject));
+}
+
+async function scanAccount(account: IntelligenceAccount, options: Required<ScanOptions>): Promise<ClassifiedMessage[]> {
+  const summaries = await listMessagesSince(
+    account.mailbox,
+    account.account,
+    options.lookbackDays,
+    options.limitPerAccount
+  );
+
+  const results: ClassifiedMessage[] = [];
+
+  for (const summary of summaries) {
+    let snippet = "";
+    if (options.includeSnippets) {
+      try {
+        snippet = toSnippet(await getMessageContent(account.mailbox, account.account, summary.id));
+      } catch {
+        snippet = "";
+      }
+    }
+
+    const parsedSender = parseSender(summary.sender);
+    const haystack = normalizeWhitespace(
+      `${summary.subject} ${summary.sender} ${parsedSender.email ?? ""} ${snippet}`
+    ).toLowerCase();
+    const sourceRule = findSourceRule(account, haystack);
+    const domain = inferDomain(account, haystack, sourceRule);
+    const lane = inferLane(account, haystack, sourceRule, parsedSender.email);
+    const score = scoreMessage(account, summary.subject, haystack, sourceRule, lane, summary.isRead);
+
+    results.push({
+      account: account.account,
+      mailbox: account.mailbox,
+      personaId: account.personaId,
+      persona: account.persona,
+      role: account.role,
+      id: summary.id,
+      subject: summary.subject,
+      sender: summary.sender,
+      senderName: parsedSender.name,
+      senderEmail: parsedSender.email,
+      date: summary.date,
+      isRead: summary.isRead,
+      snippet,
+      domain,
+      lane,
+      sourceLabel: sourceRule?.label ?? null,
+      priority: toPriority(score),
+      score,
+    });
+  }
+
+  return sortMessages(results);
+}
+
+function countBy<T extends string>(values: T[]): { name: T; count: number }[] {
+  const counts = new Map<T, number>();
+  values.forEach((value) => counts.set(value, (counts.get(value) ?? 0) + 1));
+  return Array.from(counts.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((left, right) => right.count - left.count || left.name.localeCompare(right.name));
+}
+
+function summarizePersona(account: IntelligenceAccount, messages: ClassifiedMessage[]): PersonaSummary {
+  const domains = countBy(messages.map((message) => message.domain)).map((item) => ({
+    domain: item.name,
+    count: item.count,
+  }));
+
+  const lanes = countBy(messages.map((message) => message.lane)).map((item) => {
+    const laneMessages = messages.filter((message) => message.lane === item.name);
+    return {
+      lane: item.name,
+      count: item.count,
+      high_priority: laneMessages.filter((message) => message.priority === "high").length,
+      top_messages: laneMessages.slice(0, 4),
+    };
+  });
+
+  return {
+    account: account.account,
+    persona: account.persona,
+    persona_id: account.personaId,
+    role: account.role,
+    total_messages: messages.length,
+    high_priority: messages.filter((message) => message.priority === "high").length,
+    domains,
+    lanes,
+  };
+}
+
+export async function scanPersonaInboxes(options?: ScanOptions): Promise<ScanSummary> {
+  const config = loadConfig();
+  const resolvedOptions: Required<ScanOptions> = {
+    lookbackDays: options?.lookbackDays ?? config.notes.defaultLookbackDays,
+    limitPerAccount: options?.limitPerAccount ?? config.notes.defaultLimitPerAccount,
+    includeSnippets: options?.includeSnippets ?? true,
+  };
+
+  const raw = await scanAllAccounts(resolvedOptions);
+  const personas = raw.scanned.map(({ account, messages }) => summarizePersona(account, messages));
+
+  return {
+    lookback_days: raw.options.lookbackDays,
+    limit_per_account: raw.options.limitPerAccount,
+    total_messages: raw.allMessages.length,
+    personas,
+    top_signals: raw.allMessages.slice(0, 8),
+  };
+}
+
+async function scanAllAccounts(options: Required<ScanOptions>): Promise<RawScanResult> {
+  const config = loadConfig();
+  // Sequential - concurrent AppleScript calls deadlock/timeout under osascript
+  const scanned: Array<{ account: IntelligenceAccount; messages: ClassifiedMessage[] }> = [];
+  for (const account of config.accounts) {
+    scanned.push({ account, messages: await scanAccount(account, options) });
+  }
+  const allMessages = sortMessages(scanned.flatMap((entry) => entry.messages));
+
+  return {
+    scanned,
+    allMessages,
+    options,
+  };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatSignal(message: ClassifiedMessage): string {
+  const source = message.sourceLabel ?? message.senderName;
+  const snippet = message.snippet ? ` - ${message.snippet}` : "";
+  return `<strong>${escapeHtml(source)}</strong>: ${escapeHtml(message.subject)}${escapeHtml(snippet)}`;
+}
+
+function buildBriefHtml(summary: ScanSummary): string {
+  const config = loadConfig();
+  const today = new Date().toISOString().slice(0, 10);
+  const personaSections = summary.personas
+    .map((persona) => {
+      const laneSections = persona.lanes
+        .filter((lane) => lane.count > 0)
+        .map((lane) => {
+          const items = lane.top_messages.map((message) => `<li>${formatSignal(message)}</li>`).join("");
+          return `<h3>${escapeHtml(lane.lane)}</h3><ul>${items}</ul>`;
+        })
+        .join("");
+
+      const domainSummary = persona.domains
+        .slice(0, 3)
+        .map((domain) => `${domain.domain} (${domain.count})`)
+        .join(", ");
+
+      return `
+        <h2>${escapeHtml(persona.persona)} - ${escapeHtml(persona.account)}</h2>
+        <p>${escapeHtml(persona.role)}. ${escapeHtml(persona.total_messages.toString())} messages scanned, ${escapeHtml(persona.high_priority.toString())} high-priority. Top domains: ${escapeHtml(domainSummary || "none")}.</p>
+        ${laneSections}
+      `;
+    })
+    .join("");
+
+  const tlDr = summary.top_signals
+    .slice(0, 5)
+    .map((message) => `<li>[${escapeHtml(message.persona)} / ${escapeHtml(message.domain)}] ${formatSignal(message)}</li>`)
+    .join("");
+
+  return `
+    <h1>${escapeHtml(config.notes.titlePrefix)} - ${today}</h1>
+    <p>Generated from ${escapeHtml(summary.personas.length.toString())} inbox personas and ${escapeHtml(summary.total_messages.toString())} recent messages.</p>
+    <h2>TL;DR</h2>
+    <ul>${tlDr}</ul>
+    ${personaSections}
+  `.trim();
+}
+
+const MAX_BRIEF_SNIPPETS = 8;
+const MAX_BRIEF_SNIPPET_BUDGET_MS = 15_000;
+
+/** Fetch snippets only for messages that will appear in the brief. Keeps the brief responsive when Mail body reads stall. */
+async function fetchSnippetsForDisplaySet(summary: ScanSummary): Promise<void> {
+  const seen = new Set<number>();
+  const toFetch: ClassifiedMessage[] = [];
+
+  for (const msg of summary.top_signals) {
+    if (!seen.has(msg.id)) {
+      seen.add(msg.id);
+      toFetch.push(msg);
+    }
+  }
+  for (const persona of summary.personas) {
+    for (const lane of persona.lanes) {
+      for (const msg of lane.top_messages) {
+        if (!seen.has(msg.id)) {
+          seen.add(msg.id);
+          toFetch.push(msg);
+        }
+      }
+    }
+  }
+
+  const deadline = Date.now() + MAX_BRIEF_SNIPPET_BUDGET_MS;
+  for (const [index, msg] of toFetch.entries()) {
+    if (index >= MAX_BRIEF_SNIPPETS || Date.now() >= deadline) {
+      msg.snippet = "";
+      continue;
+    }
+
+    try {
+      msg.snippet = toSnippet(await getMessageContent(msg.mailbox, msg.account, msg.id));
+    } catch {
+      msg.snippet = "";
+    }
+  }
+}
+
+export async function generateDailyBrief(options?: {
+  lookbackDays?: number;
+  limitPerAccount?: number;
+  saveToNotes?: boolean;
+}): Promise<BriefResult> {
+  const config = loadConfig();
+  // Scan without snippets first - classification uses subject+sender; snippets are only needed for display
+  const summary = await scanPersonaInboxes({
+    lookbackDays: options?.lookbackDays ?? config.notes.defaultLookbackDays,
+    limitPerAccount: options?.limitPerAccount ?? config.notes.defaultLimitPerAccount,
+    includeSnippets: false,
+  });
+
+  await fetchSnippetsForDisplaySet(summary);
+
+  const date = new Date().toISOString().slice(0, 10);
+  const noteTitle = `${config.notes.titlePrefix} - ${date}`;
+  const html = buildBriefHtml(summary);
+
+  let noteStatus: "created" | "updated" | "not_saved" = "not_saved";
+  let noteError: string | undefined;
+  if (options?.saveToNotes ?? true) {
+    try {
+      noteStatus = await upsertNote(noteTitle, html, config.notes.folder);
+    } catch (error) {
+      noteError = (error as Error).message;
+    }
+  }
+
+  return {
+    note_title: noteTitle,
+    note_folder: config.notes.folder,
+    note_status: noteStatus,
+    note_error: noteError,
+    summary,
+    html,
+  };
+}
+
+export async function analyzeSignalTrends(options?: {
+  windows?: number[];
+  limitPerAccount?: number;
+}): Promise<{
+  windows: Array<{
+    days: number;
+    total_messages: number;
+    top_domains: { domain: string; count: number }[];
+    top_lanes: { lane: string; count: number }[];
+    top_sources: { source: string; count: number }[];
+  }>;
+}> {
+  const config = loadConfig();
+  const windows = (options?.windows?.length ? options.windows : [30, 60, 90])
+    .map((days) => Math.max(1, Math.floor(days)));
+
+  const analyses = [];
+
+  for (const days of windows) {
+    const raw = await scanAllAccounts({
+      lookbackDays: days,
+      limitPerAccount: options?.limitPerAccount ?? Math.max(config.notes.defaultLimitPerAccount, 80),
+      includeSnippets: false,
+    });
+    const summary = {
+      total_messages: raw.allMessages.length,
+      personas: raw.scanned.map(({ account, messages }) => summarizePersona(account, messages)),
+    };
+    const allMessages = raw.allMessages;
+
+    const topDomains = countBy(
+      summary.personas.flatMap((persona) =>
+        persona.domains.flatMap((domain) => Array.from({ length: domain.count }, () => domain.domain))
+      )
+    )
+      .slice(0, 5)
+      .map((item) => ({ domain: item.name, count: item.count }));
+
+    const topLanes = countBy(
+      summary.personas.flatMap((persona) =>
+        persona.lanes.flatMap((lane) => Array.from({ length: lane.count }, () => lane.lane))
+      )
+    )
+      .slice(0, 5)
+      .map((item) => ({ lane: item.name, count: item.count }));
+
+    const topSources = countBy(
+      allMessages.map((message) => message.sourceLabel ?? message.senderName ?? "Unknown")
+    )
+      .slice(0, 5)
+      .map((item) => ({ source: item.name, count: item.count }));
+
+    analyses.push({
+      days,
+      total_messages: summary.total_messages,
+      top_domains: topDomains,
+      top_lanes: topLanes,
+      top_sources: topSources,
+    });
+  }
+
+  return { windows: analyses };
+}

--- a/mail-intelligence/src/mail.ts
+++ b/mail-intelligence/src/mail.ts
@@ -1,0 +1,185 @@
+import { execFile } from "node:child_process";
+
+const FIELD_DELIM = "|||";
+const RECORD_DELIM = "<<<>>>";
+
+export interface MailAccount {
+  name: string;
+  emails: string[];
+}
+
+export interface MailMessageSummary {
+  id: number;
+  subject: string;
+  sender: string;
+  date: string;
+  isRead: boolean;
+}
+
+export function sanitize(input: string): string {
+  return input
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\r\n/g, "\\n")
+    .replace(/\r/g, "\\n")
+    .replace(/\n/g, "\\n");
+}
+
+function runAppleScript(script: string): Promise<string> {
+  return runAppleScriptWithTimeout(script);
+}
+
+function runAppleScriptWithTimeout(script: string, timeoutMs = 30_000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "osascript",
+      ["-e", script],
+      { maxBuffer: 10 * 1024 * 1024, timeout: timeoutMs },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`AppleScript error: ${stderr || error.message}`));
+          return;
+        }
+        resolve(stdout.trimEnd());
+      }
+    );
+  });
+}
+
+let _accountsCache: MailAccount[] | null = null;
+
+export async function listAccounts(): Promise<MailAccount[]> {
+  if (_accountsCache) return _accountsCache;
+  const script = `
+tell application "Mail"
+  set results to {}
+  repeat with acct in accounts
+    set acctName to name of acct
+    set AppleScript's text item delimiters to ","
+    set emailList to (email addresses of acct) as text
+    set end of results to acctName & "${FIELD_DELIM}" & emailList
+  end repeat
+  set AppleScript's text item delimiters to "${RECORD_DELIM}"
+  return results as text
+end tell`;
+
+  const raw = await runAppleScript(script);
+  if (!raw) {
+    return [];
+  }
+
+  _accountsCache = raw.split(RECORD_DELIM).map((record) => {
+    const [name, emails] = record.split(FIELD_DELIM).map((value) => value.trim());
+    return {
+      name,
+      emails: emails ? emails.split(",").map((value) => value.trim()).filter(Boolean) : [],
+    };
+  });
+  return _accountsCache;
+}
+
+async function resolveAccountName(accountIdentifier: string): Promise<string> {
+  const accounts = await listAccounts();
+  const normalized = accountIdentifier.toLowerCase();
+
+  const exactName = accounts.find((account) => account.name.toLowerCase() === normalized);
+  if (exactName) {
+    return exactName.name;
+  }
+
+  const exactEmail = accounts.find((account) =>
+    account.emails.some((email) => email.toLowerCase() === normalized)
+  );
+  if (exactEmail) {
+    return exactEmail.name;
+  }
+
+  const partialEmail = accounts.find((account) =>
+    account.emails.some((email) => email.toLowerCase().includes(normalized))
+  );
+  if (partialEmail) {
+    return partialEmail.name;
+  }
+
+  const available = accounts.map((account) => `${account.name} [${account.emails.join(", ")}]`);
+  throw new Error(
+    `Mail account "${accountIdentifier}" not found. Available accounts: ${available.join("; ")}`
+  );
+}
+
+export async function listMessagesSince(
+  mailboxName: string,
+  accountName: string,
+  lookbackDays: number,
+  limit: number
+): Promise<MailMessageSummary[]> {
+  const safeMailbox = sanitize(mailboxName);
+  const resolvedAccountName = await resolveAccountName(accountName);
+  const safeAccount = sanitize(resolvedAccountName);
+  const safeDays = Math.max(1, Math.floor(lookbackDays));
+  const safeLimit = Math.max(1, Math.floor(limit));
+  const sampleSize = Math.min(Math.max(safeLimit, safeLimit * Math.min(safeDays, 10)), 250);
+
+  // Indexed access avoids building a message range, which is much slower on large Mailboxes.
+  const script = `
+tell application "Mail"
+  set mb to mailbox "${safeMailbox}" of account "${safeAccount}"
+  set results to {}
+  repeat with i from 1 to ${sampleSize}
+    try
+      set m to message i of mb
+      set end of results to (id of m as text) & "${FIELD_DELIM}" & (subject of m) & "${FIELD_DELIM}" & (sender of m) & "${FIELD_DELIM}" & (date sent of m as text) & "${FIELD_DELIM}" & (read status of m as text)
+    on error
+      exit repeat
+    end try
+  end repeat
+  set AppleScript's text item delimiters to "${RECORD_DELIM}"
+  return results as text
+end tell`;
+
+  const raw = await runAppleScriptWithTimeout(script, 180_000);
+  if (!raw) {
+    return [];
+  }
+
+  const cutoff = Date.now() - safeDays * 24 * 60 * 60 * 1000;
+  const messages = raw.split(RECORD_DELIM).map((record) => {
+    const [id, subject, sender, date, isRead] = record.split(FIELD_DELIM).map((value) => value.trim());
+    return {
+      id: parseInt(id, 10),
+      subject,
+      sender,
+      date,
+      isRead: isRead === "true",
+    };
+  });
+
+  return messages
+    .filter((message) => {
+      const parsed = Date.parse(message.date);
+      return Number.isNaN(parsed) ? true : parsed >= cutoff;
+    })
+    .slice(0, safeLimit);
+}
+
+export async function getMessageContent(
+  mailboxName: string,
+  accountName: string,
+  messageId: number
+): Promise<string> {
+  const safeMailbox = sanitize(mailboxName);
+  const resolvedAccountName = await resolveAccountName(accountName);
+  const safeAccount = sanitize(resolvedAccountName);
+  const script = `
+tell application "Mail"
+  set mb to mailbox "${safeMailbox}" of account "${safeAccount}"
+  set matchedMsgs to (every message of mb whose id is ${messageId})
+  if (count of matchedMsgs) is 0 then
+    error "Message not found with id: ${messageId}"
+  end if
+  set m to item 1 of matchedMsgs
+  return content of m
+end tell`;
+
+  return runAppleScriptWithTimeout(script, 4_000);
+}

--- a/mail-intelligence/src/notes.ts
+++ b/mail-intelligence/src/notes.ts
@@ -1,0 +1,99 @@
+import { execFile } from "node:child_process";
+
+const FIELD_DELIM = "|||";
+
+function sanitize(input: string): string {
+  return input
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\r\n/g, "\\n")
+    .replace(/\r/g, "\\n")
+    .replace(/\n/g, "\\n");
+}
+
+function runAppleScript(script: string, timeoutMs = 20_000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "osascript",
+      ["-e", script],
+      { maxBuffer: 10 * 1024 * 1024, timeout: timeoutMs },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`AppleScript error: ${stderr || error.message}`));
+          return;
+        }
+        resolve(stdout.trimEnd());
+      }
+    );
+  });
+}
+
+export async function listFolders(): Promise<string[]> {
+  const script = `
+tell application "Notes"
+  set folderList to {}
+  repeat with f in folders
+    set end of folderList to name of f
+  end repeat
+  set AppleScript's text item delimiters to "${FIELD_DELIM}"
+  return folderList as text
+end tell`;
+  const raw = await runAppleScript(script);
+  return raw ? raw.split(FIELD_DELIM).map((item) => item.trim()).filter(Boolean) : [];
+}
+
+export async function createFolder(name: string): Promise<void> {
+  const safeName = sanitize(name);
+  await runAppleScript(`
+tell application "Notes"
+  make new folder with properties {name:"${safeName}"}
+end tell`);
+}
+
+export async function ensureFolder(name: string): Promise<void> {
+  const safeName = sanitize(name);
+  await runAppleScript(`
+tell application "Notes"
+  try
+    folder "${safeName}"
+  on error
+    make new folder with properties {name:"${safeName}"}
+  end try
+end tell`);
+}
+
+export async function createNote(title: string, body: string, folder: string): Promise<void> {
+  const safeTitle = sanitize(title);
+  const safeBody = sanitize(body);
+  const safeFolder = sanitize(folder);
+  await runAppleScript(`
+tell application "Notes"
+  set theFolder to folder "${safeFolder}"
+  make new note at theFolder with properties {name:"${safeTitle}", body:"${safeBody}"}
+end tell`);
+}
+
+export async function updateNote(title: string, body: string, folder: string): Promise<void> {
+  const safeTitle = sanitize(title);
+  const safeBody = sanitize(body);
+  const safeFolder = sanitize(folder);
+  await runAppleScript(`
+tell application "Notes"
+  set matchedNotes to (notes of folder "${safeFolder}" whose name is "${safeTitle}")
+  if (count of matchedNotes) is 0 then
+    error "Note not found: ${safeTitle}"
+  end if
+  set body of item 1 of matchedNotes to "${safeBody}"
+end tell`);
+}
+
+export async function upsertNote(title: string, body: string, folder: string): Promise<"created" | "updated"> {
+  await ensureFolder(folder);
+  try {
+    await updateNote(title, body, folder);
+    return "updated";
+  } catch {
+    await createNote(title, body, folder);
+    return "created";
+  }
+}

--- a/mail-intelligence/tsconfig.json
+++ b/mail-intelligence/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./build",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "build", "tests"]
+}

--- a/memory/context/email-personas.md
+++ b/memory/context/email-personas.md
@@ -1,0 +1,58 @@
+# Email Personas
+
+Last verified: 2026-03-12
+
+## Canonical Model
+
+This repo should treat the three accounts as distinct operating identities, not one inbox cleanup problem.
+
+| Account | Persona | Function | Default lane |
+|------|------|------|------|
+| `mojosolo@mac.com` | The Author | Curated reading list and creative/intellectual intake | `creative_intake` |
+| `david@mojosolo.com` | The Operator | Human relationships, clients, deals, partnerships, and primary reply-from address | `human_replies_required` |
+| `info@mojosolo.com` | The Machine | Catch-all aliases, campaign intake, client workflows, meeting intel, and automated signals | `machine_signals` |
+
+## Durable Facts
+
+- `david@mojosolo.com` is the primary email David gives to people.
+- `info@mojosolo.com` is a catch-all account used for creative campaigns via funny aliases and inbound routing.
+- `mojosolo@mac.com` is the author/creative-intake persona.
+- `info@mojosolo.com` contains active client-work signals, not just generic operations noise.
+
+## Known High-Value Streams
+
+### `mojosolo@mac.com`
+
+- Seeking Alpha
+- AI Builder Club
+- Superhuman AI
+- Glasp
+- Business Insider
+- Apple News
+
+### `david@mojosolo.com`
+
+- GitHub CI/CD for `mojoOS` and `voyani-brain`
+- Replit
+- New York Times
+- LinkedIn
+- Binance
+- Existing labels include Axios, TechCrunch, Medium, Employee Benefit News, Donald Miller
+
+### `info@mojosolo.com`
+
+- ElanPresentation client work for credit union presentations
+- Otter.ai meeting summaries, including Mojo standup transcripts
+- MojoMosaicXYZ platform alerts
+- Wisconsin Department of Agriculture regulatory updates
+- WhatTheAI
+- simple.ai
+
+## Implementation Assumptions
+
+- `knowledge-corpus/data/mojosolo_operating_brain.json` is the canonical brain.
+- `mail-intelligence` should load config from the canonical brain instead of maintaining a parallel config file.
+- Laravel is the intended primary application and API layer on top of the canonical brain.
+- Default output location for synthesized daily intelligence should be Apple Notes.
+- Notes should be structured by persona plus domain, not dumped as a flat mailbox digest.
+- `info@mojosolo.com` should bias toward automated signals, client-work routing, and meeting intelligence instead of defaulting to a human-reply inbox.

--- a/memory/glossary.md
+++ b/memory/glossary.md
@@ -1,0 +1,17 @@
+# Glossary
+
+## Inbox Architecture
+| Term | Meaning | Context |
+|------|---------|---------|
+| Daily Intel | A daily, Superhuman-style synthesis of signals across the three inboxes | Default output is Apple Notes |
+| The Author | `mojosolo@mac.com` | Curated reading, creative and intellectual intake |
+| The Operator | `david@mojosolo.com` | Real humans, clients, partnerships, deals, and primary reply-from identity |
+| The Machine | `info@mojosolo.com` | Catch-all campaigns, client ops, meeting summaries, and automated/platform signals |
+
+## Operating Terms
+| Term | Meaning | Context |
+|------|---------|---------|
+| human replies required | Messages likely needing a person-level response, usually routed to The Operator | Do not treat as generic automation |
+| client work | Active client delivery signals, including ElanPresentation workflows for credit union presentations | Primarily arrives in `info@mojosolo.com` |
+| meeting intel | Otter.ai standup summaries and similar transcript-style messages | Primarily arrives in `info@mojosolo.com` |
+| creative intake | High-signal reading and inspiration sources for strategy and writing | Primarily arrives in `mojosolo@mac.com` |

--- a/messages/package.json
+++ b/messages/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "export-from-handles": "node scripts/export-from-handles.mjs",
     "start": "node build/index.js",
     "test": "bun test tests/applescript.test.ts && node --experimental-strip-types --no-warnings --test tests/database.test.ts",
     "test:clean": "bun test --bail tests/applescript.test.ts && node --experimental-strip-types --no-warnings --test tests/database.test.ts",

--- a/messages/scripts/export-from-handles.mjs
+++ b/messages/scripts/export-from-handles.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Export Apple Messages from specific handles (e.g. mojosolo@mac.com, david@mojosolo.com).
+ * Run from the messages package directory. Requires Full Disk Access for Terminal/Cursor.
+ *
+ * Usage: node scripts/export-from-handles.mjs [output.json]
+ *        Default output: messages-export.json
+ */
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const HANDLES = ["mojosolo@mac.com", "david@mojosolo.com"];
+
+async function main() {
+  const buildPath = join(process.cwd(), "build", "database.js");
+  const mod = await import(pathToFileURL(buildPath).href);
+  const { getMessagesFromHandles, listChats } = mod;
+
+  let messages;
+  try {
+    messages = getMessagesFromHandles(HANDLES);
+    if (messages.length === 0) {
+      const { findHandlesContaining } = mod;
+      const discovered = findHandlesContaining(HANDLES);
+      if (discovered.length > 0) {
+        console.error(`No exact match; found handles: ${discovered.join(", ")}. Retrying with those.`);
+        messages = getMessagesFromHandles(discovered);
+      }
+    }
+  } catch (err) {
+    if (err.message?.includes("unable to open") || err.message?.includes("authorization denied")) {
+      console.error("Error: Cannot read ~/Library/Messages/chat.db");
+      console.error("Grant Full Disk Access to Terminal (or Cursor) in System Settings > Privacy & Security > Full Disk Access");
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  // Group by chat for readability
+  const byChat = new Map();
+  for (const m of messages) {
+    const key = m.chat_id;
+    if (!byChat.has(key)) {
+      byChat.set(key, { chat_id: key, display_name: m.display_name, messages: [] });
+    }
+    byChat.get(key).messages.push({
+      date: m.date,
+      from_me: m.is_from_me,
+      sender: m.sender,
+      text: m.text || "(no text)",
+    });
+  }
+
+  const result = {
+    exported_at: new Date().toISOString(),
+    handles: HANDLES,
+    total_messages: messages.length,
+    chats: Array.from(byChat.values()),
+  };
+
+  const outPath = process.argv[2] || "messages-export.json";
+  writeFileSync(outPath, JSON.stringify(result, null, 2), "utf8");
+  console.log(`Exported ${messages.length} messages from ${HANDLES.join(", ")} to ${outPath}`);
+
+  // Print summary for quick view
+  console.log("\n--- Summary by chat ---");
+  for (const [chatId, data] of byChat) {
+    console.log(`\n${data.display_name || chatId} (${data.messages.length} messages)`);
+    data.messages.slice(-5).forEach((m) => {
+      const dir = m.from_me ? "→" : "←";
+      const preview = (m.text || "").slice(0, 60).replace(/\n/g, " ");
+      console.log(`  ${m.date} ${dir} ${preview}${preview.length >= 60 ? "…" : ""}`);
+    });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/messages/src/database.ts
+++ b/messages/src/database.ts
@@ -306,6 +306,87 @@ export interface Participant {
   service: string | null;
 }
 
+export interface MessageFromHandle extends Message {
+  chat_id: string;
+  display_name: string | null;
+  sender_handle: string | null;
+}
+
+/**
+ * List handle IDs that contain any of the given substrings (for discovering handle format).
+ */
+export function findHandlesContaining(substrings: string[]): string[] {
+  const db = openDb();
+  try {
+    const conditions = substrings.map(() => "h.id LIKE ?").join(" OR ");
+    const params = substrings.flatMap((s) => `%${s}%`);
+    const rows = db.prepare(`
+      SELECT DISTINCT h.id FROM handle h
+      WHERE ${conditions}
+    `).all(...params) as Array<{ id: string }>;
+    return rows.map((r) => r.id);
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Get all messages where the sender handle is one of the given addresses
+ * (e.g. mojosolo@mac.com, david@mojosolo.com).
+ * Returns messages ordered by date ascending (oldest first) for chronological history.
+ */
+export function getMessagesFromHandles(handles: string[]): MessageFromHandle[] {
+  if (handles.length === 0) return [];
+
+  const db = openDb();
+  try {
+    const placeholders = handles.map(() => "?").join(", ");
+
+    const rows = db.prepare(`
+      SELECT
+        m.ROWID as rowid,
+        m.text,
+        m.attributedBody,
+        m.is_from_me,
+        ${DATE_SQL("m.date")} as date,
+        m.service,
+        h.id as sender_handle,
+        c.chat_identifier as chat_id,
+        c.display_name
+      FROM message m
+      JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
+      JOIN chat c ON c.ROWID = cmj.chat_id
+      JOIN handle h ON h.ROWID = m.handle_id
+      WHERE ${handles.map(() => "h.id = ?").join(" OR ")}
+      ORDER BY m.date ASC
+    `).all(...handles) as Array<{
+      rowid: number;
+      text: string | null;
+      attributedBody: Buffer | null;
+      is_from_me: number;
+      date: string | null;
+      service: string | null;
+      sender_handle: string | null;
+      chat_id: string;
+      display_name: string | null;
+    }>;
+
+    return rows.map((row) => ({
+        rowid: row.rowid,
+        text: getMessageText(row.text, row.attributedBody),
+        is_from_me: row.is_from_me === 1,
+        date: row.date,
+        sender: row.sender_handle,
+        service: row.service,
+        chat_id: row.chat_id,
+        display_name: row.display_name,
+        sender_handle: row.sender_handle,
+      }));
+  } finally {
+    db.close();
+  }
+}
+
 /**
  * Get participants of a chat.
  */

--- a/music/package-lock.json
+++ b/music/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@griches/apple-messages-mcp",
+  "name": "@griches/apple-music-mcp",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@griches/apple-messages-mcp",
+      "name": "@griches/apple-music-mcp",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -13,20 +13,20 @@
         "zod": "^3.24.4"
       },
       "bin": {
-        "apple-messages-mcp": "build/index.js"
+        "apple-music-mcp": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.15.3",
         "typescript": "^5.8.3"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
-      "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -429,12 +429,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -590,9 +590,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
-      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -641,9 +641,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -671,9 +671,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/music/package.json
+++ b/music/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@griches/apple-music-mcp",
+  "version": "1.0.0",
+  "description": "MCP server for controlling Apple Music on macOS",
+  "main": "build/index.js",
+  "bin": {
+    "apple-music-mcp": "build/index.js"
+  },
+  "files": [
+    "build/**/*.js",
+    "build/**/*.d.ts",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node build/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "apple",
+    "music",
+    "macos",
+    "applescript"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.3",
+    "typescript": "^5.8.3"
+  }
+}

--- a/music/src/applescript.ts
+++ b/music/src/applescript.ts
@@ -1,0 +1,257 @@
+import { execFile } from "node:child_process";
+
+export function sanitize(input: string): string {
+  return input
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\r\n/g, "\\n")
+    .replace(/\r/g, "\\n")
+    .replace(/\n/g, "\\n");
+}
+
+export function runAppleScript(script: string, timeout = 30000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("osascript", ["-e", script], { maxBuffer: 10 * 1024 * 1024, timeout }, (error, stdout, stderr) => {
+      if (error) {
+        if ((error as NodeJS.ErrnoException & { killed?: boolean }).killed) {
+          reject(new Error("AppleScript timed out"));
+          return;
+        }
+        reject(new Error(`AppleScript error: ${stderr || error.message}`));
+        return;
+      }
+      resolve(stdout.trimEnd());
+    });
+  });
+}
+
+export interface NowPlayingInfo {
+  state: "playing" | "paused" | "stopped";
+  track?: {
+    name: string;
+    artist: string;
+    album: string;
+    duration: number;
+    position: number;
+    loved: boolean;
+    rating: number;
+  };
+  volume: number;
+  shuffle: boolean;
+  repeat: "off" | "one" | "all";
+}
+
+export async function getNowPlaying(): Promise<NowPlayingInfo> {
+  const script = `
+tell application "Music"
+  set st to player state as text
+  set vol to sound volume
+  set sh to shuffle enabled as text
+  set rep to song repeat as text
+  if player state is not stopped then
+    set t to current track
+    set tName to name of t
+    set tArtist to artist of t
+    set tAlbum to album of t
+    set tDuration to duration of t
+    set tPosition to player position
+    set tLoved to false
+    try
+      set tLoved to loved of t
+    end try
+    set tRating to 0
+    try
+      set tRating to rating of t
+    end try
+    return st & "|||" & vol & "|||" & sh & "|||" & rep & "|||" & tName & "|||" & tArtist & "|||" & tAlbum & "|||" & tDuration & "|||" & tPosition & "|||" & (tLoved as text) & "|||" & tRating
+  else
+    return st & "|||" & vol & "|||" & sh & "|||" & rep
+  end if
+end tell`;
+  const raw = await runAppleScript(script);
+  const parts = raw.split("|||");
+  const stateRaw = parts[0]?.trim() ?? "stopped";
+  const state = stateRaw === "playing" ? "playing" : stateRaw === "paused" ? "paused" : "stopped";
+  const volume = parseInt(parts[1]?.trim() ?? "0", 10);
+  const shuffle = parts[2]?.trim() === "true";
+  const repeatRaw = parts[3]?.trim() ?? "off";
+  const repeat: "off" | "one" | "all" = repeatRaw === "one" ? "one" : repeatRaw === "all" ? "all" : "off";
+
+  if (state === "stopped" || parts.length < 8) {
+    return { state, volume, shuffle, repeat };
+  }
+
+  return {
+    state,
+    volume,
+    shuffle,
+    repeat,
+    track: {
+      name: parts[4]?.trim() ?? "",
+      artist: parts[5]?.trim() ?? "",
+      album: parts[6]?.trim() ?? "",
+      duration: parseFloat(parts[7]?.trim() ?? "0"),
+      position: parseFloat(parts[8]?.trim() ?? "0"),
+      loved: parts[9]?.trim() === "true",
+      rating: parseInt(parts[10]?.trim() ?? "0", 10),
+    },
+  };
+}
+
+export async function play(): Promise<string> {
+  await runAppleScript(`tell application "Music" to play`);
+  return "Playback started";
+}
+
+export async function pause(): Promise<string> {
+  await runAppleScript(`tell application "Music" to pause`);
+  return "Playback paused";
+}
+
+export async function nextTrack(): Promise<string> {
+  await runAppleScript(`tell application "Music" to next track`);
+  return "Skipped to next track";
+}
+
+export async function previousTrack(): Promise<string> {
+  await runAppleScript(`tell application "Music" to back track`);
+  return "Went to previous track";
+}
+
+export async function setVolume(volume: number): Promise<string> {
+  const v = Math.max(0, Math.min(100, Math.round(volume)));
+  await runAppleScript(`tell application "Music" to set sound volume to ${v}`);
+  return `Volume set to ${v}`;
+}
+
+export async function setShuffle(enabled: boolean): Promise<string> {
+  await runAppleScript(`tell application "Music" to set shuffle enabled to ${enabled}`);
+  return `Shuffle ${enabled ? "enabled" : "disabled"}`;
+}
+
+export async function setRepeat(mode: "off" | "one" | "all"): Promise<string> {
+  const modeMap = { off: "off", one: "one", all: "all" };
+  await runAppleScript(`tell application "Music" to set song repeat to ${modeMap[mode]}`);
+  return `Repeat set to ${mode}`;
+}
+
+export async function seek(seconds: number): Promise<string> {
+  const pos = Math.max(0, seconds);
+  await runAppleScript(`tell application "Music" to set player position to ${pos}`);
+  return `Seeked to ${pos}s`;
+}
+
+export interface Track {
+  id: string;
+  name: string;
+  artist: string;
+  album: string;
+  duration: number;
+}
+
+export async function search(query: string, limit = 25): Promise<Track[]> {
+  const safeQuery = sanitize(query);
+  const script = `
+tell application "Music"
+  set results to search playlist "Library" for "${safeQuery}"
+  set lim to ${limit}
+  if (count of results) < lim then set lim to count of results
+  set output to {}
+  repeat with i from 1 to lim
+    set t to item i of results
+    set end of output to (id of t as text) & "|||" & (name of t) & "|||" & (artist of t) & "|||" & (album of t) & "|||" & (duration of t as text)
+  end repeat
+  set AppleScript's text item delimiters to "<<<>>>"
+  return output as text
+end tell`;
+  const raw = await runAppleScript(script);
+  if (!raw) return [];
+  return raw.split("<<<>>>").map((record) => {
+    const parts = record.split("|||");
+    return {
+      id: parts[0]?.trim() ?? "",
+      name: parts[1]?.trim() ?? "",
+      artist: parts[2]?.trim() ?? "",
+      album: parts[3]?.trim() ?? "",
+      duration: parseFloat(parts[4]?.trim() ?? "0"),
+    };
+  });
+}
+
+export async function playTrack(name: string, artist?: string): Promise<string> {
+  const safeQuery = sanitize(artist ? `${name} ${artist}` : name);
+  const safeName = sanitize(name);
+  const script = `
+tell application "Music"
+  set results to search playlist "Library" for "${safeQuery}"
+  if (count of results) is 0 then
+    error "No tracks found matching: ${safeName}"
+  end if
+  play item 1 of results
+  set t to current track
+  return "Now playing: " & (name of t) & " by " & (artist of t)
+end tell`;
+  return runAppleScript(script);
+}
+
+export interface Playlist {
+  name: string;
+  kind: string;
+  trackCount: number;
+}
+
+export async function listPlaylists(): Promise<Playlist[]> {
+  const script = `
+tell application "Music"
+  set output to {}
+  set playlistCount to count of every playlist
+  repeat with i from 1 to playlistCount
+    set p to playlist i
+    set pKind to class of p as text
+    set pCount to 0
+    try
+      set pCount to count of tracks of p
+    end try
+    set end of output to (name of p) & "|||" & pKind & "|||" & (pCount as text)
+  end repeat
+  set AppleScript's text item delimiters to "<<<>>>"
+  return output as text
+end tell`;
+  const raw = await runAppleScript(script);
+  if (!raw) return [];
+  return raw.split("<<<>>>").map((record) => {
+    const parts = record.split("|||");
+    return {
+      name: parts[0]?.trim() ?? "",
+      kind: parts[1]?.trim() ?? "",
+      trackCount: parseInt(parts[2]?.trim() ?? "0", 10),
+    };
+  });
+}
+
+export async function playPlaylist(name: string): Promise<string> {
+  const safeName = sanitize(name);
+  const script = `
+tell application "Music"
+  set matched to (every playlist whose name is "${safeName}")
+  if (count of matched) is 0 then
+    error "Playlist not found: ${safeName}"
+  end if
+  play item 1 of matched
+  return "Now playing playlist: ${safeName}"
+end tell`;
+  return runAppleScript(script);
+}
+
+export async function setLoved(loved: boolean): Promise<string> {
+  const script = `
+tell application "Music"
+  if player state is stopped then
+    error "Nothing is currently playing"
+  end if
+  set t to current track
+  set loved of t to ${loved}
+  return "Track " & (name of t) & " " & "${loved ? "marked as loved" : "removed from loved"}"
+end tell`;
+  return runAppleScript(script);
+}

--- a/music/src/index.ts
+++ b/music/src/index.ts
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import * as applescript from "./applescript.js";
+
+const server = new McpServer({
+  name: "apple-music",
+  version: "1.0.0",
+});
+
+// ---- now_playing ----
+server.registerTool(
+  "now_playing",
+  {
+    description: "Get the currently playing track and playback state in Apple Music",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      const info = await applescript.getNowPlaying();
+      return { content: [{ type: "text", text: JSON.stringify(info, null, 2) }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- play ----
+server.registerTool(
+  "play",
+  {
+    description: "Resume or start playback in Apple Music",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      const result = await applescript.play();
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- pause ----
+server.registerTool(
+  "pause",
+  {
+    description: "Pause playback in Apple Music",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      const result = await applescript.pause();
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- next_track ----
+server.registerTool(
+  "next_track",
+  {
+    description: "Skip to the next track in Apple Music",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      const result = await applescript.nextTrack();
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- previous_track ----
+server.registerTool(
+  "previous_track",
+  {
+    description: "Go back to the previous track in Apple Music",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      const result = await applescript.previousTrack();
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- set_volume ----
+server.registerTool(
+  "set_volume",
+  {
+    description: "Set the volume in Apple Music (0–100)",
+    inputSchema: z.object({
+      volume: z.number().min(0).max(100).describe("Volume level from 0 (mute) to 100 (max)"),
+    }),
+  },
+  async ({ volume }) => {
+    try {
+      const result = await applescript.setVolume(volume);
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- set_shuffle ----
+server.registerTool(
+  "set_shuffle",
+  {
+    description: "Enable or disable shuffle in Apple Music",
+    inputSchema: z.object({
+      enabled: z.boolean().describe("true to enable shuffle, false to disable"),
+    }),
+  },
+  async ({ enabled }) => {
+    try {
+      const result = await applescript.setShuffle(enabled);
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- set_repeat ----
+server.registerTool(
+  "set_repeat",
+  {
+    description: "Set the repeat mode in Apple Music",
+    inputSchema: z.object({
+      mode: z.enum(["off", "one", "all"]).describe("Repeat mode: off, one (repeat current track), or all (repeat playlist)"),
+    }),
+  },
+  async ({ mode }) => {
+    try {
+      const result = await applescript.setRepeat(mode);
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- seek ----
+server.registerTool(
+  "seek",
+  {
+    description: "Seek to a position in the current track (in seconds)",
+    inputSchema: z.object({
+      seconds: z.number().min(0).describe("Position to seek to in seconds"),
+    }),
+  },
+  async ({ seconds }) => {
+    try {
+      const result = await applescript.seek(seconds);
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- search ----
+server.registerTool(
+  "search",
+  {
+    description: "Search for tracks in the Apple Music library",
+    inputSchema: z.object({
+      query: z.string().describe("Search query (matches track name, artist, album)"),
+      limit: z.number().optional().describe("Maximum number of results to return (default 25)"),
+    }),
+  },
+  async ({ query, limit }) => {
+    try {
+      const results = await applescript.search(query, limit);
+      return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- play_track ----
+server.registerTool(
+  "play_track",
+  {
+    description: "Search for a track and play the first match",
+    inputSchema: z.object({
+      name: z.string().describe("Track name to search for"),
+      artist: z.string().optional().describe("Artist name to narrow the search"),
+    }),
+  },
+  async ({ name, artist }) => {
+    try {
+      const result = await applescript.playTrack(name, artist);
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- list_playlists ----
+server.registerTool(
+  "list_playlists",
+  {
+    description: "List all playlists in Apple Music",
+    inputSchema: z.object({}),
+  },
+  async () => {
+    try {
+      const playlists = await applescript.listPlaylists();
+      return { content: [{ type: "text", text: JSON.stringify(playlists, null, 2) }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- play_playlist ----
+server.registerTool(
+  "play_playlist",
+  {
+    description: "Play a playlist by name in Apple Music",
+    inputSchema: z.object({
+      name: z.string().describe("Name of the playlist to play"),
+    }),
+  },
+  async ({ name }) => {
+    try {
+      const result = await applescript.playPlaylist(name);
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- set_loved ----
+server.registerTool(
+  "set_loved",
+  {
+    description: "Mark or unmark the currently playing track as loved in Apple Music",
+    inputSchema: z.object({
+      loved: z.boolean().describe("true to mark as loved, false to remove loved"),
+    }),
+  },
+  async ({ loved }) => {
+    try {
+      const result = await applescript.setLoved(loved);
+      return { content: [{ type: "text", text: result }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
+// ---- Start server ----
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("Apple Music MCP server running on stdio");
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/music/tsconfig.json
+++ b/music/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./build",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "build"]
+}

--- a/notes/package-lock.json
+++ b/notes/package-lock.json
@@ -1,19 +1,26 @@
 {
-  "name": "apple-notes-mcp",
+  "name": "@griches/apple-notes-mcp",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "apple-notes-mcp",
+      "name": "@griches/apple-notes-mcp",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "zod": "^3.24.4"
       },
+      "bin": {
+        "apple-notes-mcp": "build/index.js"
+      },
       "devDependencies": {
         "@types/node": "^22.15.3",
         "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@hono/node-server": {

--- a/scripts/discover_ax_elements.py
+++ b/scripts/discover_ax_elements.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Discover interactive macOS Accessibility elements for a running app.
+
+Setup:
+  uv venv /tmp/ax_env
+  uv pip install pyobjc-framework-ApplicationServices pyobjc-framework-Cocoa --python /tmp/ax_env/bin/python
+
+Examples:
+  /tmp/ax_env/bin/python scripts/discover_ax_elements.py --app "Final Cut Pro"
+  /tmp/ax_env/bin/python scripts/discover_ax_elements.py --app "Final Cut Pro" --title share
+  /tmp/ax_env/bin/python scripts/discover_ax_elements.py --app Finder --max-depth 6
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from Cocoa import NSWorkspace
+from ApplicationServices import (
+    AXIsProcessTrusted,
+    AXUIElementCreateApplication,
+    AXUIElementCopyAttributeValue,
+    kAXChildrenAttribute,
+    kAXDescriptionAttribute,
+    kAXErrorSuccess as AX_SUCCESS,
+    kAXPositionAttribute,
+    kAXRoleAttribute,
+    kAXRoleDescriptionAttribute,
+    kAXSizeAttribute,
+    kAXTitleAttribute,
+    kAXValueAttribute,
+    AXValueGetValue,
+)
+
+
+DEFAULT_ROLES = {
+    "AXButton",
+    "AXMenuItem",
+    "AXMenuBarItem",
+    "AXComboBox",
+    "AXPopUpButton",
+    "AXTextField",
+    "AXCheckBox",
+    "AXRadioButton",
+    "AXMenuButton",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--app", default="Final Cut Pro", help="Localized app name")
+    parser.add_argument("--title", default="", help="Case-insensitive title substring filter")
+    parser.add_argument("--max-depth", type=int, default=8, help="AX tree recursion depth")
+    return parser.parse_args()
+
+
+def str_attr(element, key):
+    err, value = AXUIElementCopyAttributeValue(element, key, None)
+    if err == AX_SUCCESS and isinstance(value, str):
+        return value
+    return None
+
+
+def point_of(element):
+    err_p, pos_val = AXUIElementCopyAttributeValue(element, kAXPositionAttribute, None)
+    err_s, size_val = AXUIElementCopyAttributeValue(element, kAXSizeAttribute, None)
+    if err_p != AX_SUCCESS or err_s != AX_SUCCESS:
+        return None, None
+
+    result_p = AXValueGetValue(pos_val, 1, None)  # kAXValueCGPointType
+    result_s = AXValueGetValue(size_val, 2, None)  # kAXValueCGSizeType
+
+    ok_p, x, y = False, 0.0, 0.0
+    ok_s, width, height = False, 0.0, 0.0
+
+    if result_p and len(result_p) == 2:
+        point_ok, point_val = result_p
+        if point_ok and hasattr(point_val, "x"):
+            x, y = point_val.x, point_val.y
+            ok_p = True
+
+    if result_s and len(result_s) == 2:
+        size_ok, size_val2 = result_s
+        if size_ok and hasattr(size_val2, "width"):
+            width, height = size_val2.width, size_val2.height
+            ok_s = True
+
+    if ok_p and ok_s and width > 0 and height > 0:
+        return x + width / 2, y + height / 2
+
+    return None, None
+
+
+def collect(element, results, title_filter: str, max_depth: int, depth: int = 0):
+    if depth > max_depth:
+        return
+
+    role = str_attr(element, kAXRoleAttribute)
+    if role in DEFAULT_ROLES:
+        title = (
+            str_attr(element, kAXTitleAttribute)
+            or str_attr(element, kAXDescriptionAttribute)
+            or str_attr(element, kAXRoleDescriptionAttribute)
+            or str_attr(element, kAXValueAttribute)
+            or ""
+        )
+        if not title_filter or title_filter in title.lower():
+            x, y = point_of(element)
+            if x is not None:
+                results.append((role, title, int(x), int(y)))
+
+    err, children = AXUIElementCopyAttributeValue(element, kAXChildrenAttribute, None)
+    if err == AX_SUCCESS and children:
+        for child in children:
+            collect(child, results, title_filter, max_depth, depth + 1)
+
+
+def main():
+    args = parse_args()
+
+    if not AXIsProcessTrusted():
+        print("ERROR: Accessibility permission not granted.", file=sys.stderr)
+        sys.exit(1)
+
+    app = next(
+        (
+            candidate
+            for candidate in NSWorkspace.sharedWorkspace().runningApplications()
+            if candidate.localizedName() == args.app
+        ),
+        None,
+    )
+    if app is None:
+        print(f"ERROR: {args.app} is not running.", file=sys.stderr)
+        sys.exit(1)
+
+    results = []
+    collect(
+        AXUIElementCreateApplication(app.processIdentifier()),
+        results,
+        args.title.lower(),
+        args.max_depth,
+    )
+
+    if not results:
+        print(f"No interactive elements found in {args.app}.")
+        return
+
+    print(f"\n{args.app} — {len(results)} interactive elements\n")
+    print(f"{'ROLE':<22} {'TITLE':<60} {'X':>6} {'Y':>6}")
+    print("-" * 100)
+    for role, title, x, y in sorted(results, key=lambda row: (row[0], row[1].lower(), row[2], row[3])):
+        print(f"{role:<22} {title[:60]:<60} {x:>6} {y:>6}")
+
+
+if __name__ == "__main__":
+    main()

--- a/shell/Package.swift
+++ b/shell/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "MojoShell",
+    platforms: [
+        .macOS(.v14),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MojoShell",
+            path: "Sources/MojoShell"
+        ),
+        .testTarget(
+            name: "MojoShellTests",
+            dependencies: ["MojoShell"],
+            path: "Tests/MojoShellTests"
+        ),
+    ]
+)

--- a/shell/Sources/MojoShell/App/AppState.swift
+++ b/shell/Sources/MojoShell/App/AppState.swift
@@ -7,22 +7,17 @@ final class AppState: ObservableObject {
     let executor: MCPToolExecutor
     let computerUseProvider: any ComputerUseProvider
     private let llmProviders: [any LLMProvider]
-    private let assemblyClickTarget: String?
 
     init(
         daemons: DaemonManager? = nil,
         executor: MCPToolExecutor? = nil,
         computerUseProvider: (any ComputerUseProvider)? = nil,
-        llmProviders: [any LLMProvider]? = nil,
-        assemblyClickTarget: String? = nil
+        llmProviders: [any LLMProvider]? = nil
     ) {
         let resolvedDaemons = daemons ?? DaemonManager()
         self.daemons = resolvedDaemons
         self.executor = executor ?? MCPToolExecutor(daemonManager: resolvedDaemons)
         self.computerUseProvider = computerUseProvider ?? CuaComputerUseProvider()
-        self.assemblyClickTarget = AppState.normalizedAssemblyClickTarget(
-            assemblyClickTarget ?? ProcessInfo.processInfo.environment["MOJOSHELL_ASSEMBLY_CLICK_TARGET"]
-        )
 
         if let llmProviders {
             self.llmProviders = llmProviders
@@ -125,54 +120,4 @@ final class AppState: ObservableObject {
         )
     }
 
-    func runAssemblyWorkflow(jobName: String) async -> Result<String, Error> {
-        let clickTarget = assemblyClickTarget ?? (computerUseProviderName == "stub" ? "Export Button" : nil)
-        guard let clickTarget else {
-            return .failure(AssemblyWorkflowError.missingClickTarget)
-        }
-
-        do {
-            let sessionID = try await computerUseProvider.startSession()
-            do {
-                let state = try await computerUseProvider.captureState(sessionId: sessionID)
-                let actionResult = try await computerUseProvider.execute(
-                    sessionId: sessionID,
-                    action: ComputerUseAction(type: .click, target: clickTarget)
-                )
-                try await computerUseProvider.stopSession(sessionId: sessionID)
-
-                return .success(
-                    """
-                    Session: \(sessionID)
-                    Job: \(jobName)
-                    Provider: \(state.appName)
-                    Target: \(clickTarget)
-                    Result: \(actionResult.message)
-                    """
-                )
-            } catch {
-                try? await computerUseProvider.stopSession(sessionId: sessionID)
-                return .failure(error)
-            }
-        } catch {
-            return .failure(error)
-        }
-    }
-
-    private static func normalizedAssemblyClickTarget(_ value: String?) -> String? {
-        guard let value else { return nil }
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
-}
-
-enum AssemblyWorkflowError: LocalizedError, Equatable {
-    case missingClickTarget
-
-    var errorDescription: String? {
-        switch self {
-        case .missingClickTarget:
-            return "Assembly click target is not configured. Set MOJOSHELL_ASSEMBLY_CLICK_TARGET to coordinates like '640,400'."
-        }
-    }
 }

--- a/shell/Sources/MojoShell/App/AppState.swift
+++ b/shell/Sources/MojoShell/App/AppState.swift
@@ -1,0 +1,13 @@
+import Combine
+import Foundation
+
+@MainActor
+final class AppState: ObservableObject {
+    let daemons: DaemonManager
+
+    init(daemons: DaemonManager? = nil) {
+        let resolvedDaemons = daemons ?? DaemonManager()
+        self.daemons = resolvedDaemons
+        resolvedDaemons.startAll()
+    }
+}

--- a/shell/Sources/MojoShell/App/AppState.swift
+++ b/shell/Sources/MojoShell/App/AppState.swift
@@ -6,18 +6,21 @@ final class AppState: ObservableObject {
     let daemons: DaemonManager
     let executor: MCPToolExecutor
     let computerUseProvider: any ComputerUseProvider
+    let nativeExecutor: any NativeToolExecuting
     private let llmProviders: [any LLMProvider]
 
     init(
         daemons: DaemonManager? = nil,
         executor: MCPToolExecutor? = nil,
         computerUseProvider: (any ComputerUseProvider)? = nil,
+        nativeExecutor: (any NativeToolExecuting)? = nil,
         llmProviders: [any LLMProvider]? = nil
     ) {
         let resolvedDaemons = daemons ?? DaemonManager()
         self.daemons = resolvedDaemons
         self.executor = executor ?? MCPToolExecutor(daemonManager: resolvedDaemons)
         self.computerUseProvider = computerUseProvider ?? CuaComputerUseProvider()
+        self.nativeExecutor = nativeExecutor ?? NativeToolExecutor(repoRoot: resolvedDaemons.repoRoot)
 
         if let llmProviders {
             self.llmProviders = llmProviders
@@ -57,8 +60,13 @@ final class AppState: ObservableObject {
             do {
                 let response = try await provider.resolve(prompt: prompt, availableTools: availableTools)
                 if let tool = response.resolvedTool {
-                    let execResult = try await executor.execute(tool)
-                    return .success(execResult.text)
+                    let execResult = await execute(tool)
+                    switch execResult {
+                    case .success(let output):
+                        return .success(output.text)
+                    case .failure(let error):
+                        throw error
+                    }
                 }
                 return .success(response.text)
             } catch {
@@ -71,6 +79,14 @@ final class AppState: ObservableObject {
 
     func execute(_ resolvedTool: ResolvedTool) async -> Result<MCPToolExecutionResult, Error> {
         do {
+            if resolvedTool.server == NativeToolExecutor.serverName {
+                return .success(
+                    try await nativeExecutor.execute(
+                        tool: resolvedTool.tool,
+                        arguments: resolvedTool.arguments
+                    )
+                )
+            }
             return .success(try await executor.execute(resolvedTool))
         } catch {
             return .failure(error)
@@ -116,6 +132,76 @@ final class AppState: ObservableObject {
                 server: "apple-music",
                 tool: "now_playing",
                 arguments: [:]
+            )
+        )
+    }
+
+    func openDownloadsFolder() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderOpenPath.rawValue,
+                arguments: ["path": .string("~/Downloads")]
+            )
+        )
+    }
+
+    func openRepoFolder() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderOpenRepoRoot.rawValue,
+                arguments: [:]
+            )
+        )
+    }
+
+    func revealBrainFile() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderRevealBrainFile.rawValue,
+                arguments: [:]
+            )
+        )
+    }
+
+    func fetchFinderSelection() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderListSelection.rawValue,
+                arguments: [:]
+            )
+        )
+    }
+
+    func fetchSafariCurrentTab() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.safariCurrentTab.rawValue,
+                arguments: [:]
+            )
+        )
+    }
+
+    func listShortcuts() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.shortcutsList.rawValue,
+                arguments: [:]
+            )
+        )
+    }
+
+    func openAccessibilitySettings() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.systemSettingsOpen.rawValue,
+                arguments: ["pane": .string("accessibility")]
             )
         )
     }

--- a/shell/Sources/MojoShell/App/AppState.swift
+++ b/shell/Sources/MojoShell/App/AppState.swift
@@ -203,6 +203,74 @@ final class AppState: ObservableObject {
         )
     }
 
+    func openPathInPreview(_ path: String) async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.previewOpenPath.rawValue,
+                arguments: ["path": .string(path)]
+            )
+        )
+    }
+
+    func openPathInPhotos(_ path: String) async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.photosImportPath.rawValue,
+                arguments: ["path": .string(path)]
+            )
+        )
+    }
+
+    func openRepoInTerminal() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.terminalOpenRepo.rawValue,
+                arguments: [:]
+            )
+        )
+    }
+
+    func openRepoInITerm() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.itermOpenRepo.rawValue,
+                arguments: [:]
+            )
+        )
+    }
+
+    func runTerminalCommand(_ command: String, path: String? = nil) async -> Result<MCPToolExecutionResult, Error> {
+        var arguments: [String: AnyCodable] = ["command": .string(command)]
+        if let path, !path.isEmpty {
+            arguments["path"] = .string(path)
+        }
+        return await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.terminalRunCommand.rawValue,
+                arguments: arguments
+            )
+        )
+    }
+
+    func runITermCommand(_ command: String, path: String? = nil) async -> Result<MCPToolExecutionResult, Error> {
+        var arguments: [String: AnyCodable] = ["command": .string(command)]
+        if let path, !path.isEmpty {
+            arguments["path"] = .string(path)
+        }
+        return await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.itermRunCommand.rawValue,
+                arguments: arguments
+            )
+        )
+    }
+
     func openDownloadsFolder() async -> Result<MCPToolExecutionResult, Error> {
         await openFinderPath("~/Downloads")
     }
@@ -232,6 +300,26 @@ final class AppState: ObservableObject {
             ResolvedTool(
                 server: NativeToolExecutor.serverName,
                 tool: NativeToolName.finderListSelection.rawValue,
+                arguments: [:]
+            )
+        )
+    }
+
+    func openFinderSelectionInPreview() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderSelectionOpenInPreview.rawValue,
+                arguments: [:]
+            )
+        )
+    }
+
+    func openFinderSelectionInPhotos() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderSelectionOpenInPhotos.rawValue,
                 arguments: [:]
             )
         )

--- a/shell/Sources/MojoShell/App/AppState.swift
+++ b/shell/Sources/MojoShell/App/AppState.swift
@@ -6,17 +6,46 @@ final class AppState: ObservableObject {
     let daemons: DaemonManager
     let executor: MCPToolExecutor
     let computerUseProvider: any ComputerUseProvider
+    private let llmProvider: (any LLMProvider)?
 
     init(
         daemons: DaemonManager? = nil,
         executor: MCPToolExecutor? = nil,
-        computerUseProvider: (any ComputerUseProvider)? = nil
+        computerUseProvider: (any ComputerUseProvider)? = nil,
+        llmProvider: (any LLMProvider)? = nil
     ) {
         let resolvedDaemons = daemons ?? DaemonManager()
         self.daemons = resolvedDaemons
         self.executor = executor ?? MCPToolExecutor(daemonManager: resolvedDaemons)
         self.computerUseProvider = computerUseProvider ?? StubComputerUseProvider()
+
+        if let llmProvider {
+            self.llmProvider = llmProvider
+        } else if let key = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"], !key.isEmpty {
+            self.llmProvider = ClaudeProvider(apiKey: key)
+        } else {
+            self.llmProvider = nil
+        }
+
         resolvedDaemons.startAll()
+    }
+
+    var llmProviderName: String { llmProvider?.name ?? "none" }
+
+    func resolveWithLLM(prompt: String, availableTools: [LLMToolDefinition]) async -> Result<String, Error> {
+        guard let provider = llmProvider else {
+            return .failure(LLMRoutingError.noAPIKey)
+        }
+        do {
+            let response = try await provider.resolve(prompt: prompt, availableTools: availableTools)
+            if let tool = response.resolvedTool {
+                let execResult = try await executor.execute(tool)
+                return .success(execResult.text)
+            }
+            return .success(response.text)
+        } catch {
+            return .failure(error)
+        }
     }
 
     func execute(_ resolvedTool: ResolvedTool) async -> Result<MCPToolExecutionResult, Error> {

--- a/shell/Sources/MojoShell/App/AppState.swift
+++ b/shell/Sources/MojoShell/App/AppState.swift
@@ -17,7 +17,7 @@ final class AppState: ObservableObject {
         let resolvedDaemons = daemons ?? DaemonManager()
         self.daemons = resolvedDaemons
         self.executor = executor ?? MCPToolExecutor(daemonManager: resolvedDaemons)
-        self.computerUseProvider = computerUseProvider ?? StubComputerUseProvider()
+        self.computerUseProvider = computerUseProvider ?? CuaComputerUseProvider()
 
         if let llmProviders {
             self.llmProviders = llmProviders

--- a/shell/Sources/MojoShell/App/AppState.swift
+++ b/shell/Sources/MojoShell/App/AppState.swift
@@ -4,10 +4,33 @@ import Foundation
 @MainActor
 final class AppState: ObservableObject {
     let daemons: DaemonManager
+    let executor: MCPToolExecutor
 
     init(daemons: DaemonManager? = nil) {
         let resolvedDaemons = daemons ?? DaemonManager()
         self.daemons = resolvedDaemons
+        self.executor = MCPToolExecutor(daemonManager: resolvedDaemons)
         resolvedDaemons.startAll()
+    }
+
+    func execute(_ resolvedTool: ResolvedTool) async -> Result<MCPToolExecutionResult, Error> {
+        do {
+            return .success(try await executor.execute(resolvedTool))
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    func scanInboxes() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: "mail-intelligence",
+                tool: "scan_persona_inboxes",
+                arguments: [
+                    "lookback_days": .int(1),
+                    "limit_per_account": .int(10),
+                ]
+            )
+        )
     }
 }

--- a/shell/Sources/MojoShell/App/AppState.swift
+++ b/shell/Sources/MojoShell/App/AppState.swift
@@ -5,11 +5,17 @@ import Foundation
 final class AppState: ObservableObject {
     let daemons: DaemonManager
     let executor: MCPToolExecutor
+    let computerUseProvider: any ComputerUseProvider
 
-    init(daemons: DaemonManager? = nil) {
+    init(
+        daemons: DaemonManager? = nil,
+        executor: MCPToolExecutor? = nil,
+        computerUseProvider: (any ComputerUseProvider)? = nil
+    ) {
         let resolvedDaemons = daemons ?? DaemonManager()
         self.daemons = resolvedDaemons
-        self.executor = MCPToolExecutor(daemonManager: resolvedDaemons)
+        self.executor = executor ?? MCPToolExecutor(daemonManager: resolvedDaemons)
+        self.computerUseProvider = computerUseProvider ?? StubComputerUseProvider()
         resolvedDaemons.startAll()
     }
 
@@ -32,5 +38,58 @@ final class AppState: ObservableObject {
                 ]
             )
         )
+    }
+
+    func fetchPersonaMap() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: "mail-intelligence",
+                tool: "get_persona_map",
+                arguments: [:]
+            )
+        )
+    }
+
+    func fetchBrainOverview() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: "knowledge-corpus",
+                tool: "get_corpus_overview",
+                arguments: [:]
+            )
+        )
+    }
+
+    func fetchNowPlaying() async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: "apple-music",
+                tool: "now_playing",
+                arguments: [:]
+            )
+        )
+    }
+
+    func runAssemblyWorkflow(jobName: String) async -> Result<String, Error> {
+        do {
+            let sessionID = try await computerUseProvider.startSession()
+            let state = try await computerUseProvider.captureState(sessionId: sessionID)
+            let actionResult = try await computerUseProvider.execute(
+                sessionId: sessionID,
+                action: ComputerUseAction(type: .click, target: "Run Assembly Workflow")
+            )
+            try await computerUseProvider.stopSession(sessionId: sessionID)
+
+            return .success(
+                """
+                Session: \(sessionID)
+                Job: \(jobName)
+                Provider: \(state.appName)
+                Result: \(actionResult.message)
+                """
+            )
+        } catch {
+            return .failure(error)
+        }
     }
 }

--- a/shell/Sources/MojoShell/App/AppState.swift
+++ b/shell/Sources/MojoShell/App/AppState.swift
@@ -16,7 +16,8 @@ final class AppState: ObservableObject {
         computerUseProvider: (any ComputerUseProvider)? = nil,
         nativeExecutor: (any NativeToolExecuting)? = nil,
         llmProviders: [any LLMProvider]? = nil,
-        auditRecorder: (@MainActor (AuditCategory, String, String, [String: String]) -> Void)? = nil
+        auditRecorder: (@MainActor (AuditCategory, String, String, [String: String]) -> Void)? = nil,
+        startDaemonsOnInit: Bool = true
     ) {
         let resolvedDaemons = daemons ?? DaemonManager()
         self.daemons = resolvedDaemons
@@ -38,7 +39,9 @@ final class AppState: ObservableObject {
             self.llmProviders = providers
         }
 
-        resolvedDaemons.startAll()
+        if startDaemonsOnInit {
+            resolvedDaemons.startAll()
+        }
     }
 
     var computerUseProviderName: String {

--- a/shell/Sources/MojoShell/App/AppState.swift
+++ b/shell/Sources/MojoShell/App/AppState.swift
@@ -305,6 +305,16 @@ final class AppState: ObservableObject {
         )
     }
 
+    func fetchFinderSelectionPaths() async -> Result<[String], Error> {
+        let result = await fetchFinderSelection()
+        switch result {
+        case .success(let output):
+            return .success(parseFinderSelectionPaths(from: output))
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
     func openFinderSelectionInPreview() async -> Result<MCPToolExecutionResult, Error> {
         await execute(
             ResolvedTool(
@@ -369,5 +379,23 @@ final class AppState: ObservableObject {
                 arguments: ["pane": .string(pane)]
             )
         )
+    }
+
+    private func parseFinderSelectionPaths(from output: MCPToolExecutionResult) -> [String] {
+        if case .array(let values)? = output.payload {
+            return values.compactMap { value in
+                guard case .string(let path) = value else {
+                    return nil
+                }
+                return path.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            .filter { !$0.isEmpty }
+        }
+
+        return output.text
+            .split(separator: "\n")
+            .map(String.init)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && $0 != "Finder selection is empty." }
     }
 }

--- a/shell/Sources/MojoShell/App/AppState.swift
+++ b/shell/Sources/MojoShell/App/AppState.swift
@@ -6,46 +6,63 @@ final class AppState: ObservableObject {
     let daemons: DaemonManager
     let executor: MCPToolExecutor
     let computerUseProvider: any ComputerUseProvider
-    private let llmProvider: (any LLMProvider)?
+    private let llmProviders: [any LLMProvider]
 
     init(
         daemons: DaemonManager? = nil,
         executor: MCPToolExecutor? = nil,
         computerUseProvider: (any ComputerUseProvider)? = nil,
-        llmProvider: (any LLMProvider)? = nil
+        llmProviders: [any LLMProvider]? = nil
     ) {
         let resolvedDaemons = daemons ?? DaemonManager()
         self.daemons = resolvedDaemons
         self.executor = executor ?? MCPToolExecutor(daemonManager: resolvedDaemons)
         self.computerUseProvider = computerUseProvider ?? StubComputerUseProvider()
 
-        if let llmProvider {
-            self.llmProvider = llmProvider
-        } else if let key = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"], !key.isEmpty {
-            self.llmProvider = ClaudeProvider(apiKey: key)
+        if let llmProviders {
+            self.llmProviders = llmProviders
         } else {
-            self.llmProvider = nil
+            var providers: [any LLMProvider] = []
+            if let key = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"], !key.isEmpty {
+                providers.append(ClaudeProvider(apiKey: key))
+            }
+            if let key = ProcessInfo.processInfo.environment["OPENAI_API_KEY"], !key.isEmpty {
+                providers.append(OpenAIProvider(apiKey: key))
+            }
+            self.llmProviders = providers
         }
 
         resolvedDaemons.startAll()
     }
 
-    var llmProviderName: String { llmProvider?.name ?? "none" }
+    var llmProviderStackDescription: String {
+        guard !llmProviders.isEmpty else {
+            return "none"
+        }
+        return llmProviders.map { $0.name }.joined(separator: " -> ")
+    }
 
     func resolveWithLLM(prompt: String, availableTools: [LLMToolDefinition]) async -> Result<String, Error> {
-        guard let provider = llmProvider else {
-            return .failure(LLMRoutingError.noAPIKey)
+        guard !llmProviders.isEmpty else {
+            return .failure(LLMRoutingError.noAvailableProviders)
         }
-        do {
-            let response = try await provider.resolve(prompt: prompt, availableTools: availableTools)
-            if let tool = response.resolvedTool {
-                let execResult = try await executor.execute(tool)
-                return .success(execResult.text)
+
+        var failures: [String] = []
+
+        for provider in llmProviders {
+            do {
+                let response = try await provider.resolve(prompt: prompt, availableTools: availableTools)
+                if let tool = response.resolvedTool {
+                    let execResult = try await executor.execute(tool)
+                    return .success(execResult.text)
+                }
+                return .success(response.text)
+            } catch {
+                failures.append("\(provider.name): \(error.localizedDescription)")
             }
-            return .success(response.text)
-        } catch {
-            return .failure(error)
         }
+
+        return .failure(LLMRoutingError.providersFailed(failures.joined(separator: " | ")))
     }
 
     func execute(_ resolvedTool: ResolvedTool) async -> Result<MCPToolExecutionResult, Error> {

--- a/shell/Sources/MojoShell/App/AppState.swift
+++ b/shell/Sources/MojoShell/App/AppState.swift
@@ -8,19 +8,22 @@ final class AppState: ObservableObject {
     let computerUseProvider: any ComputerUseProvider
     let nativeExecutor: any NativeToolExecuting
     private let llmProviders: [any LLMProvider]
+    private let auditRecorder: @MainActor (AuditCategory, String, String, [String: String]) -> Void
 
     init(
         daemons: DaemonManager? = nil,
         executor: MCPToolExecutor? = nil,
         computerUseProvider: (any ComputerUseProvider)? = nil,
         nativeExecutor: (any NativeToolExecuting)? = nil,
-        llmProviders: [any LLMProvider]? = nil
+        llmProviders: [any LLMProvider]? = nil,
+        auditRecorder: (@MainActor (AuditCategory, String, String, [String: String]) -> Void)? = nil
     ) {
         let resolvedDaemons = daemons ?? DaemonManager()
         self.daemons = resolvedDaemons
         self.executor = executor ?? MCPToolExecutor(daemonManager: resolvedDaemons)
         self.computerUseProvider = computerUseProvider ?? CuaComputerUseProvider()
         self.nativeExecutor = nativeExecutor ?? NativeToolExecutor(repoRoot: resolvedDaemons.repoRoot)
+        self.auditRecorder = auditRecorder ?? { _, _, _, _ in }
 
         if let llmProviders {
             self.llmProviders = llmProviders
@@ -55,10 +58,12 @@ final class AppState: ObservableObject {
         }
 
         var failures: [String] = []
+        auditRecorder(.llm, "LLM route requested", prompt, ["providers": llmProviderStackDescription])
 
         for provider in llmProviders {
             do {
                 let response = try await provider.resolve(prompt: prompt, availableTools: availableTools)
+                auditRecorder(.llm, "LLM provider response", provider.name, ["resolved_tool": response.resolvedTool?.tool ?? "none"])
                 if let tool = response.resolvedTool {
                     let execResult = await execute(tool)
                     switch execResult {
@@ -71,6 +76,7 @@ final class AppState: ObservableObject {
                 return .success(response.text)
             } catch {
                 failures.append("\(provider.name): \(error.localizedDescription)")
+                auditRecorder(.llm, "LLM provider failed", provider.name, ["error": error.localizedDescription])
             }
         }
 
@@ -78,17 +84,33 @@ final class AppState: ObservableObject {
     }
 
     func execute(_ resolvedTool: ResolvedTool) async -> Result<MCPToolExecutionResult, Error> {
+        let category: AuditCategory = resolvedTool.server == NativeToolExecutor.serverName ? .native : .mcp
+
         do {
+            let result: MCPToolExecutionResult
             if resolvedTool.server == NativeToolExecutor.serverName {
-                return .success(
-                    try await nativeExecutor.execute(
-                        tool: resolvedTool.tool,
-                        arguments: resolvedTool.arguments
-                    )
+                result = try await nativeExecutor.execute(
+                    tool: resolvedTool.tool,
+                    arguments: resolvedTool.arguments
                 )
+            } else {
+                result = try await executor.execute(resolvedTool)
             }
-            return .success(try await executor.execute(resolvedTool))
+
+            auditRecorder(
+                category,
+                "Tool executed",
+                "\(resolvedTool.server)/\(resolvedTool.tool)",
+                ["result": result.text]
+            )
+            return .success(result)
         } catch {
+            auditRecorder(
+                category,
+                "Tool failed",
+                "\(resolvedTool.server)/\(resolvedTool.tool)",
+                ["error": error.localizedDescription]
+            )
             return .failure(error)
         }
     }
@@ -136,14 +158,53 @@ final class AppState: ObservableObject {
         )
     }
 
-    func openDownloadsFolder() async -> Result<MCPToolExecutionResult, Error> {
+    func openFinderPath(_ path: String) async -> Result<MCPToolExecutionResult, Error> {
         await execute(
             ResolvedTool(
                 server: NativeToolExecutor.serverName,
                 tool: NativeToolName.finderOpenPath.rawValue,
-                arguments: ["path": .string("~/Downloads")]
+                arguments: ["path": .string(path)]
             )
         )
+    }
+
+    func revealFinderPath(_ path: String) async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderRevealPath.rawValue,
+                arguments: ["path": .string(path)]
+            )
+        )
+    }
+
+    func openSafariURL(_ url: String) async -> Result<MCPToolExecutionResult, Error> {
+        await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.safariOpenURL.rawValue,
+                arguments: ["url": .string(url)]
+            )
+        )
+    }
+
+    func runShortcut(named name: String, input: String? = nil) async -> Result<MCPToolExecutionResult, Error> {
+        var arguments: [String: AnyCodable] = ["name": .string(name)]
+        if let input, !input.isEmpty {
+            arguments["input"] = .string(input)
+        }
+
+        return await execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.shortcutsRun.rawValue,
+                arguments: arguments
+            )
+        )
+    }
+
+    func openDownloadsFolder() async -> Result<MCPToolExecutionResult, Error> {
+        await openFinderPath("~/Downloads")
     }
 
     func openRepoFolder() async -> Result<MCPToolExecutionResult, Error> {
@@ -197,13 +258,28 @@ final class AppState: ObservableObject {
     }
 
     func openAccessibilitySettings() async -> Result<MCPToolExecutionResult, Error> {
+        await openSettingsPane("accessibility")
+    }
+
+    func openScreenRecordingSettings() async -> Result<MCPToolExecutionResult, Error> {
+        await openSettingsPane("screen_recording")
+    }
+
+    func openAutomationSettings() async -> Result<MCPToolExecutionResult, Error> {
+        await openSettingsPane("automation")
+    }
+
+    func openFullDiskAccessSettings() async -> Result<MCPToolExecutionResult, Error> {
+        await openSettingsPane("full_disk_access")
+    }
+
+    private func openSettingsPane(_ pane: String) async -> Result<MCPToolExecutionResult, Error> {
         await execute(
             ResolvedTool(
                 server: NativeToolExecutor.serverName,
                 tool: NativeToolName.systemSettingsOpen.rawValue,
-                arguments: ["pane": .string("accessibility")]
+                arguments: ["pane": .string(pane)]
             )
         )
     }
-
 }

--- a/shell/Sources/MojoShell/App/AppState.swift
+++ b/shell/Sources/MojoShell/App/AppState.swift
@@ -7,17 +7,22 @@ final class AppState: ObservableObject {
     let executor: MCPToolExecutor
     let computerUseProvider: any ComputerUseProvider
     private let llmProviders: [any LLMProvider]
+    private let assemblyClickTarget: String?
 
     init(
         daemons: DaemonManager? = nil,
         executor: MCPToolExecutor? = nil,
         computerUseProvider: (any ComputerUseProvider)? = nil,
-        llmProviders: [any LLMProvider]? = nil
+        llmProviders: [any LLMProvider]? = nil,
+        assemblyClickTarget: String? = nil
     ) {
         let resolvedDaemons = daemons ?? DaemonManager()
         self.daemons = resolvedDaemons
         self.executor = executor ?? MCPToolExecutor(daemonManager: resolvedDaemons)
         self.computerUseProvider = computerUseProvider ?? CuaComputerUseProvider()
+        self.assemblyClickTarget = AppState.normalizedAssemblyClickTarget(
+            assemblyClickTarget ?? ProcessInfo.processInfo.environment["MOJOSHELL_ASSEMBLY_CLICK_TARGET"]
+        )
 
         if let llmProviders {
             self.llmProviders = llmProviders
@@ -33,6 +38,10 @@ final class AppState: ObservableObject {
         }
 
         resolvedDaemons.startAll()
+    }
+
+    var computerUseProviderName: String {
+        computerUseProvider.name
     }
 
     var llmProviderStackDescription: String {
@@ -117,25 +126,53 @@ final class AppState: ObservableObject {
     }
 
     func runAssemblyWorkflow(jobName: String) async -> Result<String, Error> {
+        let clickTarget = assemblyClickTarget ?? (computerUseProviderName == "stub" ? "Export Button" : nil)
+        guard let clickTarget else {
+            return .failure(AssemblyWorkflowError.missingClickTarget)
+        }
+
         do {
             let sessionID = try await computerUseProvider.startSession()
-            let state = try await computerUseProvider.captureState(sessionId: sessionID)
-            let actionResult = try await computerUseProvider.execute(
-                sessionId: sessionID,
-                action: ComputerUseAction(type: .click, target: "Run Assembly Workflow")
-            )
-            try await computerUseProvider.stopSession(sessionId: sessionID)
+            do {
+                let state = try await computerUseProvider.captureState(sessionId: sessionID)
+                let actionResult = try await computerUseProvider.execute(
+                    sessionId: sessionID,
+                    action: ComputerUseAction(type: .click, target: clickTarget)
+                )
+                try await computerUseProvider.stopSession(sessionId: sessionID)
 
-            return .success(
-                """
-                Session: \(sessionID)
-                Job: \(jobName)
-                Provider: \(state.appName)
-                Result: \(actionResult.message)
-                """
-            )
+                return .success(
+                    """
+                    Session: \(sessionID)
+                    Job: \(jobName)
+                    Provider: \(state.appName)
+                    Target: \(clickTarget)
+                    Result: \(actionResult.message)
+                    """
+                )
+            } catch {
+                try? await computerUseProvider.stopSession(sessionId: sessionID)
+                return .failure(error)
+            }
         } catch {
             return .failure(error)
+        }
+    }
+
+    private static func normalizedAssemblyClickTarget(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+enum AssemblyWorkflowError: LocalizedError, Equatable {
+    case missingClickTarget
+
+    var errorDescription: String? {
+        switch self {
+        case .missingClickTarget:
+            return "Assembly click target is not configured. Set MOJOSHELL_ASSEMBLY_CLICK_TARGET to coordinates like '640,400'."
         }
     }
 }

--- a/shell/Sources/MojoShell/App/ContentView.swift
+++ b/shell/Sources/MojoShell/App/ContentView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+enum ShellView: String, CaseIterable, Identifiable {
+    case cockpit = "Cockpit"
+    case terminal = "Agent Terminal"
+    case production = "Production"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .cockpit:
+            return "gauge.with.dots.needle.bottom.50percent"
+        case .terminal:
+            return "terminal"
+        case .production:
+            return "film.stack"
+        }
+    }
+}
+
+struct ContentView: View {
+    @State private var selected: ShellView? = .cockpit
+
+    var body: some View {
+        NavigationSplitView {
+            List(ShellView.allCases, selection: $selected) { view in
+                Label(view.rawValue, systemImage: view.icon)
+                    .tag(view)
+            }
+            .navigationSplitViewColumnWidth(220)
+            .listStyle(.sidebar)
+        } detail: {
+            switch selected ?? .cockpit {
+            case .cockpit:
+                CockpitView()
+            case .terminal:
+                AgentTerminalView()
+            case .production:
+                ProductionDashboardView()
+            }
+        }
+    }
+}

--- a/shell/Sources/MojoShell/App/ContentView.swift
+++ b/shell/Sources/MojoShell/App/ContentView.swift
@@ -4,6 +4,7 @@ enum ShellView: String, CaseIterable, Identifiable {
     case cockpit = "Cockpit"
     case terminal = "Agent Terminal"
     case production = "Production"
+    case audit = "Audit"
 
     var id: String { rawValue }
 
@@ -15,14 +16,18 @@ enum ShellView: String, CaseIterable, Identifiable {
             return "terminal"
         case .production:
             return "film.stack"
+        case .audit:
+            return "clock.arrow.circlepath"
         }
     }
 }
 
 struct ContentView: View {
+    @EnvironmentObject private var audit: AuditController
     @EnvironmentObject private var readiness: ReadinessState
     @Environment(\.scenePhase) private var scenePhase
     @State private var selected: ShellView? = .cockpit
+    @State private var isCommandPalettePresented = false
 
     var body: some View {
         NavigationSplitView {
@@ -43,15 +48,32 @@ struct ContentView: View {
                         AgentTerminalView()
                     case .production:
                         ProductionDashboardView()
+                    case .audit:
+                        AuditView()
                     }
                 }
+            }
+        }
+        .toolbar {
+            ToolbarItem {
+                Button("Command Palette") {
+                    isCommandPalettePresented = true
+                }
+                .keyboardShortcut("k", modifiers: [.command])
             }
         }
         .sheet(isPresented: $readiness.showFirstRunSheet) {
             FirstRunSheet()
         }
+        .sheet(isPresented: $isCommandPalettePresented) {
+            CommandPaletteView(isPresented: $isCommandPalettePresented, selectedView: $selected)
+        }
         .task {
             await readiness.refresh()
+        }
+        .onChange(of: selected) { _, newValue in
+            guard let newValue else { return }
+            audit.record(category: .navigation, title: "Selected view", detail: newValue.rawValue)
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {

--- a/shell/Sources/MojoShell/App/ContentView.swift
+++ b/shell/Sources/MojoShell/App/ContentView.swift
@@ -20,6 +20,8 @@ enum ShellView: String, CaseIterable, Identifiable {
 }
 
 struct ContentView: View {
+    @EnvironmentObject private var readiness: ReadinessState
+    @Environment(\.scenePhase) private var scenePhase
     @State private var selected: ShellView? = .cockpit
 
     var body: some View {
@@ -31,13 +33,31 @@ struct ContentView: View {
             .navigationSplitViewColumnWidth(220)
             .listStyle(.sidebar)
         } detail: {
-            switch selected ?? .cockpit {
-            case .cockpit:
-                CockpitView()
-            case .terminal:
-                AgentTerminalView()
-            case .production:
-                ProductionDashboardView()
+            VStack(spacing: 0) {
+                CoreIssuesBanner()
+                Group {
+                    switch selected ?? .cockpit {
+                    case .cockpit:
+                        CockpitView()
+                    case .terminal:
+                        AgentTerminalView()
+                    case .production:
+                        ProductionDashboardView()
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: $readiness.showFirstRunSheet) {
+            FirstRunSheet()
+        }
+        .task {
+            await readiness.refresh()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                Task {
+                    await readiness.refresh()
+                }
             }
         }
     }

--- a/shell/Sources/MojoShell/App/ContentView.swift
+++ b/shell/Sources/MojoShell/App/ContentView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-enum ShellView: String, CaseIterable, Identifiable {
+enum ShellView: String, CaseIterable, Identifiable, Codable, Sendable {
     case cockpit = "Cockpit"
     case terminal = "Agent Terminal"
     case production = "Production"
@@ -25,13 +25,13 @@ enum ShellView: String, CaseIterable, Identifiable {
 struct ContentView: View {
     @EnvironmentObject private var audit: AuditController
     @EnvironmentObject private var readiness: ReadinessState
+    @EnvironmentObject private var session: ShellSessionController
     @Environment(\.scenePhase) private var scenePhase
-    @State private var selected: ShellView? = .cockpit
     @State private var isCommandPalettePresented = false
 
     var body: some View {
         NavigationSplitView {
-            List(ShellView.allCases, selection: $selected) { view in
+            List(ShellView.allCases, selection: selectedBinding) { view in
                 Label(view.rawValue, systemImage: view.icon)
                     .tag(view)
             }
@@ -41,7 +41,7 @@ struct ContentView: View {
             VStack(spacing: 0) {
                 CoreIssuesBanner()
                 Group {
-                    switch selected ?? .cockpit {
+                    switch session.selectedView {
                     case .cockpit:
                         CockpitView()
                     case .terminal:
@@ -66,13 +66,12 @@ struct ContentView: View {
             FirstRunSheet()
         }
         .sheet(isPresented: $isCommandPalettePresented) {
-            CommandPaletteView(isPresented: $isCommandPalettePresented, selectedView: $selected)
+            CommandPaletteView(isPresented: $isCommandPalettePresented, selectedView: selectedBinding)
         }
         .task {
             await readiness.refresh()
         }
-        .onChange(of: selected) { _, newValue in
-            guard let newValue else { return }
+        .onChange(of: session.selectedView) { _, newValue in
             audit.record(category: .navigation, title: "Selected view", detail: newValue.rawValue)
         }
         .onChange(of: scenePhase) { _, newPhase in
@@ -82,5 +81,15 @@ struct ContentView: View {
                 }
             }
         }
+    }
+
+    private var selectedBinding: Binding<ShellView?> {
+        Binding<ShellView?>(
+            get: { session.selectedView },
+            set: { newValue in
+                guard let newValue else { return }
+                session.selectedView = newValue
+            }
+        )
     }
 }

--- a/shell/Sources/MojoShell/App/MenuBarShellView.swift
+++ b/shell/Sources/MojoShell/App/MenuBarShellView.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+struct MenuBarShellView: View {
+    @Environment(\.openWindow) private var openWindow
+    @EnvironmentObject private var appState: AppState
+    @EnvironmentObject private var production: ProductionController
+    @EnvironmentObject private var readiness: ReadinessState
+    @EnvironmentObject private var session: ShellSessionController
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(statusTitle, systemImage: statusIcon)
+                .font(.headline)
+
+            Text(statusSubtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            Button("Open Cockpit") {
+                openMainWindow(.cockpit)
+            }
+            Button("Open Agent Terminal") {
+                openMainWindow(.terminal)
+            }
+            Button("Open Production") {
+                openMainWindow(.production)
+            }
+            Button("Open Audit") {
+                openMainWindow(.audit)
+            }
+
+            Divider()
+
+            Button("Run Next Workflow") {
+                openMainWindow(.production)
+                Task { await production.runNextWorkflow() }
+            }
+            .disabled(production.isRunningWorkflow || !readiness.isReady(for: .computerUse))
+
+            Button("Restart All Daemons") {
+                appState.daemons.restartAll()
+            }
+
+            if let target = production.defaultExportTarget {
+                Button("Open Default Export Target") {
+                    Task { _ = await appState.openFinderPath(target.path) }
+                }
+            }
+
+            Divider()
+
+            if production.jobs.isEmpty {
+                Text("No queued jobs.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("\(queuedJobCount) queued job(s)")
+                    .font(.caption)
+                Text("\(failedJobCount) failed or canceled")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .frame(width: 280)
+        .task {
+            await readiness.refresh()
+        }
+    }
+
+    private var queuedJobCount: Int {
+        production.jobs.filter { $0.status == .queued }.count
+    }
+
+    private var failedJobCount: Int {
+        production.jobs.filter { $0.status == .failed || $0.status == .canceled }.count
+    }
+
+    private var statusIcon: String {
+        if hasBlockingIssue {
+            return "exclamationmark.triangle.fill"
+        }
+        if hasAnyIssue {
+            return "exclamationmark.circle"
+        }
+        return "checkmark.circle.fill"
+    }
+
+    private var statusTitle: String {
+        if hasBlockingIssue {
+            return "MojoShell needs attention"
+        }
+        if hasAnyIssue {
+            return "MojoShell partially ready"
+        }
+        return "MojoShell ready"
+    }
+
+    private var statusSubtitle: String {
+        if let issue = readiness.coreIssues.first ?? readiness.featureIssues.values.flatMap({ $0 }).first {
+            return issue.fixInstruction
+        }
+        return "Queued jobs: \(queuedJobCount) • Provider: \(appState.computerUseProviderName)"
+    }
+
+    private var hasBlockingIssue: Bool {
+        readiness.coreIssues.contains(where: { $0.severity == .blocking })
+            || readiness.featureIssues.values.flatMap({ $0 }).contains(where: { $0.severity == .blocking })
+    }
+
+    private var hasAnyIssue: Bool {
+        !readiness.coreIssues.isEmpty || readiness.featureIssues.values.contains(where: { !$0.isEmpty })
+    }
+
+    private func openMainWindow(_ view: ShellView) {
+        session.selectedView = view
+        openWindow(id: "main")
+    }
+}

--- a/shell/Sources/MojoShell/App/MenuBarShellView.swift
+++ b/shell/Sources/MojoShell/App/MenuBarShellView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MenuBarShellView: View {
     @Environment(\.openWindow) private var openWindow
     @EnvironmentObject private var appState: AppState
+    @EnvironmentObject private var brain: BrainManager
     @EnvironmentObject private var production: ProductionController
     @EnvironmentObject private var readiness: ReadinessState
     @EnvironmentObject private var session: ShellSessionController
@@ -41,6 +42,30 @@ struct MenuBarShellView: View {
 
             Button("Restart All Daemons") {
                 appState.daemons.restartAll()
+            }
+
+            Button("Build All Daemons") {
+                Task { await appState.daemons.buildAll() }
+            }
+
+            Divider()
+
+            Button("Use Repo Brain") {
+                brain.useRepoDefault()
+                appState.daemons.restart(serverName: "knowledge-corpus")
+            }
+
+            Button("Use Local Brain") {
+                do {
+                    try brain.useLocalBrain()
+                    appState.daemons.restart(serverName: "knowledge-corpus")
+                } catch {
+                    // Ignore here; readiness surface will show issues.
+                }
+            }
+
+            Button("Reveal Active Brain") {
+                Task { _ = await appState.revealBrainFile() }
             }
 
             if let target = production.defaultExportTarget {

--- a/shell/Sources/MojoShell/App/MenuBarShellView.swift
+++ b/shell/Sources/MojoShell/App/MenuBarShellView.swift
@@ -4,6 +4,7 @@ struct MenuBarShellView: View {
     @Environment(\.openWindow) private var openWindow
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var brain: BrainManager
+    @EnvironmentObject private var preferences: ShellPreferencesController
     @EnvironmentObject private var production: ProductionController
     @EnvironmentObject private var readiness: ReadinessState
     @EnvironmentObject private var session: ShellSessionController
@@ -40,6 +41,11 @@ struct MenuBarShellView: View {
             }
             .disabled(production.isRunningWorkflow || !readiness.isReady(for: .computerUse))
 
+            Button("Run Morning Ops") {
+                openMainWindow(.cockpit)
+                session.requestMorningOpsRun()
+            }
+
             Button("Restart All Daemons") {
                 appState.daemons.restartAll()
             }
@@ -67,6 +73,8 @@ struct MenuBarShellView: View {
             Button("Reveal Active Brain") {
                 Task { _ = await appState.revealBrainFile() }
             }
+
+            Toggle("Morning Ops on Launch", isOn: $preferences.morningOpsOnLaunch)
 
             if let target = production.defaultExportTarget {
                 Button("Open Default Export Target") {

--- a/shell/Sources/MojoShell/App/MojoShellApp.swift
+++ b/shell/Sources/MojoShell/App/MojoShellApp.swift
@@ -1,13 +1,22 @@
 import SwiftUI
 
+@MainActor
 @main
 struct MojoShellApp: App {
-    @StateObject private var appState = AppState()
+    @StateObject private var appState: AppState
+    @StateObject private var readiness: ReadinessState
+
+    init() {
+        let daemonManager = DaemonManager()
+        _appState = StateObject(wrappedValue: AppState(daemons: daemonManager))
+        _readiness = StateObject(wrappedValue: ReadinessState(daemonManager: daemonManager))
+    }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(appState)
+                .environmentObject(readiness)
                 .frame(minWidth: 1000, minHeight: 650)
         }
         .windowStyle(.hiddenTitleBar)

--- a/shell/Sources/MojoShell/App/MojoShellApp.swift
+++ b/shell/Sources/MojoShell/App/MojoShellApp.swift
@@ -8,7 +8,25 @@ struct MojoShellApp: App {
     @StateObject private var production: ProductionController
 
     init() {
-        let daemonManager = DaemonManager()
+        let notifications = AppNotificationManager()
+        let daemonManager = DaemonManager(
+            onRuntimeStateChanged: { previous, current in
+                guard current.status == .failed, previous?.status != .failed else {
+                    return
+                }
+
+                let body: String
+                if let lastError = current.lastError, !lastError.isEmpty {
+                    body = "\(current.serverName): \(lastError)"
+                } else {
+                    body = current.serverName
+                }
+
+                Task {
+                    await notifications.deliver(title: "MojoShell Daemon Failed", body: body)
+                }
+            }
+        )
         let computerUseProvider: any ComputerUseProvider = CuaComputerUseProvider()
         let nativeExecutor: any NativeToolExecuting = NativeToolExecutor(repoRoot: daemonManager.repoRoot)
         _appState = StateObject(
@@ -20,7 +38,10 @@ struct MojoShellApp: App {
         )
         _readiness = StateObject(wrappedValue: ReadinessState(daemonManager: daemonManager))
         _production = StateObject(
-            wrappedValue: ProductionController(computerUseProvider: computerUseProvider)
+            wrappedValue: ProductionController(
+                computerUseProvider: computerUseProvider,
+                notifications: notifications
+            )
         )
     }
 

--- a/shell/Sources/MojoShell/App/MojoShellApp.swift
+++ b/shell/Sources/MojoShell/App/MojoShellApp.swift
@@ -10,10 +10,12 @@ struct MojoShellApp: App {
     init() {
         let daemonManager = DaemonManager()
         let computerUseProvider: any ComputerUseProvider = CuaComputerUseProvider()
+        let nativeExecutor: any NativeToolExecuting = NativeToolExecutor(repoRoot: daemonManager.repoRoot)
         _appState = StateObject(
             wrappedValue: AppState(
                 daemons: daemonManager,
-                computerUseProvider: computerUseProvider
+                computerUseProvider: computerUseProvider,
+                nativeExecutor: nativeExecutor
             )
         )
         _readiness = StateObject(wrappedValue: ReadinessState(daemonManager: daemonManager))

--- a/shell/Sources/MojoShell/App/MojoShellApp.swift
+++ b/shell/Sources/MojoShell/App/MojoShellApp.swift
@@ -7,10 +7,12 @@ struct MojoShellApp: App {
     @StateObject private var audit: AuditController
     @StateObject private var readiness: ReadinessState
     @StateObject private var production: ProductionController
+    @StateObject private var session: ShellSessionController
 
     init() {
         let notifications = AppNotificationManager()
         let audit = AuditController()
+        let session = ShellSessionController()
         let daemonManager = DaemonManager(
             onRuntimeStateChanged: { previous, current in
                 audit.record(
@@ -42,6 +44,7 @@ struct MojoShellApp: App {
         let computerUseProvider: any ComputerUseProvider = CuaComputerUseProvider()
         let nativeExecutor: any NativeToolExecuting = NativeToolExecutor(repoRoot: daemonManager.repoRoot)
         _audit = StateObject(wrappedValue: audit)
+        _session = StateObject(wrappedValue: session)
         _appState = StateObject(
             wrappedValue: AppState(
                 daemons: daemonManager,
@@ -65,17 +68,27 @@ struct MojoShellApp: App {
     }
 
     var body: some Scene {
-        WindowGroup {
+        WindowGroup("MojoShell", id: "main") {
             ContentView()
                 .environmentObject(appState)
                 .environmentObject(audit)
                 .environmentObject(readiness)
                 .environmentObject(production)
+                .environmentObject(session)
                 .frame(minWidth: 1000, minHeight: 650)
         }
         .windowStyle(.hiddenTitleBar)
         .commands {
             CommandGroup(replacing: .newItem) {}
+        }
+
+        MenuBarExtra("MojoShell", systemImage: "switch.2") {
+            MenuBarShellView()
+                .environmentObject(appState)
+                .environmentObject(audit)
+                .environmentObject(readiness)
+                .environmentObject(production)
+                .environmentObject(session)
         }
     }
 }

--- a/shell/Sources/MojoShell/App/MojoShellApp.swift
+++ b/shell/Sources/MojoShell/App/MojoShellApp.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct MojoShellApp: App {
     @StateObject private var appState: AppState
     @StateObject private var audit: AuditController
+    @StateObject private var brain: BrainManager
     @StateObject private var readiness: ReadinessState
     @StateObject private var production: ProductionController
     @StateObject private var session: ShellSessionController
@@ -13,7 +14,11 @@ struct MojoShellApp: App {
         let notifications = AppNotificationManager()
         let audit = AuditController()
         let session = ShellSessionController()
+        let repoRoot = DaemonManager.defaultRepoRoot()
+        let brain = BrainManager(repoRoot: repoRoot)
         let daemonManager = DaemonManager(
+            repoRoot: repoRoot,
+            brainPathProvider: { brain.activeBrainPath },
             onRuntimeStateChanged: { previous, current in
                 audit.record(
                     category: .daemon,
@@ -42,8 +47,12 @@ struct MojoShellApp: App {
             }
         )
         let computerUseProvider: any ComputerUseProvider = CuaComputerUseProvider()
-        let nativeExecutor: any NativeToolExecuting = NativeToolExecutor(repoRoot: daemonManager.repoRoot)
+        let nativeExecutor: any NativeToolExecuting = NativeToolExecutor(
+            repoRoot: daemonManager.repoRoot,
+            brainPathProvider: { brain.activeBrainPath }
+        )
         _audit = StateObject(wrappedValue: audit)
+        _brain = StateObject(wrappedValue: brain)
         _session = StateObject(wrappedValue: session)
         _appState = StateObject(
             wrappedValue: AppState(
@@ -55,7 +64,12 @@ struct MojoShellApp: App {
                 }
             )
         )
-        _readiness = StateObject(wrappedValue: ReadinessState(daemonManager: daemonManager))
+        _readiness = StateObject(
+            wrappedValue: ReadinessState(
+                daemonManager: daemonManager,
+                brainPathProvider: { brain.activeBrainPath }
+            )
+        )
         _production = StateObject(
             wrappedValue: ProductionController(
                 computerUseProvider: computerUseProvider,
@@ -72,6 +86,7 @@ struct MojoShellApp: App {
             ContentView()
                 .environmentObject(appState)
                 .environmentObject(audit)
+                .environmentObject(brain)
                 .environmentObject(readiness)
                 .environmentObject(production)
                 .environmentObject(session)
@@ -86,6 +101,7 @@ struct MojoShellApp: App {
             MenuBarShellView()
                 .environmentObject(appState)
                 .environmentObject(audit)
+                .environmentObject(brain)
                 .environmentObject(readiness)
                 .environmentObject(production)
                 .environmentObject(session)

--- a/shell/Sources/MojoShell/App/MojoShellApp.swift
+++ b/shell/Sources/MojoShell/App/MojoShellApp.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+@main
+struct MojoShellApp: App {
+    @StateObject private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(appState)
+                .frame(minWidth: 1000, minHeight: 650)
+        }
+        .windowStyle(.hiddenTitleBar)
+        .commands {
+            CommandGroup(replacing: .newItem) {}
+        }
+    }
+}

--- a/shell/Sources/MojoShell/App/MojoShellApp.swift
+++ b/shell/Sources/MojoShell/App/MojoShellApp.swift
@@ -4,13 +4,25 @@ import SwiftUI
 @main
 struct MojoShellApp: App {
     @StateObject private var appState: AppState
+    @StateObject private var audit: AuditController
     @StateObject private var readiness: ReadinessState
     @StateObject private var production: ProductionController
 
     init() {
         let notifications = AppNotificationManager()
+        let audit = AuditController()
         let daemonManager = DaemonManager(
             onRuntimeStateChanged: { previous, current in
+                audit.record(
+                    category: .daemon,
+                    title: "Daemon state changed",
+                    detail: "\(current.serverName) -> \(current.status.rawValue)",
+                    metadata: [
+                        "previous": previous?.status.rawValue ?? "none",
+                        "error": current.lastError ?? "",
+                    ]
+                )
+
                 guard current.status == .failed, previous?.status != .failed else {
                     return
                 }
@@ -29,18 +41,25 @@ struct MojoShellApp: App {
         )
         let computerUseProvider: any ComputerUseProvider = CuaComputerUseProvider()
         let nativeExecutor: any NativeToolExecuting = NativeToolExecutor(repoRoot: daemonManager.repoRoot)
+        _audit = StateObject(wrappedValue: audit)
         _appState = StateObject(
             wrappedValue: AppState(
                 daemons: daemonManager,
                 computerUseProvider: computerUseProvider,
-                nativeExecutor: nativeExecutor
+                nativeExecutor: nativeExecutor,
+                auditRecorder: { category, title, detail, metadata in
+                    audit.record(category: category, title: title, detail: detail, metadata: metadata)
+                }
             )
         )
         _readiness = StateObject(wrappedValue: ReadinessState(daemonManager: daemonManager))
         _production = StateObject(
             wrappedValue: ProductionController(
                 computerUseProvider: computerUseProvider,
-                notifications: notifications
+                notifications: notifications,
+                auditRecorder: { category, title, detail, metadata in
+                    audit.record(category: category, title: title, detail: detail, metadata: metadata)
+                }
             )
         )
     }
@@ -49,6 +68,7 @@ struct MojoShellApp: App {
         WindowGroup {
             ContentView()
                 .environmentObject(appState)
+                .environmentObject(audit)
                 .environmentObject(readiness)
                 .environmentObject(production)
                 .frame(minWidth: 1000, minHeight: 650)

--- a/shell/Sources/MojoShell/App/MojoShellApp.swift
+++ b/shell/Sources/MojoShell/App/MojoShellApp.swift
@@ -5,11 +5,21 @@ import SwiftUI
 struct MojoShellApp: App {
     @StateObject private var appState: AppState
     @StateObject private var readiness: ReadinessState
+    @StateObject private var production: ProductionController
 
     init() {
         let daemonManager = DaemonManager()
-        _appState = StateObject(wrappedValue: AppState(daemons: daemonManager))
+        let computerUseProvider: any ComputerUseProvider = CuaComputerUseProvider()
+        _appState = StateObject(
+            wrappedValue: AppState(
+                daemons: daemonManager,
+                computerUseProvider: computerUseProvider
+            )
+        )
         _readiness = StateObject(wrappedValue: ReadinessState(daemonManager: daemonManager))
+        _production = StateObject(
+            wrappedValue: ProductionController(computerUseProvider: computerUseProvider)
+        )
     }
 
     var body: some Scene {
@@ -17,6 +27,7 @@ struct MojoShellApp: App {
             ContentView()
                 .environmentObject(appState)
                 .environmentObject(readiness)
+                .environmentObject(production)
                 .frame(minWidth: 1000, minHeight: 650)
         }
         .windowStyle(.hiddenTitleBar)

--- a/shell/Sources/MojoShell/App/MojoShellApp.swift
+++ b/shell/Sources/MojoShell/App/MojoShellApp.swift
@@ -6,6 +6,7 @@ struct MojoShellApp: App {
     @StateObject private var appState: AppState
     @StateObject private var audit: AuditController
     @StateObject private var brain: BrainManager
+    @StateObject private var preferences: ShellPreferencesController
     @StateObject private var readiness: ReadinessState
     @StateObject private var production: ProductionController
     @StateObject private var session: ShellSessionController
@@ -14,6 +15,7 @@ struct MojoShellApp: App {
         let notifications = AppNotificationManager()
         let audit = AuditController()
         let session = ShellSessionController()
+        let preferences = ShellPreferencesController()
         let repoRoot = DaemonManager.defaultRepoRoot()
         let brain = BrainManager(repoRoot: repoRoot)
         let daemonManager = DaemonManager(
@@ -53,6 +55,7 @@ struct MojoShellApp: App {
         )
         _audit = StateObject(wrappedValue: audit)
         _brain = StateObject(wrappedValue: brain)
+        _preferences = StateObject(wrappedValue: preferences)
         _session = StateObject(wrappedValue: session)
         _appState = StateObject(
             wrappedValue: AppState(
@@ -61,7 +64,8 @@ struct MojoShellApp: App {
                 nativeExecutor: nativeExecutor,
                 auditRecorder: { category, title, detail, metadata in
                     audit.record(category: category, title: title, detail: detail, metadata: metadata)
-                }
+                },
+                startDaemonsOnInit: preferences.autoStartDaemonsOnLaunch
             )
         )
         _readiness = StateObject(
@@ -87,6 +91,7 @@ struct MojoShellApp: App {
                 .environmentObject(appState)
                 .environmentObject(audit)
                 .environmentObject(brain)
+                .environmentObject(preferences)
                 .environmentObject(readiness)
                 .environmentObject(production)
                 .environmentObject(session)
@@ -102,6 +107,7 @@ struct MojoShellApp: App {
                 .environmentObject(appState)
                 .environmentObject(audit)
                 .environmentObject(brain)
+                .environmentObject(preferences)
                 .environmentObject(readiness)
                 .environmentObject(production)
                 .environmentObject(session)

--- a/shell/Sources/MojoShell/App/ShellPreferencesController.swift
+++ b/shell/Sources/MojoShell/App/ShellPreferencesController.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+struct ShellPreferencesSnapshot: Codable, Equatable, Sendable {
+    var autoStartDaemonsOnLaunch: Bool
+    var autoRefreshNowPlaying: Bool
+    var morningOpsOnLaunch: Bool
+    var lastMorningOpsRunAt: Date?
+}
+
+struct ShellPreferencesStore {
+    let fileURL: URL
+    private let fileManager: FileManager
+
+    init(
+        fileURL: URL = ShellPreferencesStore.defaultFileURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func load() throws -> ShellPreferencesSnapshot? {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return nil
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        guard !data.isEmpty else {
+            return nil
+        }
+
+        return try JSONDecoder().decode(ShellPreferencesSnapshot.self, from: data)
+    }
+
+    func save(_ snapshot: ShellPreferencesSnapshot) throws {
+        let parent = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(snapshot)
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    static func defaultFileURL() -> URL {
+        JobStore.defaultFileURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("shell-preferences.json")
+    }
+}
+
+@MainActor
+final class ShellPreferencesController: ObservableObject {
+    @Published var autoStartDaemonsOnLaunch: Bool { didSet { persistIfReady() } }
+    @Published var autoRefreshNowPlaying: Bool { didSet { persistIfReady() } }
+    @Published var morningOpsOnLaunch: Bool { didSet { persistIfReady() } }
+    @Published private(set) var lastMorningOpsRunAt: Date? { didSet { persistIfReady() } }
+
+    private let store: ShellPreferencesStore
+    private var isHydrating = true
+
+    init(store: ShellPreferencesStore = ShellPreferencesStore()) {
+        self.store = store
+        let snapshot = (try? store.load()) ?? nil
+        self.autoStartDaemonsOnLaunch = snapshot?.autoStartDaemonsOnLaunch ?? true
+        self.autoRefreshNowPlaying = snapshot?.autoRefreshNowPlaying ?? true
+        self.morningOpsOnLaunch = snapshot?.morningOpsOnLaunch ?? false
+        self.lastMorningOpsRunAt = snapshot?.lastMorningOpsRunAt
+        self.isHydrating = false
+        persistIfReady()
+    }
+
+    func recordMorningOpsRun(at date: Date = Date()) {
+        lastMorningOpsRunAt = date
+    }
+
+    private func persistIfReady() {
+        guard !isHydrating else {
+            return
+        }
+
+        do {
+            try store.save(
+                ShellPreferencesSnapshot(
+                    autoStartDaemonsOnLaunch: autoStartDaemonsOnLaunch,
+                    autoRefreshNowPlaying: autoRefreshNowPlaying,
+                    morningOpsOnLaunch: morningOpsOnLaunch,
+                    lastMorningOpsRunAt: lastMorningOpsRunAt
+                )
+            )
+        } catch {
+            // Preferences persistence must never crash the shell.
+        }
+    }
+}

--- a/shell/Sources/MojoShell/App/ShellSessionController.swift
+++ b/shell/Sources/MojoShell/App/ShellSessionController.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+struct ShellSessionSnapshot: Codable, Equatable, Sendable {
+    var selectedView: ShellView
+    var terminalHistory: [TerminalEntry]
+    var preferredPreset: ProductionWorkflowPreset
+    var preferredExportTargetID: UUID?
+    var preferredApprovalMode: WorkflowApprovalMode
+}
+
+struct ShellSessionStore {
+    let fileURL: URL
+    private let fileManager: FileManager
+
+    init(
+        fileURL: URL = ShellSessionStore.defaultFileURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func load() throws -> ShellSessionSnapshot? {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return nil
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        guard !data.isEmpty else {
+            return nil
+        }
+
+        return try JSONDecoder().decode(ShellSessionSnapshot.self, from: data)
+    }
+
+    func save(_ snapshot: ShellSessionSnapshot) throws {
+        let parent = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(snapshot)
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    static func defaultFileURL() -> URL {
+        JobStore.defaultFileURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("shell-session.json")
+    }
+}
+
+@MainActor
+final class ShellSessionController: ObservableObject {
+    @Published var selectedView: ShellView { didSet { persistIfReady() } }
+    @Published var terminalHistory: [TerminalEntry] { didSet { persistIfReady() } }
+    @Published var preferredPreset: ProductionWorkflowPreset { didSet { persistIfReady() } }
+    @Published var preferredExportTargetID: UUID? { didSet { persistIfReady() } }
+    @Published var preferredApprovalMode: WorkflowApprovalMode { didSet { persistIfReady() } }
+
+    private let store: ShellSessionStore
+    private var isHydrating = true
+
+    init(store: ShellSessionStore = ShellSessionStore()) {
+        self.store = store
+
+        let snapshot = (try? store.load()) ?? nil
+        self.selectedView = snapshot?.selectedView ?? .cockpit
+        self.terminalHistory = snapshot?.terminalHistory ?? [TerminalEntry.initialSystemEntry]
+        self.preferredPreset = snapshot?.preferredPreset ?? .fcpExportCurrentTimeline
+        self.preferredExportTargetID = snapshot?.preferredExportTargetID
+        self.preferredApprovalMode = snapshot?.preferredApprovalMode ?? .smart
+        self.isHydrating = false
+        persistIfReady()
+    }
+
+    func appendTerminalEntry(_ entry: TerminalEntry) {
+        terminalHistory.append(entry)
+        if terminalHistory.count > 500 {
+            terminalHistory.removeFirst(terminalHistory.count - 500)
+        }
+    }
+
+    func clearTerminalHistory() {
+        terminalHistory = [TerminalEntry.initialSystemEntry]
+    }
+
+    private func persistIfReady() {
+        guard !isHydrating else {
+            return
+        }
+
+        do {
+            try store.save(
+                ShellSessionSnapshot(
+                    selectedView: selectedView,
+                    terminalHistory: terminalHistory,
+                    preferredPreset: preferredPreset,
+                    preferredExportTargetID: preferredExportTargetID,
+                    preferredApprovalMode: preferredApprovalMode
+                )
+            )
+        } catch {
+            // Session persistence should never crash the shell.
+        }
+    }
+}

--- a/shell/Sources/MojoShell/App/ShellSessionController.swift
+++ b/shell/Sources/MojoShell/App/ShellSessionController.swift
@@ -54,6 +54,7 @@ final class ShellSessionController: ObservableObject {
     @Published var preferredPreset: ProductionWorkflowPreset { didSet { persistIfReady() } }
     @Published var preferredExportTargetID: UUID? { didSet { persistIfReady() } }
     @Published var preferredApprovalMode: WorkflowApprovalMode { didSet { persistIfReady() } }
+    @Published var morningOpsRequestID: UUID?
 
     private let store: ShellSessionStore
     private var isHydrating = true
@@ -80,6 +81,10 @@ final class ShellSessionController: ObservableObject {
 
     func clearTerminalHistory() {
         terminalHistory = [TerminalEntry.initialSystemEntry]
+    }
+
+    func requestMorningOpsRun() {
+        morningOpsRequestID = UUID()
     }
 
     private func persistIfReady() {

--- a/shell/Sources/MojoShell/Audit/AuditController.swift
+++ b/shell/Sources/MojoShell/Audit/AuditController.swift
@@ -100,6 +100,10 @@ final class AuditController: ObservableObject {
         load()
     }
 
+    var filePath: String {
+        store.fileURL.path
+    }
+
     func record(
         category: AuditCategory,
         title: String,
@@ -133,6 +137,22 @@ final class AuditController: ObservableObject {
 
     func refresh() {
         load()
+    }
+
+    func clear() {
+        do {
+            try store.save([])
+            events = []
+        } catch {
+            events = [
+                AuditEvent(
+                    timestamp: now(),
+                    category: .system,
+                    title: "Audit clear failure",
+                    detail: error.localizedDescription
+                ),
+            ]
+        }
     }
 
     private func load() {

--- a/shell/Sources/MojoShell/Audit/AuditController.swift
+++ b/shell/Sources/MojoShell/Audit/AuditController.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+enum AuditCategory: String, Codable, CaseIterable, Sendable {
+    case navigation
+    case commandPalette
+    case daemon
+    case mcp
+    case native
+    case production
+    case llm
+    case system
+}
+
+struct AuditEvent: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
+    let timestamp: Date
+    let category: AuditCategory
+    let title: String
+    let detail: String
+    let metadata: [String: String]
+
+    init(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        category: AuditCategory,
+        title: String,
+        detail: String,
+        metadata: [String: String] = [:]
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.category = category
+        self.title = title
+        self.detail = detail
+        self.metadata = metadata
+    }
+}
+
+struct AuditStore {
+    let fileURL: URL
+    private let fileManager: FileManager
+
+    init(
+        fileURL: URL = AuditStore.defaultFileURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func load() throws -> [AuditEvent] {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return []
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        guard !data.isEmpty else {
+            return []
+        }
+
+        return try JSONDecoder().decode([AuditEvent].self, from: data)
+    }
+
+    func append(_ event: AuditEvent, limit: Int = 500) throws {
+        var all = try load()
+        all.append(event)
+        if all.count > limit {
+            all.removeFirst(all.count - limit)
+        }
+        try save(all)
+    }
+
+    func save(_ events: [AuditEvent]) throws {
+        let parent = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(events)
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    static func defaultFileURL() -> URL {
+        JobStore.defaultFileURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("audit-log.json")
+    }
+}
+
+@MainActor
+final class AuditController: ObservableObject {
+    @Published private(set) var events: [AuditEvent] = []
+
+    private let store: AuditStore
+    private let now: () -> Date
+
+    init(
+        store: AuditStore = AuditStore(),
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.store = store
+        self.now = now
+        load()
+    }
+
+    func record(
+        category: AuditCategory,
+        title: String,
+        detail: String,
+        metadata: [String: String] = [:]
+    ) {
+        let event = AuditEvent(
+            timestamp: now(),
+            category: category,
+            title: title,
+            detail: detail,
+            metadata: metadata
+        )
+
+        do {
+            try store.append(event)
+            events.append(event)
+            if events.count > 500 {
+                events.removeFirst(events.count - 500)
+            }
+        } catch {
+            let fallback = AuditEvent(
+                timestamp: now(),
+                category: .system,
+                title: "Audit persistence failure",
+                detail: error.localizedDescription
+            )
+            events.append(fallback)
+        }
+    }
+
+    func refresh() {
+        load()
+    }
+
+    private func load() {
+        do {
+            events = try store.load()
+        } catch {
+            events = [
+                AuditEvent(
+                    timestamp: now(),
+                    category: .system,
+                    title: "Audit load failure",
+                    detail: error.localizedDescription
+                ),
+            ]
+        }
+    }
+}

--- a/shell/Sources/MojoShell/Automation/AppleScriptAutomationAdapter.swift
+++ b/shell/Sources/MojoShell/Automation/AppleScriptAutomationAdapter.swift
@@ -11,6 +11,8 @@ protocol AppleAutomationProviding: Sendable {
     func listFinderSelection() async throws -> [String]
     func openSafariURL(_ url: String) async throws
     func currentSafariTab() async throws -> SafariTabState
+    func runTerminalCommand(_ command: String, in path: String) async throws
+    func runITermCommand(_ command: String, in path: String) async throws
 }
 
 actor AppleScriptAutomationAdapter: AppleAutomationProviding {
@@ -93,6 +95,32 @@ actor AppleScriptAutomationAdapter: AppleAutomationProviding {
             title: lines.first ?? "Unknown",
             url: lines.dropFirst().first ?? ""
         )
+    }
+
+    func runTerminalCommand(_ command: String, in path: String) async throws {
+        _ = try await scriptRunner("""
+        tell application "Terminal"
+            activate
+            if (count of windows) is 0 then
+                do script ""
+            end if
+            do script "cd " & quoted form of "\(escapeAppleScriptString(path))" & "; " & "\(escapeAppleScriptString(command))" in front window
+        end tell
+        """)
+    }
+
+    func runITermCommand(_ command: String, in path: String) async throws {
+        _ = try await scriptRunner("""
+        tell application "iTerm"
+            activate
+            if (count of windows) is 0 then
+                create window with default profile
+            end if
+            tell current session of current window
+                write text "cd " & quoted form of "\(escapeAppleScriptString(path))" & "; " & "\(escapeAppleScriptString(command))"
+            end tell
+        end tell
+        """)
     }
 
     private func escapeAppleScriptString(_ value: String) -> String {

--- a/shell/Sources/MojoShell/Automation/AppleScriptAutomationAdapter.swift
+++ b/shell/Sources/MojoShell/Automation/AppleScriptAutomationAdapter.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+struct SafariTabState: Equatable, Sendable {
+    let title: String
+    let url: String
+}
+
+protocol AppleAutomationProviding: Sendable {
+    func openFinderPath(_ path: String) async throws
+    func revealFinderPath(_ path: String) async throws
+    func listFinderSelection() async throws -> [String]
+    func openSafariURL(_ url: String) async throws
+    func currentSafariTab() async throws -> SafariTabState
+}
+
+actor AppleScriptAutomationAdapter: AppleAutomationProviding {
+    private let scriptRunner: @Sendable (String) async throws -> String
+
+    init(
+        scriptRunner: @escaping @Sendable (String) async throws -> String = AppleScriptAutomationAdapter.defaultScriptRunner
+    ) {
+        self.scriptRunner = scriptRunner
+    }
+
+    func openFinderPath(_ path: String) async throws {
+        _ = try await scriptRunner("""
+        tell application "Finder"
+            activate
+            open POSIX file "\(escapeAppleScriptString(path))"
+        end tell
+        """)
+    }
+
+    func revealFinderPath(_ path: String) async throws {
+        _ = try await scriptRunner("""
+        tell application "Finder"
+            activate
+            reveal POSIX file "\(escapeAppleScriptString(path))"
+        end tell
+        """)
+    }
+
+    func listFinderSelection() async throws -> [String] {
+        let selection = try await scriptRunner("""
+        tell application "Finder"
+            set selectedItems to selection
+            set outList to {}
+            repeat with anItem in selectedItems
+                set end of outList to POSIX path of (anItem as alias)
+            end repeat
+            set AppleScript's text item delimiters to linefeed
+            set joined to outList as string
+            set AppleScript's text item delimiters to ""
+            return joined
+        end tell
+        """)
+
+        return selection
+            .split(separator: "\n")
+            .map(String.init)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    func openSafariURL(_ url: String) async throws {
+        _ = try await scriptRunner("""
+        tell application "Safari"
+            activate
+            if (count of windows) is 0 then
+                make new document with properties {URL:"\(escapeAppleScriptString(url))"}
+            else
+                set URL of current tab of front window to "\(escapeAppleScriptString(url))"
+            end if
+        end tell
+        """)
+    }
+
+    func currentSafariTab() async throws -> SafariTabState {
+        let response = try await scriptRunner("""
+        tell application "Safari"
+            if (count of windows) is 0 then error "Safari has no open windows."
+            set tabName to name of current tab of front window
+            set tabURL to URL of current tab of front window
+            return tabName & linefeed & tabURL
+        end tell
+        """)
+
+        let lines = response
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+
+        return SafariTabState(
+            title: lines.first ?? "Unknown",
+            url: lines.dropFirst().first ?? ""
+        )
+    }
+
+    private func escapeAppleScriptString(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    private static func defaultScriptRunner(script: String) async throws -> String {
+        try await ProcessCommandRunner.run("/usr/bin/osascript", ["-e", script], nil)
+    }
+}

--- a/shell/Sources/MojoShell/Automation/NativeToolExecutor.swift
+++ b/shell/Sources/MojoShell/Automation/NativeToolExecutor.swift
@@ -1,0 +1,319 @@
+import AppKit
+import Foundation
+
+protocol NativeToolExecuting: Sendable {
+    func execute(tool: String, arguments: [String: AnyCodable]) async throws -> MCPToolExecutionResult
+}
+
+enum NativeToolName: String, Sendable {
+    case finderOpenPath = "finder_open_path"
+    case finderOpenRepoRoot = "finder_open_repo_root"
+    case finderRevealPath = "finder_reveal_path"
+    case finderRevealBrainFile = "finder_reveal_brain_file"
+    case finderListSelection = "finder_list_selection"
+    case safariOpenURL = "safari_open_url"
+    case safariCurrentTab = "safari_current_tab"
+    case shortcutsList = "shortcuts_list"
+    case shortcutsRun = "shortcuts_run"
+    case systemSettingsOpen = "system_settings_open"
+}
+
+enum NativeToolError: LocalizedError, Equatable {
+    case unknownTool(String)
+    case missingArgument(String)
+    case invalidURL(String)
+    case pathNotFound(String)
+    case commandFailed(String)
+    case cannotOpenURL(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unknownTool(let tool):
+            return "Unknown native tool: \(tool)"
+        case .missingArgument(let name):
+            return "Missing required argument: \(name)"
+        case .invalidURL(let url):
+            return "Invalid URL: \(url)"
+        case .pathNotFound(let path):
+            return "Path not found: \(path)"
+        case .commandFailed(let detail):
+            return detail
+        case .cannotOpenURL(let pane):
+            return "Could not open System Settings pane: \(pane)"
+        }
+    }
+}
+
+actor NativeToolExecutor: NativeToolExecuting {
+    static let serverName = "shell-native"
+
+    private let repoRoot: String
+    private let appleScriptRunner: @Sendable (String) async throws -> String
+    private let commandRunner: @Sendable (String, [String], String?) async throws -> String
+    private let urlOpener: @Sendable (URL) async -> Bool
+
+    init(
+        repoRoot: String,
+        appleScriptRunner: @escaping @Sendable (String) async throws -> String = NativeToolExecutor.defaultAppleScriptRunner,
+        commandRunner: @escaping @Sendable (String, [String], String?) async throws -> String = NativeToolExecutor.defaultCommandRunner,
+        urlOpener: @escaping @Sendable (URL) async -> Bool = { url in
+            await MainActor.run { NSWorkspace.shared.open(url) }
+        }
+    ) {
+        self.repoRoot = repoRoot
+        self.appleScriptRunner = appleScriptRunner
+        self.commandRunner = commandRunner
+        self.urlOpener = urlOpener
+    }
+
+    func execute(tool: String, arguments: [String: AnyCodable]) async throws -> MCPToolExecutionResult {
+        guard let name = NativeToolName(rawValue: tool) else {
+            throw NativeToolError.unknownTool(tool)
+        }
+
+        switch name {
+        case .finderOpenPath:
+            let path = try requiredString("path", from: arguments)
+            let expanded = expandPath(path)
+            try ensurePathExists(expanded)
+            _ = try await appleScriptRunner("""
+            tell application "Finder"
+                activate
+                open POSIX file "\(escapeAppleScriptString(expanded))"
+            end tell
+            """)
+            return result(tool: tool, text: "Opened in Finder: \(expanded)")
+
+        case .finderOpenRepoRoot:
+            _ = try await appleScriptRunner("""
+            tell application "Finder"
+                activate
+                open POSIX file "\(escapeAppleScriptString(repoRoot))"
+            end tell
+            """)
+            return result(tool: tool, text: "Opened repo root in Finder: \(repoRoot)")
+
+        case .finderRevealPath:
+            let path = try requiredString("path", from: arguments)
+            let expanded = expandPath(path)
+            try ensurePathExists(expanded)
+            _ = try await appleScriptRunner("""
+            tell application "Finder"
+                activate
+                reveal POSIX file "\(escapeAppleScriptString(expanded))"
+            end tell
+            """)
+            return result(tool: tool, text: "Revealed in Finder: \(expanded)")
+
+        case .finderRevealBrainFile:
+            let path = "\(repoRoot)/knowledge-corpus/data/mojosolo_operating_brain.json"
+            try ensurePathExists(path)
+            _ = try await appleScriptRunner("""
+            tell application "Finder"
+                activate
+                reveal POSIX file "\(escapeAppleScriptString(path))"
+            end tell
+            """)
+            return result(tool: tool, text: "Revealed brain file in Finder: \(path)")
+
+        case .finderListSelection:
+            let selection = try await appleScriptRunner("""
+            tell application "Finder"
+                set selectedItems to selection
+                set outList to {}
+                repeat with anItem in selectedItems
+                    set end of outList to POSIX path of (anItem as alias)
+                end repeat
+                set AppleScript's text item delimiters to linefeed
+                set joined to outList as string
+                set AppleScript's text item delimiters to ""
+                return joined
+            end tell
+            """)
+            let trimmed = selection.trimmingCharacters(in: .whitespacesAndNewlines)
+            return result(
+                tool: tool,
+                text: trimmed.isEmpty ? "Finder selection is empty." : trimmed
+            )
+
+        case .safariOpenURL:
+            let rawURL = try requiredString("url", from: arguments)
+            guard let normalizedURL = normalizedURL(from: rawURL) else {
+                throw NativeToolError.invalidURL(rawURL)
+            }
+            _ = try await appleScriptRunner("""
+            tell application "Safari"
+                activate
+                if (count of windows) is 0 then
+                    make new document with properties {URL:"\(escapeAppleScriptString(normalizedURL))"}
+                else
+                    set URL of current tab of front window to "\(escapeAppleScriptString(normalizedURL))"
+                end if
+            end tell
+            """)
+            return result(tool: tool, text: "Opened in Safari: \(normalizedURL)")
+
+        case .safariCurrentTab:
+            let response = try await appleScriptRunner("""
+            tell application "Safari"
+                if (count of windows) is 0 then error "Safari has no open windows."
+                set tabName to name of current tab of front window
+                set tabURL to URL of current tab of front window
+                return tabName & linefeed & tabURL
+            end tell
+            """)
+            let lines = response
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .map(String.init)
+            let title = lines.first ?? "Unknown"
+            let url = lines.dropFirst().first ?? ""
+            return result(tool: tool, text: "{\"title\":\"\(escapeJSONString(title))\",\"url\":\"\(escapeJSONString(url))\"}")
+
+        case .shortcutsList:
+            let output = try await commandRunner("/usr/bin/shortcuts", ["list"], nil)
+            let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            return result(tool: tool, text: trimmed.isEmpty ? "No shortcuts found." : trimmed)
+
+        case .shortcutsRun:
+            let name = try requiredString("name", from: arguments)
+            let input = optionalString("input", from: arguments)
+            var commandArguments = ["run", name, "--output-path", "-"]
+            if input != nil {
+                commandArguments.append(contentsOf: ["--input-path", "-"])
+            }
+            let output = try await commandRunner("/usr/bin/shortcuts", commandArguments, input)
+            let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            return result(
+                tool: tool,
+                text: trimmed.isEmpty ? "Shortcut '\(name)' completed with no stdout." : trimmed
+            )
+
+        case .systemSettingsOpen:
+            let pane = try requiredString("pane", from: arguments)
+            guard let url = systemSettingsURL(for: pane) else {
+                throw NativeToolError.cannotOpenURL(pane)
+            }
+            let didOpen = await urlOpener(url)
+            guard didOpen else {
+                throw NativeToolError.cannotOpenURL(pane)
+            }
+            return result(tool: tool, text: "Opened System Settings: \(pane)")
+        }
+    }
+
+    private func result(tool: String, text: String) -> MCPToolExecutionResult {
+        MCPToolExecutionResult(server: Self.serverName, tool: tool, text: text)
+    }
+
+    private func requiredString(_ key: String, from arguments: [String: AnyCodable]) throws -> String {
+        guard case .string(let value)? = arguments[key], !value.isEmpty else {
+            throw NativeToolError.missingArgument(key)
+        }
+        return value
+    }
+
+    private func optionalString(_ key: String, from arguments: [String: AnyCodable]) -> String? {
+        guard case .string(let value)? = arguments[key], !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private func expandPath(_ path: String) -> String {
+        (path as NSString).expandingTildeInPath
+    }
+
+    private func ensurePathExists(_ path: String) throws {
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw NativeToolError.pathNotFound(path)
+        }
+    }
+
+    private func systemSettingsURL(for pane: String) -> URL? {
+        let path: String
+        switch pane {
+        case "accessibility":
+            path = "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        case "screen_recording":
+            path = "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+        case "automation":
+            path = "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation"
+        case "full_disk_access":
+            path = "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
+        default:
+            return nil
+        }
+        return URL(string: path)
+    }
+
+    private func normalizedURL(from rawURL: String) -> String? {
+        let trimmed = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        if trimmed.lowercased().hasPrefix("http://") || trimmed.lowercased().hasPrefix("https://") {
+            return URL(string: trimmed) != nil ? trimmed : nil
+        }
+
+        if trimmed.contains(" "), !trimmed.contains(".") {
+            return nil
+        }
+
+        let withScheme = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
+        return URL(string: withScheme) != nil ? withScheme : nil
+    }
+
+    private func escapeAppleScriptString(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    private func escapeJSONString(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+    }
+
+    private static func defaultAppleScriptRunner(script: String) async throws -> String {
+        try await defaultCommandRunner("/usr/bin/osascript", ["-e", script], nil)
+    }
+
+    private static func defaultCommandRunner(_ executable: String, _ arguments: [String], _ stdin: String?) async throws -> String {
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let stdinPipe = Pipe()
+
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        if stdin != nil {
+            process.standardInput = stdinPipe
+        }
+
+        try process.run()
+
+        if let stdin {
+            stdinPipe.fileHandleForWriting.write(Data(stdin.utf8))
+            try? stdinPipe.fileHandleForWriting.close()
+        }
+
+        process.waitUntilExit()
+
+        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+
+        if process.terminationStatus != 0 {
+            let stderrText = String(decoding: stderrData, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+            let message = stderrText.isEmpty ? "Command failed with status \(process.terminationStatus)." : stderrText
+            throw NativeToolError.commandFailed(message)
+        }
+
+        return String(decoding: stdoutData, as: UTF8.self)
+    }
+}

--- a/shell/Sources/MojoShell/Automation/NativeToolExecutor.swift
+++ b/shell/Sources/MojoShell/Automation/NativeToolExecutor.swift
@@ -56,12 +56,14 @@ actor NativeToolExecutor: NativeToolExecuting {
     static let serverName = "shell-native"
 
     private let repoRoot: String
+    private let brainPathProvider: @MainActor () -> String
     private let appleAutomation: any AppleAutomationProviding
     private let commandRunner: @Sendable (String, [String], String?) async throws -> String
     private let urlOpener: @Sendable (URL) async -> Bool
 
     init(
         repoRoot: String,
+        brainPathProvider: (@MainActor () -> String)? = nil,
         appleAutomation: (any AppleAutomationProviding)? = nil,
         commandRunner: @escaping @Sendable (String, [String], String?) async throws -> String = NativeToolExecutor.defaultCommandRunner,
         urlOpener: @escaping @Sendable (URL) async -> Bool = { url in
@@ -69,6 +71,9 @@ actor NativeToolExecutor: NativeToolExecuting {
         }
     ) {
         self.repoRoot = repoRoot
+        self.brainPathProvider = brainPathProvider ?? {
+            "\(repoRoot)/knowledge-corpus/data/mojosolo_operating_brain.json"
+        }
         self.appleAutomation = appleAutomation ?? AppleScriptAutomationAdapter()
         self.commandRunner = commandRunner
         self.urlOpener = urlOpener
@@ -76,6 +81,7 @@ actor NativeToolExecutor: NativeToolExecuting {
 
     init(
         repoRoot: String,
+        brainPathProvider: (@MainActor () -> String)? = nil,
         appleScriptRunner: @escaping @Sendable (String) async throws -> String,
         commandRunner: @escaping @Sendable (String, [String], String?) async throws -> String = NativeToolExecutor.defaultCommandRunner,
         urlOpener: @escaping @Sendable (URL) async -> Bool = { url in
@@ -84,6 +90,7 @@ actor NativeToolExecutor: NativeToolExecuting {
     ) {
         self.init(
             repoRoot: repoRoot,
+            brainPathProvider: brainPathProvider,
             appleAutomation: ScriptBackedAppleAutomation(scriptRunner: appleScriptRunner),
             commandRunner: commandRunner,
             urlOpener: urlOpener
@@ -115,7 +122,7 @@ actor NativeToolExecutor: NativeToolExecuting {
             return result(tool: tool, text: "Revealed in Finder: \(expanded)")
 
         case .finderRevealBrainFile:
-            let path = "\(repoRoot)/knowledge-corpus/data/mojosolo_operating_brain.json"
+            let path = expandPath(await MainActor.run { brainPathProvider() })
             try ensurePathExists(path)
             try await appleAutomation.revealFinderPath(path)
             return result(tool: tool, text: "Revealed brain file in Finder: \(path)")

--- a/shell/Sources/MojoShell/Automation/NativeToolExecutor.swift
+++ b/shell/Sources/MojoShell/Automation/NativeToolExecutor.swift
@@ -48,22 +48,38 @@ actor NativeToolExecutor: NativeToolExecuting {
     static let serverName = "shell-native"
 
     private let repoRoot: String
-    private let appleScriptRunner: @Sendable (String) async throws -> String
+    private let appleAutomation: any AppleAutomationProviding
     private let commandRunner: @Sendable (String, [String], String?) async throws -> String
     private let urlOpener: @Sendable (URL) async -> Bool
 
     init(
         repoRoot: String,
-        appleScriptRunner: @escaping @Sendable (String) async throws -> String = NativeToolExecutor.defaultAppleScriptRunner,
+        appleAutomation: (any AppleAutomationProviding)? = nil,
         commandRunner: @escaping @Sendable (String, [String], String?) async throws -> String = NativeToolExecutor.defaultCommandRunner,
         urlOpener: @escaping @Sendable (URL) async -> Bool = { url in
             await MainActor.run { NSWorkspace.shared.open(url) }
         }
     ) {
         self.repoRoot = repoRoot
-        self.appleScriptRunner = appleScriptRunner
+        self.appleAutomation = appleAutomation ?? AppleScriptAutomationAdapter()
         self.commandRunner = commandRunner
         self.urlOpener = urlOpener
+    }
+
+    init(
+        repoRoot: String,
+        appleScriptRunner: @escaping @Sendable (String) async throws -> String,
+        commandRunner: @escaping @Sendable (String, [String], String?) async throws -> String = NativeToolExecutor.defaultCommandRunner,
+        urlOpener: @escaping @Sendable (URL) async -> Bool = { url in
+            await MainActor.run { NSWorkspace.shared.open(url) }
+        }
+    ) {
+        self.init(
+            repoRoot: repoRoot,
+            appleAutomation: ScriptBackedAppleAutomation(scriptRunner: appleScriptRunner),
+            commandRunner: commandRunner,
+            urlOpener: urlOpener
+        )
     }
 
     func execute(tool: String, arguments: [String: AnyCodable]) async throws -> MCPToolExecutionResult {
@@ -76,64 +92,33 @@ actor NativeToolExecutor: NativeToolExecuting {
             let path = try requiredString("path", from: arguments)
             let expanded = expandPath(path)
             try ensurePathExists(expanded)
-            _ = try await appleScriptRunner("""
-            tell application "Finder"
-                activate
-                open POSIX file "\(escapeAppleScriptString(expanded))"
-            end tell
-            """)
+            try await appleAutomation.openFinderPath(expanded)
             return result(tool: tool, text: "Opened in Finder: \(expanded)")
 
         case .finderOpenRepoRoot:
-            _ = try await appleScriptRunner("""
-            tell application "Finder"
-                activate
-                open POSIX file "\(escapeAppleScriptString(repoRoot))"
-            end tell
-            """)
+            try await appleAutomation.openFinderPath(repoRoot)
             return result(tool: tool, text: "Opened repo root in Finder: \(repoRoot)")
 
         case .finderRevealPath:
             let path = try requiredString("path", from: arguments)
             let expanded = expandPath(path)
             try ensurePathExists(expanded)
-            _ = try await appleScriptRunner("""
-            tell application "Finder"
-                activate
-                reveal POSIX file "\(escapeAppleScriptString(expanded))"
-            end tell
-            """)
+            try await appleAutomation.revealFinderPath(expanded)
             return result(tool: tool, text: "Revealed in Finder: \(expanded)")
 
         case .finderRevealBrainFile:
             let path = "\(repoRoot)/knowledge-corpus/data/mojosolo_operating_brain.json"
             try ensurePathExists(path)
-            _ = try await appleScriptRunner("""
-            tell application "Finder"
-                activate
-                reveal POSIX file "\(escapeAppleScriptString(path))"
-            end tell
-            """)
+            try await appleAutomation.revealFinderPath(path)
             return result(tool: tool, text: "Revealed brain file in Finder: \(path)")
 
         case .finderListSelection:
-            let selection = try await appleScriptRunner("""
-            tell application "Finder"
-                set selectedItems to selection
-                set outList to {}
-                repeat with anItem in selectedItems
-                    set end of outList to POSIX path of (anItem as alias)
-                end repeat
-                set AppleScript's text item delimiters to linefeed
-                set joined to outList as string
-                set AppleScript's text item delimiters to ""
-                return joined
-            end tell
-            """)
-            let trimmed = selection.trimmingCharacters(in: .whitespacesAndNewlines)
+            let selection = try await appleAutomation.listFinderSelection()
+            let trimmed = selection.joined(separator: "\n")
             return result(
                 tool: tool,
-                text: trimmed.isEmpty ? "Finder selection is empty." : trimmed
+                text: trimmed.isEmpty ? "Finder selection is empty." : trimmed,
+                payload: .array(selection.map(AnyCodable.string))
             )
 
         case .safariOpenURL:
@@ -141,38 +126,29 @@ actor NativeToolExecutor: NativeToolExecuting {
             guard let normalizedURL = normalizedURL(from: rawURL) else {
                 throw NativeToolError.invalidURL(rawURL)
             }
-            _ = try await appleScriptRunner("""
-            tell application "Safari"
-                activate
-                if (count of windows) is 0 then
-                    make new document with properties {URL:"\(escapeAppleScriptString(normalizedURL))"}
-                else
-                    set URL of current tab of front window to "\(escapeAppleScriptString(normalizedURL))"
-                end if
-            end tell
-            """)
+            try await appleAutomation.openSafariURL(normalizedURL)
             return result(tool: tool, text: "Opened in Safari: \(normalizedURL)")
 
         case .safariCurrentTab:
-            let response = try await appleScriptRunner("""
-            tell application "Safari"
-                if (count of windows) is 0 then error "Safari has no open windows."
-                set tabName to name of current tab of front window
-                set tabURL to URL of current tab of front window
-                return tabName & linefeed & tabURL
-            end tell
-            """)
-            let lines = response
-                .split(separator: "\n", omittingEmptySubsequences: false)
-                .map(String.init)
-            let title = lines.first ?? "Unknown"
-            let url = lines.dropFirst().first ?? ""
-            return result(tool: tool, text: "{\"title\":\"\(escapeJSONString(title))\",\"url\":\"\(escapeJSONString(url))\"}")
+            let tab = try await appleAutomation.currentSafariTab()
+            return result(
+                tool: tool,
+                text: "\(tab.title)\n\(tab.url)",
+                payload: .object([
+                    "title": .string(tab.title),
+                    "url": .string(tab.url),
+                ])
+            )
 
         case .shortcutsList:
             let output = try await commandRunner("/usr/bin/shortcuts", ["list"], nil)
             let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
-            return result(tool: tool, text: trimmed.isEmpty ? "No shortcuts found." : trimmed)
+            let names = trimmed.isEmpty ? [] : trimmed.split(separator: "\n").map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            return result(
+                tool: tool,
+                text: trimmed.isEmpty ? "No shortcuts found." : trimmed,
+                payload: .array(names.map(AnyCodable.string))
+            )
 
         case .shortcutsRun:
             let name = try requiredString("name", from: arguments)
@@ -185,7 +161,12 @@ actor NativeToolExecutor: NativeToolExecuting {
             let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
             return result(
                 tool: tool,
-                text: trimmed.isEmpty ? "Shortcut '\(name)' completed with no stdout." : trimmed
+                text: trimmed.isEmpty ? "Shortcut '\(name)' completed with no stdout." : trimmed,
+                payload: .object([
+                    "name": .string(name),
+                    "input_provided": .bool(input != nil),
+                    "stdout": .string(trimmed),
+                ])
             )
 
         case .systemSettingsOpen:
@@ -201,8 +182,8 @@ actor NativeToolExecutor: NativeToolExecuting {
         }
     }
 
-    private func result(tool: String, text: String) -> MCPToolExecutionResult {
-        MCPToolExecutionResult(server: Self.serverName, tool: tool, text: text)
+    private func result(tool: String, text: String, payload: AnyCodable? = nil) -> MCPToolExecutionResult {
+        MCPToolExecutionResult(server: Self.serverName, tool: tool, text: text, payload: payload)
     }
 
     private func requiredString(_ key: String, from arguments: [String: AnyCodable]) throws -> String {
@@ -264,56 +245,90 @@ actor NativeToolExecutor: NativeToolExecuting {
         return URL(string: withScheme) != nil ? withScheme : nil
     }
 
-    private func escapeAppleScriptString(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-    }
-
-    private func escapeJSONString(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-            .replacingOccurrences(of: "\n", with: "\\n")
-    }
-
-    private static func defaultAppleScriptRunner(script: String) async throws -> String {
-        try await defaultCommandRunner("/usr/bin/osascript", ["-e", script], nil)
-    }
-
     private static func defaultCommandRunner(_ executable: String, _ arguments: [String], _ stdin: String?) async throws -> String {
-        let process = Process()
-        let stdout = Pipe()
-        let stderr = Pipe()
-        let stdinPipe = Pipe()
+        try await ProcessCommandRunner.run(executable, arguments, stdin)
+    }
+}
 
-        process.executableURL = URL(fileURLWithPath: executable)
-        process.arguments = arguments
-        process.standardOutput = stdout
-        process.standardError = stderr
+private actor ScriptBackedAppleAutomation: AppleAutomationProviding {
+    private let scriptRunner: @Sendable (String) async throws -> String
 
-        if stdin != nil {
-            process.standardInput = stdinPipe
-        }
+    init(scriptRunner: @escaping @Sendable (String) async throws -> String) {
+        self.scriptRunner = scriptRunner
+    }
 
-        try process.run()
+    func openFinderPath(_ path: String) async throws {
+        _ = try await scriptRunner("""
+        tell application "Finder"
+            activate
+            open POSIX file "\(escape(path))"
+        end tell
+        """)
+    }
 
-        if let stdin {
-            stdinPipe.fileHandleForWriting.write(Data(stdin.utf8))
-            try? stdinPipe.fileHandleForWriting.close()
-        }
+    func revealFinderPath(_ path: String) async throws {
+        _ = try await scriptRunner("""
+        tell application "Finder"
+            activate
+            reveal POSIX file "\(escape(path))"
+        end tell
+        """)
+    }
 
-        process.waitUntilExit()
+    func listFinderSelection() async throws -> [String] {
+        let output = try await scriptRunner("""
+        tell application "Finder"
+            set selectedItems to selection
+            set outList to {}
+            repeat with anItem in selectedItems
+                set end of outList to POSIX path of (anItem as alias)
+            end repeat
+            set AppleScript's text item delimiters to linefeed
+            set joined to outList as string
+            set AppleScript's text item delimiters to ""
+            return joined
+        end tell
+        """)
 
-        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
-        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+        return output
+            .split(separator: "\n")
+            .map(String.init)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
 
-        if process.terminationStatus != 0 {
-            let stderrText = String(decoding: stderrData, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
-            let message = stderrText.isEmpty ? "Command failed with status \(process.terminationStatus)." : stderrText
-            throw NativeToolError.commandFailed(message)
-        }
+    func openSafariURL(_ url: String) async throws {
+        _ = try await scriptRunner("""
+        tell application "Safari"
+            activate
+            if (count of windows) is 0 then
+                make new document with properties {URL:"\(escape(url))"}
+            else
+                set URL of current tab of front window to "\(escape(url))"
+            end if
+        end tell
+        """)
+    }
 
-        return String(decoding: stdoutData, as: UTF8.self)
+    func currentSafariTab() async throws -> SafariTabState {
+        let output = try await scriptRunner("""
+        tell application "Safari"
+            if (count of windows) is 0 then error "Safari has no open windows."
+            set tabName to name of current tab of front window
+            set tabURL to URL of current tab of front window
+            return tabName & linefeed & tabURL
+        end tell
+        """)
+
+        let lines = output
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        return SafariTabState(title: lines.first ?? "Unknown", url: lines.dropFirst().first ?? "")
+    }
+
+    private func escape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
     }
 }

--- a/shell/Sources/MojoShell/Automation/NativeToolExecutor.swift
+++ b/shell/Sources/MojoShell/Automation/NativeToolExecutor.swift
@@ -11,8 +11,16 @@ enum NativeToolName: String, Sendable {
     case finderRevealPath = "finder_reveal_path"
     case finderRevealBrainFile = "finder_reveal_brain_file"
     case finderListSelection = "finder_list_selection"
+    case finderSelectionOpenInPreview = "finder_selection_open_in_preview"
+    case finderSelectionOpenInPhotos = "finder_selection_open_in_photos"
     case safariOpenURL = "safari_open_url"
     case safariCurrentTab = "safari_current_tab"
+    case terminalOpenRepo = "terminal_open_repo"
+    case terminalRunCommand = "terminal_run_command"
+    case itermOpenRepo = "iterm_open_repo"
+    case itermRunCommand = "iterm_run_command"
+    case previewOpenPath = "preview_open_path"
+    case photosImportPath = "photos_import_path"
     case shortcutsList = "shortcuts_list"
     case shortcutsRun = "shortcuts_run"
     case systemSettingsOpen = "system_settings_open"
@@ -121,6 +129,24 @@ actor NativeToolExecutor: NativeToolExecuting {
                 payload: .array(selection.map(AnyCodable.string))
             )
 
+        case .finderSelectionOpenInPreview:
+            let path = try await firstFinderSelectionPath()
+            try await openFile(path: path, appName: "Preview")
+            return result(
+                tool: tool,
+                text: "Opened Finder selection in Preview: \(path)",
+                payload: .object(["path": .string(path), "application": .string("Preview")])
+            )
+
+        case .finderSelectionOpenInPhotos:
+            let path = try await firstFinderSelectionPath()
+            try await openFile(path: path, appName: "Photos")
+            return result(
+                tool: tool,
+                text: "Opened Finder selection in Photos: \(path)",
+                payload: .object(["path": .string(path), "application": .string("Photos")])
+            )
+
         case .safariOpenURL:
             let rawURL = try requiredString("url", from: arguments)
             guard let normalizedURL = normalizedURL(from: rawURL) else {
@@ -138,6 +164,66 @@ actor NativeToolExecutor: NativeToolExecuting {
                     "title": .string(tab.title),
                     "url": .string(tab.url),
                 ])
+            )
+
+        case .terminalOpenRepo:
+            try ensurePathExists(repoRoot)
+            try await openApplication("Terminal", path: repoRoot)
+            return result(
+                tool: tool,
+                text: "Opened repo root in Terminal: \(repoRoot)",
+                payload: .object(["path": .string(repoRoot), "application": .string("Terminal")])
+            )
+
+        case .terminalRunCommand:
+            let command = try requiredString("command", from: arguments)
+            let path = optionalString("path", from: arguments).map(expandPath) ?? repoRoot
+            try ensurePathExists(path)
+            try await appleAutomation.runTerminalCommand(command, in: path)
+            return result(
+                tool: tool,
+                text: "Ran command in Terminal: \(command)",
+                payload: .object(["command": .string(command), "path": .string(path)])
+            )
+
+        case .itermOpenRepo:
+            try ensurePathExists(repoRoot)
+            try await appleAutomation.runITermCommand("clear", in: repoRoot)
+            return result(
+                tool: tool,
+                text: "Opened repo root in iTerm: \(repoRoot)",
+                payload: .object(["path": .string(repoRoot), "application": .string("iTerm")])
+            )
+
+        case .itermRunCommand:
+            let command = try requiredString("command", from: arguments)
+            let path = optionalString("path", from: arguments).map(expandPath) ?? repoRoot
+            try ensurePathExists(path)
+            try await appleAutomation.runITermCommand(command, in: path)
+            return result(
+                tool: tool,
+                text: "Ran command in iTerm: \(command)",
+                payload: .object(["command": .string(command), "path": .string(path)])
+            )
+
+        case .previewOpenPath:
+            let path = expandPath(try requiredString("path", from: arguments))
+            try ensurePathExists(path)
+            try await openFile(path: path, appName: "Preview")
+            return result(
+                tool: tool,
+                text: "Opened in Preview: \(path)",
+                payload: .object(["path": .string(path), "application": .string("Preview")])
+            )
+
+        case .photosImportPath:
+            let path = expandPath(try requiredString("path", from: arguments))
+            try ensurePathExists(path)
+            try await openFile(path: path, appName: "Photos")
+            return result(
+                tool: tool,
+                text: "Opened in Photos: \(path)",
+                payload: .object(["path": .string(path), "application": .string("Photos")])
             )
 
         case .shortcutsList:
@@ -208,6 +294,23 @@ actor NativeToolExecutor: NativeToolExecuting {
         guard FileManager.default.fileExists(atPath: path) else {
             throw NativeToolError.pathNotFound(path)
         }
+    }
+
+    private func firstFinderSelectionPath() async throws -> String {
+        let selection = try await appleAutomation.listFinderSelection()
+        guard let first = selection.first else {
+            throw NativeToolError.commandFailed("Finder selection is empty.")
+        }
+        try ensurePathExists(first)
+        return first
+    }
+
+    private func openApplication(_ appName: String, path: String) async throws {
+        _ = try await commandRunner("/usr/bin/open", ["-a", appName, path], nil)
+    }
+
+    private func openFile(path: String, appName: String) async throws {
+        _ = try await commandRunner("/usr/bin/open", ["-a", appName, path], nil)
     }
 
     private func systemSettingsURL(for pane: String) -> URL? {
@@ -324,6 +427,32 @@ private actor ScriptBackedAppleAutomation: AppleAutomationProviding {
             .split(separator: "\n", omittingEmptySubsequences: false)
             .map(String.init)
         return SafariTabState(title: lines.first ?? "Unknown", url: lines.dropFirst().first ?? "")
+    }
+
+    func runTerminalCommand(_ command: String, in path: String) async throws {
+        _ = try await scriptRunner("""
+        tell application "Terminal"
+            activate
+            if (count of windows) is 0 then
+                do script ""
+            end if
+            do script "cd " & quoted form of "\(escape(path))" & "; " & "\(escape(command))" in front window
+        end tell
+        """)
+    }
+
+    func runITermCommand(_ command: String, in path: String) async throws {
+        _ = try await scriptRunner("""
+        tell application "iTerm"
+            activate
+            if (count of windows) is 0 then
+                create window with default profile
+            end if
+            tell current session of current window
+                write text "cd " & quoted form of "\(escape(path))" & "; " & "\(escape(command))"
+            end tell
+        end tell
+        """)
     }
 
     private func escape(_ value: String) -> String {

--- a/shell/Sources/MojoShell/Automation/ProcessCommandRunner.swift
+++ b/shell/Sources/MojoShell/Automation/ProcessCommandRunner.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+enum ProcessCommandRunner {
+    static func run(_ executable: String, _ arguments: [String], _ stdin: String?) async throws -> String {
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let stdinPipe = Pipe()
+
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        if stdin != nil {
+            process.standardInput = stdinPipe
+        }
+
+        try process.run()
+
+        if let stdin {
+            stdinPipe.fileHandleForWriting.write(Data(stdin.utf8))
+            try? stdinPipe.fileHandleForWriting.close()
+        }
+
+        process.waitUntilExit()
+
+        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+
+        if process.terminationStatus != 0 {
+            let stderrText = String(decoding: stderrData, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+            let message = stderrText.isEmpty ? "Command failed with status \(process.terminationStatus)." : stderrText
+            throw NativeToolError.commandFailed(message)
+        }
+
+        return String(decoding: stdoutData, as: UTF8.self)
+    }
+}

--- a/shell/Sources/MojoShell/ComputerUse/AccessibilityElementFinder.swift
+++ b/shell/Sources/MojoShell/ComputerUse/AccessibilityElementFinder.swift
@@ -1,0 +1,172 @@
+import ApplicationServices
+import Foundation
+
+/// A UI element discovered via the macOS Accessibility API.
+struct FoundAXElement: Identifiable, Equatable, Sendable {
+    let id: String        // AX identifier or generated UUID string
+    let role: String      // e.g. "AXButton", "AXMenuItem"
+    let title: String     // AXTitle or AXDescription
+    let screenPoint: CGPoint  // Center of the element in global screen coordinates
+}
+
+/// Discovers accessible UI elements in a running macOS application.
+///
+/// Requires the Accessibility permission (System Settings → Privacy & Security → Accessibility).
+enum AccessibilityElementFinder {
+
+    enum FinderError: LocalizedError {
+        case accessibilityPermissionDenied
+        case appNotRunning(String)
+        case noElementsFound(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .accessibilityPermissionDenied:
+                return "Accessibility permission denied. Grant access in System Settings → Privacy & Security → Accessibility."
+            case .appNotRunning(let name):
+                return "\(name) is not running."
+            case .noElementsFound(let context):
+                return "No accessible elements found: \(context)"
+            }
+        }
+    }
+
+    /// Find all interactive elements (buttons, menu items, text fields) in the named app.
+    ///
+    /// - Parameters:
+    ///   - appName: The app's `localizedName` (e.g. "Final Cut Pro", "Motion").
+    ///   - roles: AX roles to include. Pass nil to include all interactive roles.
+    ///   - titleContaining: Optional substring filter on element title.
+    ///   - maxDepth: How deep to recurse into the AX tree (default: 8).
+    static func findElements(
+        inApp appName: String,
+        roles: [String]? = nil,
+        titleContaining titleSubstring: String? = nil,
+        maxDepth: Int = 8
+    ) throws -> [FoundAXElement] {
+        guard AXIsProcessTrusted() else {
+            throw FinderError.accessibilityPermissionDenied
+        }
+
+        guard let app = runningApp(named: appName) else {
+            throw FinderError.appNotRunning(appName)
+        }
+
+        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+        var results: [FoundAXElement] = []
+        let interactiveRoles = roles ?? [
+            "AXButton", "AXMenuItem", "AXMenuBarItem", "AXComboBox",
+            "AXPopUpButton", "AXTextField", "AXCheckBox", "AXRadioButton",
+        ]
+
+        collectElements(
+            from: axApp,
+            roles: interactiveRoles,
+            titleFilter: titleSubstring.map { $0.lowercased() },
+            depth: 0,
+            maxDepth: maxDepth,
+            into: &results
+        )
+
+        return results
+    }
+
+    /// Convenience: find buttons in the named app, optionally filtered by title.
+    static func findButtons(
+        inApp appName: String,
+        titleContaining substring: String? = nil
+    ) throws -> [FoundAXElement] {
+        try findElements(inApp: appName, roles: ["AXButton"], titleContaining: substring)
+    }
+
+    // MARK: - Private
+
+    private static func runningApp(named name: String) -> NSRunningApplication? {
+        NSWorkspace.shared.runningApplications.first {
+            $0.localizedName == name || $0.bundleIdentifier?.hasSuffix(name) == true
+        }
+    }
+
+    private static func collectElements(
+        from element: AXUIElement,
+        roles: [String],
+        titleFilter: String?,
+        depth: Int,
+        maxDepth: Int,
+        into results: inout [FoundAXElement]
+    ) {
+        guard depth <= maxDepth else { return }
+
+        // Check if this element matches
+        if let role = stringAttribute(of: element, key: kAXRoleAttribute as CFString),
+           roles.contains(role)
+        {
+            let title = stringAttribute(of: element, key: kAXTitleAttribute as CFString)
+                ?? stringAttribute(of: element, key: kAXDescriptionAttribute as CFString)
+                ?? stringAttribute(of: element, key: kAXValueAttribute as CFString)
+                ?? ""
+
+            let passes = titleFilter == nil || title.lowercased().contains(titleFilter!)
+
+            if passes, let center = elementCenter(of: element) {
+                let identifier = stringAttribute(of: element, key: kAXIdentifierAttribute as CFString)
+                    ?? "\(role)-\(title)-\(Int(center.x))-\(Int(center.y))"
+                results.append(FoundAXElement(
+                    id: identifier,
+                    role: role,
+                    title: title,
+                    screenPoint: center
+                ))
+            }
+        }
+
+        // Recurse into children
+        var childrenRef: AnyObject?
+        guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+              let children = childrenRef as? [AXUIElement]
+        else { return }
+
+        for child in children {
+            collectElements(
+                from: child,
+                roles: roles,
+                titleFilter: titleFilter,
+                depth: depth + 1,
+                maxDepth: maxDepth,
+                into: &results
+            )
+        }
+    }
+
+    private static func stringAttribute(of element: AXUIElement, key: CFString) -> String? {
+        var value: AnyObject?
+        guard AXUIElementCopyAttributeValue(element, key, &value) == .success else { return nil }
+        return value as? String
+    }
+
+    private static func elementCenter(of element: AXUIElement) -> CGPoint? {
+        var positionValue: AnyObject?
+        var sizeValue: AnyObject?
+
+        guard
+            AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionValue) == .success,
+            AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeValue) == .success,
+            let posAX = positionValue,
+            let sizeAX = sizeValue
+        else { return nil }
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+
+        // AXValue wraps CGPoint and CGSize
+        AXValueGetValue(posAX as! AXValue, .cgPoint, &position)
+        AXValueGetValue(sizeAX as! AXValue, .cgSize, &size)
+
+        guard size.width > 0, size.height > 0 else { return nil }
+
+        return CGPoint(
+            x: position.x + size.width / 2,
+            y: position.y + size.height / 2
+        )
+    }
+}

--- a/shell/Sources/MojoShell/ComputerUse/AccessibilityElementFinder.swift
+++ b/shell/Sources/MojoShell/ComputerUse/AccessibilityElementFinder.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ApplicationServices
 import Foundation
 

--- a/shell/Sources/MojoShell/ComputerUse/ComputerUseProvider.swift
+++ b/shell/Sources/MojoShell/ComputerUse/ComputerUseProvider.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct ComputerUseState: Equatable {
+    let appName: String
+    let screenshotData: Data?
+    let timestamp: Date
+}
+
+enum ComputerUseActionType: String, Equatable {
+    case click
+    case type
+    case keypress
+    case scroll
+    case drag
+}
+
+struct ComputerUseAction: Equatable {
+    let type: ComputerUseActionType
+    let target: String
+    let value: String?
+
+    init(type: ComputerUseActionType, target: String, value: String? = nil) {
+        self.type = type
+        self.target = target
+        self.value = value
+    }
+}
+
+struct ComputerUseResult: Equatable {
+    let success: Bool
+    let message: String
+    let screenshotAfter: Data?
+}
+
+protocol ComputerUseProvider {
+    var name: String { get }
+    func startSession() async throws -> String
+    func captureState(sessionId: String) async throws -> ComputerUseState
+    func execute(sessionId: String, action: ComputerUseAction) async throws -> ComputerUseResult
+    func stopSession(sessionId: String) async throws
+}

--- a/shell/Sources/MojoShell/ComputerUse/ComputerUseProvider.swift
+++ b/shell/Sources/MojoShell/ComputerUse/ComputerUseProvider.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-struct ComputerUseState: Equatable {
+struct ComputerUseState: Equatable, Sendable {
     let appName: String
     let screenshotData: Data?
     let timestamp: Date
 }
 
-enum ComputerUseActionType: String, Equatable {
+enum ComputerUseActionType: String, Equatable, Sendable {
     case click
     case type
     case keypress
@@ -14,7 +14,7 @@ enum ComputerUseActionType: String, Equatable {
     case drag
 }
 
-struct ComputerUseAction: Equatable {
+struct ComputerUseAction: Equatable, Sendable {
     let type: ComputerUseActionType
     let target: String
     let value: String?
@@ -26,13 +26,13 @@ struct ComputerUseAction: Equatable {
     }
 }
 
-struct ComputerUseResult: Equatable {
+struct ComputerUseResult: Equatable, Sendable {
     let success: Bool
     let message: String
     let screenshotAfter: Data?
 }
 
-protocol ComputerUseProvider {
+protocol ComputerUseProvider: Sendable {
     var name: String { get }
     func startSession() async throws -> String
     func captureState(sessionId: String) async throws -> ComputerUseState

--- a/shell/Sources/MojoShell/ComputerUse/CuaComputerUseProvider.swift
+++ b/shell/Sources/MojoShell/ComputerUse/CuaComputerUseProvider.swift
@@ -124,7 +124,7 @@ actor CuaComputerUseProvider: ComputerUseProvider {
         let src = CGEventSource(stateID: .hidSystemState)
 
         for scalar in text.unicodeScalars {
-            var ch = scalar.value
+            var ch = UniChar(truncatingIfNeeded: scalar.value)
             guard
                 let down = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: true),
                 let up = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: false)

--- a/shell/Sources/MojoShell/ComputerUse/CuaComputerUseProvider.swift
+++ b/shell/Sources/MojoShell/ComputerUse/CuaComputerUseProvider.swift
@@ -1,0 +1,249 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+/// Phase 1 computer-use provider.
+///
+/// Uses CoreGraphics CGEvent for input injection (requires Accessibility permission)
+/// and CGWindowListCreateImage for screenshots (requires Screen Recording permission).
+/// No external processes or cloud dependency — runs fully local on the host Mac.
+///
+/// Coordinate format for `action.target`: "x,y" (e.g. "640,400")
+/// Key combination format for keypress: "cmd+e", "shift+return", "escape"
+/// Text to type: `action.value` (falls back to `action.target`)
+actor CuaComputerUseProvider: ComputerUseProvider {
+    let name = "cua"
+
+    private var sessions: Set<String> = []
+
+    // MARK: - Protocol
+
+    func startSession() async throws -> String {
+        let id = UUID().uuidString
+        sessions.insert(id)
+        return id
+    }
+
+    func captureState(sessionId: String) async throws -> ComputerUseState {
+        try requireSession(sessionId)
+
+        let appName = await MainActor.run {
+            NSWorkspace.shared.frontmostApplication?.localizedName ?? "Unknown"
+        }
+
+        return ComputerUseState(
+            appName: appName,
+            screenshotData: captureScreenshot(),
+            timestamp: Date()
+        )
+    }
+
+    func execute(sessionId: String, action: ComputerUseAction) async throws -> ComputerUseResult {
+        try requireSession(sessionId)
+
+        switch action.type {
+        case .click:
+            try performClick(target: action.target)
+        case .type:
+            try performType(text: action.value ?? action.target)
+        case .keypress:
+            try performKeypress(key: action.target)
+        case .scroll:
+            try performScroll(target: action.target, deltaString: action.value)
+        case .drag:
+            try performDrag(from: action.target, to: action.value)
+        }
+
+        return ComputerUseResult(
+            success: true,
+            message: "executed \(action.type.rawValue) → \(action.target)",
+            screenshotAfter: captureScreenshot()
+        )
+    }
+
+    func stopSession(sessionId: String) async throws {
+        sessions.remove(sessionId)
+    }
+
+    // MARK: - Screenshot
+
+    private func captureScreenshot() -> Data? {
+        guard let image = CGWindowListCreateImage(
+            .infinite,
+            .optionAll,
+            kCGNullWindowID,
+            [.bestResolution, .boundsIgnoreFraming]
+        ) else { return nil }
+
+        let nsImage = NSImage(
+            cgImage: image,
+            size: NSSize(width: image.width, height: image.height)
+        )
+
+        guard
+            let tiff = nsImage.tiffRepresentation,
+            let rep = NSBitmapImageRep(data: tiff)
+        else { return nil }
+
+        return rep.representation(using: .png, properties: [:])
+    }
+
+    // MARK: - Input
+
+    private func performClick(target: String) throws {
+        let point = try parseCoordinates(target)
+        let src = CGEventSource(stateID: .hidSystemState)
+
+        guard
+            let down = CGEvent(mouseEventSource: src, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left),
+            let up = CGEvent(mouseEventSource: src, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left)
+        else { throw CuaError.eventCreationFailed }
+
+        down.post(tap: .cghidEventTap)
+        Thread.sleep(forTimeInterval: 0.05)
+        up.post(tap: .cghidEventTap)
+    }
+
+    private func performType(text: String) throws {
+        let src = CGEventSource(stateID: .hidSystemState)
+
+        for scalar in text.unicodeScalars {
+            var ch = scalar.value
+            guard
+                let down = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: true),
+                let up = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: false)
+            else { throw CuaError.eventCreationFailed }
+
+            down.keyboardSetUnicodeString(stringLength: 1, unicodeString: &ch)
+            up.keyboardSetUnicodeString(stringLength: 1, unicodeString: &ch)
+            down.post(tap: .cghidEventTap)
+            up.post(tap: .cghidEventTap)
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+    }
+
+    private func performKeypress(key: String) throws {
+        let parts = key.lowercased().components(separatedBy: "+")
+        let keyName = parts.last ?? key.lowercased()
+
+        guard let keyCode = virtualKeyCode(for: keyName) else {
+            throw CuaError.unknownKey(key)
+        }
+
+        var flags: CGEventFlags = []
+        if parts.contains("cmd") || parts.contains("command") { flags.insert(.maskCommand) }
+        if parts.contains("shift") { flags.insert(.maskShift) }
+        if parts.contains("opt") || parts.contains("option") || parts.contains("alt") { flags.insert(.maskAlternate) }
+        if parts.contains("ctrl") || parts.contains("control") { flags.insert(.maskControl) }
+
+        let src = CGEventSource(stateID: .hidSystemState)
+        guard
+            let down = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: true),
+            let up = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: false)
+        else { throw CuaError.eventCreationFailed }
+
+        down.flags = flags
+        up.flags = flags
+        down.post(tap: .cghidEventTap)
+        Thread.sleep(forTimeInterval: 0.05)
+        up.post(tap: .cghidEventTap)
+    }
+
+    private func performScroll(target: String, deltaString: String?) throws {
+        let point = try parseCoordinates(target)
+        let delta = deltaString.flatMap(Int32.init) ?? -3
+        let src = CGEventSource(stateID: .hidSystemState)
+
+        guard let event = CGEvent(
+            scrollWheelEvent2Source: src,
+            units: .line,
+            wheelCount: 1,
+            wheel1: delta,
+            wheel2: 0,
+            wheel3: 0
+        ) else { throw CuaError.eventCreationFailed }
+
+        event.location = point
+        event.post(tap: .cghidEventTap)
+    }
+
+    private func performDrag(from fromString: String, to toString: String?) throws {
+        let from = try parseCoordinates(fromString)
+        let to = try toString.map(parseCoordinates) ?? from
+        let src = CGEventSource(stateID: .hidSystemState)
+
+        guard
+            let down = CGEvent(mouseEventSource: src, mouseType: .leftMouseDown, mouseCursorPosition: from, mouseButton: .left),
+            let drag = CGEvent(mouseEventSource: src, mouseType: .leftMouseDragged, mouseCursorPosition: to, mouseButton: .left),
+            let up = CGEvent(mouseEventSource: src, mouseType: .leftMouseUp, mouseCursorPosition: to, mouseButton: .left)
+        else { throw CuaError.eventCreationFailed }
+
+        down.post(tap: .cghidEventTap)
+        Thread.sleep(forTimeInterval: 0.05)
+        drag.post(tap: .cghidEventTap)
+        Thread.sleep(forTimeInterval: 0.1)
+        up.post(tap: .cghidEventTap)
+    }
+
+    // MARK: - Helpers
+
+    private func requireSession(_ id: String) throws {
+        guard sessions.contains(id) else { throw CuaError.unknownSession }
+    }
+
+    private func parseCoordinates(_ string: String) throws -> CGPoint {
+        let parts = string
+            .split(separator: ",")
+            .compactMap { Double($0.trimmingCharacters(in: .whitespaces)) }
+        guard parts.count == 2 else {
+            throw CuaError.invalidCoordinates(string)
+        }
+        return CGPoint(x: parts[0], y: parts[1])
+    }
+
+    // swiftlint:disable cyclomatic_complexity
+    private func virtualKeyCode(for key: String) -> CGKeyCode? {
+        let map: [String: CGKeyCode] = [
+            "return": 36, "enter": 36,
+            "tab": 48, "space": 49,
+            "delete": 51, "backspace": 51,
+            "escape": 53, "esc": 53,
+            "cmd": 55, "command": 55,
+            "shift": 56,
+            "option": 58, "alt": 58, "opt": 58,
+            "ctrl": 59, "control": 59,
+            "f1": 122, "f2": 120, "f3": 99, "f4": 118, "f5": 96,
+            "f6": 97, "f7": 98, "f8": 100, "f9": 101, "f10": 109,
+            "left": 123, "right": 124, "down": 125, "up": 126,
+            "a": 0, "b": 11, "c": 8, "d": 2, "e": 14, "f": 3,
+            "g": 5, "h": 4, "i": 34, "j": 38, "k": 40, "l": 37,
+            "m": 46, "n": 45, "o": 31, "p": 35, "q": 12, "r": 15,
+            "s": 1, "t": 17, "u": 32, "v": 9, "w": 13, "x": 7,
+            "y": 16, "z": 6,
+            "0": 29, "1": 18, "2": 19, "3": 20, "4": 21, "5": 23,
+            "6": 22, "7": 26, "8": 28, "9": 25,
+        ]
+        return map[key.lowercased()]
+    }
+    // swiftlint:enable cyclomatic_complexity
+}
+
+enum CuaError: LocalizedError {
+    case unknownSession
+    case eventCreationFailed
+    case invalidCoordinates(String)
+    case unknownKey(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unknownSession:
+            return "Unknown computer-use session."
+        case .eventCreationFailed:
+            return "Failed to create CGEvent — grant Accessibility permission in System Settings → Privacy & Security."
+        case .invalidCoordinates(let s):
+            return "Invalid coordinates '\(s)'. Expected 'x,y' (e.g. '640,400')."
+        case .unknownKey(let k):
+            return "Unknown key '\(k)'. Use names like 'return', 'esc', 'cmd+e', 'shift+tab'."
+        }
+    }
+}

--- a/shell/Sources/MojoShell/ComputerUse/CuaComputerUseProvider.swift
+++ b/shell/Sources/MojoShell/ComputerUse/CuaComputerUseProvider.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 import CoreGraphics
 import Foundation
 
@@ -15,6 +16,11 @@ actor CuaComputerUseProvider: ComputerUseProvider {
     let name = "cua"
 
     private var sessions: Set<String> = []
+    private let permissionStatusProvider: @Sendable () -> CuaPermissionStatus
+
+    init(permissionStatusProvider: @escaping @Sendable () -> CuaPermissionStatus = { .live }) {
+        self.permissionStatusProvider = permissionStatusProvider
+    }
 
     // MARK: - Protocol
 
@@ -26,6 +32,10 @@ actor CuaComputerUseProvider: ComputerUseProvider {
 
     func captureState(sessionId: String) async throws -> ComputerUseState {
         try requireSession(sessionId)
+        let permissions = permissionStatusProvider()
+        guard permissions.screenRecordingGranted else {
+            throw CuaError.screenRecordingPermissionDenied
+        }
 
         let appName = await MainActor.run {
             NSWorkspace.shared.frontmostApplication?.localizedName ?? "Unknown"
@@ -40,6 +50,10 @@ actor CuaComputerUseProvider: ComputerUseProvider {
 
     func execute(sessionId: String, action: ComputerUseAction) async throws -> ComputerUseResult {
         try requireSession(sessionId)
+        let permissions = permissionStatusProvider()
+        guard permissions.accessibilityTrusted else {
+            throw CuaError.accessibilityPermissionDenied
+        }
 
         switch action.type {
         case .click:
@@ -54,10 +68,12 @@ actor CuaComputerUseProvider: ComputerUseProvider {
             try performDrag(from: action.target, to: action.value)
         }
 
+        let screenshotAfter = permissions.screenRecordingGranted ? captureScreenshot() : nil
+        let screenshotSuffix = screenshotAfter == nil ? " (screenshot unavailable)" : ""
         return ComputerUseResult(
             success: true,
-            message: "executed \(action.type.rawValue) → \(action.target)",
-            screenshotAfter: captureScreenshot()
+            message: "executed \(action.type.rawValue) → \(action.target)\(screenshotSuffix)",
+            screenshotAfter: screenshotAfter
         )
     }
 
@@ -228,11 +244,25 @@ actor CuaComputerUseProvider: ComputerUseProvider {
     // swiftlint:enable cyclomatic_complexity
 }
 
+struct CuaPermissionStatus: Equatable {
+    let accessibilityTrusted: Bool
+    let screenRecordingGranted: Bool
+
+    static var live: CuaPermissionStatus {
+        CuaPermissionStatus(
+            accessibilityTrusted: AXIsProcessTrusted(),
+            screenRecordingGranted: CGPreflightScreenCaptureAccess()
+        )
+    }
+}
+
 enum CuaError: LocalizedError {
     case unknownSession
     case eventCreationFailed
     case invalidCoordinates(String)
     case unknownKey(String)
+    case accessibilityPermissionDenied
+    case screenRecordingPermissionDenied
 
     var errorDescription: String? {
         switch self {
@@ -244,6 +274,10 @@ enum CuaError: LocalizedError {
             return "Invalid coordinates '\(s)'. Expected 'x,y' (e.g. '640,400')."
         case .unknownKey(let k):
             return "Unknown key '\(k)'. Use names like 'return', 'esc', 'cmd+e', 'shift+tab'."
+        case .accessibilityPermissionDenied:
+            return "Accessibility permission is required for computer-use input injection."
+        case .screenRecordingPermissionDenied:
+            return "Screen Recording permission is required for computer-use screenshots."
         }
     }
 }

--- a/shell/Sources/MojoShell/ComputerUse/StubComputerUseProvider.swift
+++ b/shell/Sources/MojoShell/ComputerUse/StubComputerUseProvider.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+actor StubComputerUseProvider: ComputerUseProvider {
+    let name = "stub"
+
+    private var sessions: Set<String> = []
+
+    func startSession() async throws -> String {
+        let id = UUID().uuidString
+        sessions.insert(id)
+        print("[StubCU] Session started: \(id)")
+        return id
+    }
+
+    func captureState(sessionId: String) async throws -> ComputerUseState {
+        guard sessions.contains(sessionId) else {
+            throw StubComputerUseError.unknownSession
+        }
+
+        return ComputerUseState(appName: "stub", screenshotData: nil, timestamp: Date())
+    }
+
+    func execute(sessionId: String, action: ComputerUseAction) async throws -> ComputerUseResult {
+        guard sessions.contains(sessionId) else {
+            throw StubComputerUseError.unknownSession
+        }
+
+        print("[StubCU] \(action.type.rawValue) -> \(action.target) (session: \(sessionId))")
+        return ComputerUseResult(
+            success: true,
+            message: "Stub executed: \(action.type.rawValue)",
+            screenshotAfter: nil
+        )
+    }
+
+    func stopSession(sessionId: String) async throws {
+        sessions.remove(sessionId)
+        print("[StubCU] Session stopped: \(sessionId)")
+    }
+}
+
+enum StubComputerUseError: Error {
+    case unknownSession
+}

--- a/shell/Sources/MojoShell/Jobs/DocumentInspector.swift
+++ b/shell/Sources/MojoShell/Jobs/DocumentInspector.swift
@@ -1,0 +1,66 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+struct DocumentMetadata: Equatable, Sendable {
+    let path: String
+    let name: String
+    let kind: SourceAssetKind
+    let byteSize: Int64?
+    let createdAt: Date?
+    let modifiedAt: Date?
+    let pixelWidth: Int?
+    let pixelHeight: Int?
+    let contentType: String?
+}
+
+enum DocumentInspector {
+    static func inspect(path: String) -> DocumentMetadata? {
+        let expanded = (path as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: expanded)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return nil
+        }
+
+        let values = try? url.resourceValues(forKeys: [
+            .nameKey,
+            .contentTypeKey,
+            .isDirectoryKey,
+            .fileSizeKey,
+            .creationDateKey,
+            .contentModificationDateKey,
+        ])
+
+        let type = values?.contentType
+        let kind = SourceAsset.from(path: url.path)?.kind ?? .other
+        let dimensions = pixelDimensions(for: url)
+
+        return DocumentMetadata(
+            path: url.path,
+            name: values?.name ?? url.lastPathComponent,
+            kind: kind,
+            byteSize: values?.fileSize.map(Int64.init),
+            createdAt: values?.creationDate,
+            modifiedAt: values?.contentModificationDate,
+            pixelWidth: dimensions?.0,
+            pixelHeight: dimensions?.1,
+            contentType: type?.preferredMIMEType ?? type?.identifier
+        )
+    }
+
+    private static func pixelDimensions(for url: URL) -> (Int, Int)? {
+        guard let image = NSImage(contentsOf: url) else {
+            return nil
+        }
+
+        if let representation = image.representations.first {
+            return (representation.pixelsWide, representation.pixelsHigh)
+        }
+
+        let size = image.size
+        guard size.width > 0, size.height > 0 else {
+            return nil
+        }
+        return (Int(size.width), Int(size.height))
+    }
+}

--- a/shell/Sources/MojoShell/Jobs/ExportTargetStore.swift
+++ b/shell/Sources/MojoShell/Jobs/ExportTargetStore.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+struct ExportTarget: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
+    var name: String
+    var path: String
+    var isDefault: Bool
+
+    init(id: UUID = UUID(), name: String, path: String, isDefault: Bool) {
+        self.id = id
+        self.name = name
+        self.path = path
+        self.isDefault = isDefault
+    }
+}
+
+struct ExportTargetStore {
+    let fileURL: URL
+    private let fileManager: FileManager
+
+    init(
+        fileURL: URL = ExportTargetStore.defaultFileURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func load() throws -> [ExportTarget] {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return defaultTargets()
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        guard !data.isEmpty else {
+            return defaultTargets()
+        }
+
+        let decoded = try JSONDecoder().decode([ExportTarget].self, from: data)
+        return decoded.isEmpty ? defaultTargets() : decoded
+    }
+
+    func save(_ targets: [ExportTarget]) throws {
+        try ensureParentDirectory()
+        let data = try JSONEncoder().encode(targets)
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    private func ensureParentDirectory() throws {
+        let parent = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+    }
+
+    static func defaultFileURL() -> URL {
+        JobStore.defaultFileURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("export-targets.json")
+    }
+
+    private func defaultTargets() -> [ExportTarget] {
+        let home = URL(fileURLWithPath: NSHomeDirectory())
+        return [
+            ExportTarget(
+                id: UUID(uuidString: "10000000-0000-0000-0000-000000000001") ?? UUID(),
+                name: "Movies",
+                path: home.appendingPathComponent("Movies").path,
+                isDefault: true
+            ),
+            ExportTarget(
+                id: UUID(uuidString: "10000000-0000-0000-0000-000000000002") ?? UUID(),
+                name: "Downloads",
+                path: home.appendingPathComponent("Downloads").path,
+                isDefault: false
+            ),
+            ExportTarget(
+                id: UUID(uuidString: "10000000-0000-0000-0000-000000000003") ?? UUID(),
+                name: "Desktop",
+                path: home.appendingPathComponent("Desktop").path,
+                isDefault: false
+            ),
+        ]
+    }
+}

--- a/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
+++ b/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+/// A single step in a computer-use workflow.
+struct WorkflowStep: Identifiable, Sendable {
+    let id = UUID()
+    let description: String
+
+    /// Preferred: find an AX element by role + title fragment and click its center.
+    let axQuery: AXQuery?
+
+    /// Fallback: fixed coordinates as "x,y" string (used when AX lookup fails or isn't applicable).
+    let fallbackCoordinates: String?
+
+    /// Keystroke to fire (e.g. "cmd+e") — used instead of a click when set.
+    let keypress: String?
+
+    /// Text to type into the focused element.
+    let typeText: String?
+
+    /// Delay in seconds AFTER this step executes.
+    let delayAfter: TimeInterval
+
+    struct AXQuery: Sendable {
+        let appName: String
+        let role: String        // e.g. "AXButton"
+        let titleContaining: String
+    }
+
+    // Convenience initialisers
+
+    static func click(
+        _ description: String,
+        app: String,
+        buttonTitled title: String,
+        fallback: String? = nil,
+        delay: TimeInterval = 0.3
+    ) -> WorkflowStep {
+        WorkflowStep(
+            description: description,
+            axQuery: AXQuery(appName: app, role: "AXButton", titleContaining: title),
+            fallbackCoordinates: fallback,
+            keypress: nil,
+            typeText: nil,
+            delayAfter: delay
+        )
+    }
+
+    static func keypress(
+        _ description: String,
+        key: String,
+        delay: TimeInterval = 0.3
+    ) -> WorkflowStep {
+        WorkflowStep(
+            description: description,
+            axQuery: nil,
+            fallbackCoordinates: nil,
+            keypress: key,
+            typeText: nil,
+            delayAfter: delay
+        )
+    }
+
+    static func type(
+        _ description: String,
+        text: String,
+        delay: TimeInterval = 0.2
+    ) -> WorkflowStep {
+        WorkflowStep(
+            description: description,
+            axQuery: nil,
+            fallbackCoordinates: nil,
+            keypress: nil,
+            typeText: text,
+            delayAfter: delay
+        )
+    }
+
+    static func coordinate(
+        _ description: String,
+        at xy: String,
+        delay: TimeInterval = 0.3
+    ) -> WorkflowStep {
+        WorkflowStep(
+            description: description,
+            axQuery: nil,
+            fallbackCoordinates: xy,
+            keypress: nil,
+            typeText: nil,
+            delayAfter: delay
+        )
+    }
+}
+
+/// Predefined computer-use workflow sequences for Final Cut Pro.
+enum FcpWorkflowDefinition {
+
+    /// Assembly workflow: bring FCP to front, open the Share sheet, select the target format.
+    ///
+    /// Phase 1 scope: gets FCP focused and opens the export dialog.
+    /// The specific share destination (Master File, YouTube, etc.) is wired per client template.
+    static func assemblyWorkflow(shareDestination: String = "Master File…") -> [WorkflowStep] {
+        [
+            // 1. Bring FCP to front so input events land on the right app
+            .keypress("Focus Final Cut Pro", key: "cmd+tab", delay: 0.5),
+
+            // 2. Open the Share sheet via menu shortcut (Cmd+E = Share → Master File by default)
+            .keypress("Open Share menu (Cmd+E)", key: "cmd+e", delay: 1.0),
+
+            // 3. If a sheet is now open, click the share destination button
+            .click(
+                "Select share destination '\(shareDestination)'",
+                app: "Final Cut Pro",
+                buttonTitled: shareDestination,
+                fallback: nil,
+                delay: 0.5
+            ),
+
+            // 4. Click "Next…" in the sheet
+            .click(
+                "Click Next",
+                app: "Final Cut Pro",
+                buttonTitled: "Next",
+                delay: 0.5
+            ),
+        ]
+    }
+
+    /// Monitoring check: read the current background task list via Cmd+9 (Background Tasks window).
+    static func monitoringCheck() -> [WorkflowStep] {
+        [
+            .keypress("Focus Final Cut Pro", key: "cmd+tab", delay: 0.5),
+            .keypress("Open Background Tasks window (Cmd+9)", key: "cmd+9", delay: 0.8),
+        ]
+    }
+}
+
+/// Executes a list of `WorkflowStep` values against a `ComputerUseProvider`, logging progress.
+struct WorkflowExecutor {
+    let provider: any ComputerUseProvider
+
+    func run(
+        steps: [WorkflowStep],
+        sessionId: String,
+        onProgress: @escaping @Sendable (String) -> Void
+    ) async throws {
+        for (index, step) in steps.enumerated() {
+            onProgress("[\(index + 1)/\(steps.count)] \(step.description)…")
+
+            if let keypress = step.keypress {
+                _ = try await provider.execute(
+                    sessionId: sessionId,
+                    action: ComputerUseAction(type: .keypress, target: keypress)
+                )
+            } else if let text = step.typeText {
+                _ = try await provider.execute(
+                    sessionId: sessionId,
+                    action: ComputerUseAction(type: .type, target: text)
+                )
+            } else if let query = step.axQuery {
+                let target = try resolveAXTarget(query: query, fallback: step.fallbackCoordinates)
+                _ = try await provider.execute(
+                    sessionId: sessionId,
+                    action: ComputerUseAction(type: .click, target: target)
+                )
+            } else if let coords = step.fallbackCoordinates {
+                _ = try await provider.execute(
+                    sessionId: sessionId,
+                    action: ComputerUseAction(type: .click, target: coords)
+                )
+            }
+
+            if step.delayAfter > 0 {
+                try await Task.sleep(nanoseconds: UInt64(step.delayAfter * 1_000_000_000))
+            }
+        }
+
+        onProgress("Workflow complete.")
+    }
+
+    private func resolveAXTarget(query: WorkflowStep.AXQuery, fallback: String?) throws -> String {
+        if let elements = try? AccessibilityElementFinder.findElements(
+            inApp: query.appName,
+            roles: [query.role],
+            titleContaining: query.titleContaining
+        ), let first = elements.first {
+            return "\(Int(first.screenPoint.x)),\(Int(first.screenPoint.y))"
+        }
+
+        if let fallback {
+            return fallback
+        }
+
+        throw WorkflowError.elementNotFound(query.appName, query.role, query.titleContaining)
+    }
+}
+
+enum WorkflowError: LocalizedError {
+    case elementNotFound(String, String, String)
+
+    var errorDescription: String? {
+        switch self {
+        case .elementNotFound(let app, let role, let title):
+            return "Could not find '\(title)' (\(role)) in \(app). Is the app open?"
+        }
+    }
+}

--- a/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
+++ b/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
@@ -149,8 +149,19 @@ enum FcpWorkflowDefinition {
     /// - Parameter shareDestination: The share-sheet destination button title to select.
     ///   Defaults to `"Export File (default)…"` — the File > Share item name (context-sensitive).
     ///   Other destinations: `"Apple Devices 1080p…"`, `"Social Platforms…"`, etc.
-    static func assemblyWorkflow(shareDestination: String = "Export File (default)…") -> [WorkflowStep] {
-        [
+    static func assemblyWorkflow(
+        shareDestination: String = "Export File (default)…",
+        exportTargetPath: String? = nil
+    ) -> [WorkflowStep] {
+        let destinationPrompt = exportTargetPath.map {
+            "Confirm the export destination in Final Cut Pro before MojoShell clicks it. Target folder: \($0)"
+        } ?? "Confirm the export destination in Final Cut Pro before MojoShell clicks it."
+
+        let nextPrompt = exportTargetPath.map {
+            "Confirm the export sheet is configured correctly before advancing. Save into: \($0)"
+        } ?? "Confirm the export sheet is configured correctly before advancing."
+
+        return [
             // 1. Bring FCP to front deterministically (NSWorkspace, not cmd+tab)
             .activateApp("Final Cut Pro"),
 
@@ -173,7 +184,7 @@ enum FcpWorkflowDefinition {
                 "Select '\(shareDestination)'",
                 app: "Final Cut Pro",
                 buttonTitled: shareDestination,
-                approvalPrompt: "Confirm the export destination in Final Cut Pro before MojoShell clicks it.",
+                approvalPrompt: destinationPrompt,
                 delay: 0.5
             ),
 
@@ -185,7 +196,7 @@ enum FcpWorkflowDefinition {
                 app: "Final Cut Pro",
                 buttonTitled: "Next…",
                 fallback: nil,
-                approvalPrompt: "Confirm the export sheet is configured correctly before advancing.",
+                approvalPrompt: nextPrompt,
                 delay: 0.5
             ),
         ]

--- a/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
+++ b/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
@@ -122,17 +122,19 @@ enum FcpWorkflowDefinition {
 
     /// Assembly workflow: bring FCP to front, open the Export File sheet, confirm.
     ///
-    /// Verified against live Final Cut Pro via AX discovery (2026-03-12):
-    ///   - Toolbar share button: "Share the project, event clip, or Timeline range"
-    ///   - File > Share submenu entry: "Export File (default)…" (greyed unless clip selected)
-    ///   - "Next" and "Save" button titles inside the sheet: TBD — requires clip selected to open
-    ///
-    /// The toolbar button click opens the same sheet as File > Share > Export File (default)…
-    /// Requires a clip or project to be selected in the FCP timeline before running.
+    /// AX discovery status (2026-03-12):
+    ///   ✅ Step 1 — toolbar Share button: "Share the project, event clip, or Timeline range"
+    ///   ⚠️  Step 2 — shareDestination: "Export File (default)…" is context-sensitive.
+    ///              It does NOT appear in the AX tree unless FCP has an exportable project/clip
+    ///              selected. Without that state, only "Export XML…" and "Export Captions…"
+    ///              are visible. File > Share > "Export File (default)…" is the target entry.
+    ///   ❌ Steps 3-4 — "Next" / "Save" inside the export sheet: TBD.
+    ///              Requires: project open → timeline selection → Share → Export File → sheet open.
+    ///              Then run: scripts/discover_ax_elements.py --app "Final Cut Pro" --title next
     ///
     /// - Parameter shareDestination: The share-sheet destination button title to select.
-    ///   Defaults to `"Export File (default)…"` — the verified File > Share item name.
-    ///   Other options from the submenu: `"Apple Devices 1080p…"`, `"Social Platforms…"`, etc.
+    ///   Defaults to `"Export File (default)…"` — the File > Share item name (context-sensitive).
+    ///   Other destinations: `"Apple Devices 1080p…"`, `"Social Platforms…"`, etc.
     static func assemblyWorkflow(shareDestination: String = "Export File (default)…") -> [WorkflowStep] {
         [
             // 1. Bring FCP to front deterministically (NSWorkspace, not cmd+tab)
@@ -148,10 +150,11 @@ enum FcpWorkflowDefinition {
                 delay: 1.0
             ),
 
-            // 3. Select the export destination inside the sheet.
-            //    Live AX title for the default path: "Export File (default)…"
-            //    "Next" and "Save" button titles inside the open sheet are TBD —
-            //    run discover_ax_elements.py with a clip selected to get exact strings.
+            // 3. Select the export destination.
+            //    "Export File (default)…" is the target AX title — only exposed when FCP
+            //    has an exportable project/clip selected in the timeline.
+            //    TBD: verify exact title with:
+            //      scripts/discover_ax_elements.py --app "Final Cut Pro" --title export --max-depth 10
             .click(
                 "Select '\(shareDestination)'",
                 app: "Final Cut Pro",
@@ -159,9 +162,10 @@ enum FcpWorkflowDefinition {
                 delay: 0.5
             ),
 
-            // 4. Advance through the sheet.
-            //    Title TBD — will be "Next…" or "Save" depending on sheet step.
-            //    Update after running: scripts/discover_ax_elements.py --app "Final Cut Pro" --title next
+            // 4. Advance through the export sheet.
+            //    Title TBD — verify with sheet open:
+            //      scripts/discover_ax_elements.py --app "Final Cut Pro" --title next --max-depth 10
+            //      scripts/discover_ax_elements.py --app "Final Cut Pro" --title save --max-depth 10
             .click(
                 "Click Next / Save",
                 app: "Final Cut Pro",

--- a/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
+++ b/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
@@ -128,9 +128,10 @@ enum FcpWorkflowDefinition {
     ///              It does NOT appear in the AX tree unless FCP has an exportable project/clip
     ///              selected. Without that state, only "Export XML…" and "Export Captions…"
     ///              are visible. File > Share > "Export File (default)…" is the target entry.
-    ///   ❌ Steps 3-4 — "Next" / "Save" inside the export sheet: TBD.
-    ///              Requires: project open → timeline selection → Share → Export File → sheet open.
-    ///              Then run: scripts/discover_ax_elements.py --app "Final Cut Pro" --title next
+    ///   ✅ Step 3-4 — export sheet buttons confirmed live (2026-03-12):
+    ///              Advance: "Next…" (AXButton, ellipsis included) at approx 994,715
+    ///              Cancel:  "Cancel" (AXButton) at approx 916,715
+    ///              Note: "Save Effects Preset" is a separate inspector button, not the sheet advance.
     ///
     /// - Parameter shareDestination: The share-sheet destination button title to select.
     ///   Defaults to `"Export File (default)…"` — the File > Share item name (context-sensitive).
@@ -163,13 +164,12 @@ enum FcpWorkflowDefinition {
             ),
 
             // 4. Advance through the export sheet.
-            //    Title TBD — verify with sheet open:
-            //      scripts/discover_ax_elements.py --app "Final Cut Pro" --title next --max-depth 10
-            //      scripts/discover_ax_elements.py --app "Final Cut Pro" --title save --max-depth 10
+            //    Verified AX title: "Next…" (with ellipsis) — confirmed live 2026-03-12.
+            //    "Save Effects Preset" is a separate inspector button; the sheet advance is "Next…".
             .click(
-                "Click Next / Save",
+                "Click Next…",
                 app: "Final Cut Pro",
-                buttonTitled: "Next",
+                buttonTitled: "Next…",
                 fallback: nil,
                 delay: 0.5
             ),

--- a/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
+++ b/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
@@ -22,6 +22,9 @@ struct WorkflowStep: Identifiable, Sendable {
     /// When set, all other action fields are ignored.
     let appActivationName: String?
 
+    /// Optional operator checkpoint before executing this step.
+    let approvalPrompt: String?
+
     /// Delay in seconds AFTER this step executes.
     let delayAfter: TimeInterval
 
@@ -37,6 +40,7 @@ struct WorkflowStep: Identifiable, Sendable {
     /// Does NOT use cmd+tab — directly addresses the target process.
     static func activateApp(
         _ appName: String,
+        approvalPrompt: String? = nil,
         delay: TimeInterval = 0.5
     ) -> WorkflowStep {
         WorkflowStep(
@@ -46,6 +50,7 @@ struct WorkflowStep: Identifiable, Sendable {
             keypress: nil,
             typeText: nil,
             appActivationName: appName,
+            approvalPrompt: approvalPrompt,
             delayAfter: delay
         )
     }
@@ -55,6 +60,7 @@ struct WorkflowStep: Identifiable, Sendable {
         app: String,
         buttonTitled title: String,
         fallback: String? = nil,
+        approvalPrompt: String? = nil,
         delay: TimeInterval = 0.3
     ) -> WorkflowStep {
         WorkflowStep(
@@ -64,6 +70,7 @@ struct WorkflowStep: Identifiable, Sendable {
             keypress: nil,
             typeText: nil,
             appActivationName: nil,
+            approvalPrompt: approvalPrompt,
             delayAfter: delay
         )
     }
@@ -71,6 +78,7 @@ struct WorkflowStep: Identifiable, Sendable {
     static func keypress(
         _ description: String,
         key: String,
+        approvalPrompt: String? = nil,
         delay: TimeInterval = 0.3
     ) -> WorkflowStep {
         WorkflowStep(
@@ -80,6 +88,7 @@ struct WorkflowStep: Identifiable, Sendable {
             keypress: key,
             typeText: nil,
             appActivationName: nil,
+            approvalPrompt: approvalPrompt,
             delayAfter: delay
         )
     }
@@ -87,6 +96,7 @@ struct WorkflowStep: Identifiable, Sendable {
     static func type(
         _ description: String,
         text: String,
+        approvalPrompt: String? = nil,
         delay: TimeInterval = 0.2
     ) -> WorkflowStep {
         WorkflowStep(
@@ -96,6 +106,7 @@ struct WorkflowStep: Identifiable, Sendable {
             keypress: nil,
             typeText: text,
             appActivationName: nil,
+            approvalPrompt: approvalPrompt,
             delayAfter: delay
         )
     }
@@ -103,6 +114,7 @@ struct WorkflowStep: Identifiable, Sendable {
     static func coordinate(
         _ description: String,
         at xy: String,
+        approvalPrompt: String? = nil,
         delay: TimeInterval = 0.3
     ) -> WorkflowStep {
         WorkflowStep(
@@ -112,6 +124,7 @@ struct WorkflowStep: Identifiable, Sendable {
             keypress: nil,
             typeText: nil,
             appActivationName: nil,
+            approvalPrompt: approvalPrompt,
             delayAfter: delay
         )
     }
@@ -160,6 +173,7 @@ enum FcpWorkflowDefinition {
                 "Select '\(shareDestination)'",
                 app: "Final Cut Pro",
                 buttonTitled: shareDestination,
+                approvalPrompt: "Confirm the export destination in Final Cut Pro before MojoShell clicks it.",
                 delay: 0.5
             ),
 
@@ -171,6 +185,7 @@ enum FcpWorkflowDefinition {
                 app: "Final Cut Pro",
                 buttonTitled: "Next…",
                 fallback: nil,
+                approvalPrompt: "Confirm the export sheet is configured correctly before advancing.",
                 delay: 0.5
             ),
         ]
@@ -194,10 +209,19 @@ struct WorkflowExecutor {
         steps: [WorkflowStep],
         sessionId: String,
         onProgress: @escaping (String) -> Void,
-        onStepResult: ((Int, WorkflowStep, ComputerUseResult) -> Void)? = nil
+        onStepResult: ((Int, WorkflowStep, ComputerUseResult) -> Void)? = nil,
+        onApprovalRequested: ((Int, WorkflowStep) async -> Bool)? = nil
     ) async throws {
         for (index, step) in steps.enumerated() {
             onProgress("[\(index + 1)/\(steps.count)] \(step.description)…")
+
+            if step.approvalPrompt != nil {
+                let approved = await onApprovalRequested?(index, step) ?? false
+                if !approved {
+                    throw WorkflowError.approvalRejected(step.description)
+                }
+            }
+
             var stepResult: ComputerUseResult?
 
             if let appName = step.appActivationName {
@@ -265,6 +289,7 @@ struct WorkflowExecutor {
 enum WorkflowError: LocalizedError {
     case elementNotFound(String, String, String)
     case appNotRunning(String)
+    case approvalRejected(String)
 
     var errorDescription: String? {
         switch self {
@@ -272,6 +297,8 @@ enum WorkflowError: LocalizedError {
             return "Could not find '\(title)' (\(role)) in \(app). Is the app open?"
         case .appNotRunning(let name):
             return "\(name) is not running. Open it before starting the workflow."
+        case .approvalRejected(let description):
+            return "Approval rejected for step: \(description)"
         }
     }
 }

--- a/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
+++ b/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 /// A single step in a computer-use workflow.
@@ -17,6 +18,10 @@ struct WorkflowStep: Identifiable, Sendable {
     /// Text to type into the focused element.
     let typeText: String?
 
+    /// App to bring to the foreground via NSWorkspace (deterministic; ignores the app-switcher order).
+    /// When set, all other action fields are ignored.
+    let appActivationName: String?
+
     /// Delay in seconds AFTER this step executes.
     let delayAfter: TimeInterval
 
@@ -27,6 +32,23 @@ struct WorkflowStep: Identifiable, Sendable {
     }
 
     // Convenience initialisers
+
+    /// Activates a running app by its localised name using NSWorkspace.
+    /// Does NOT use cmd+tab — directly addresses the target process.
+    static func activateApp(
+        _ appName: String,
+        delay: TimeInterval = 0.5
+    ) -> WorkflowStep {
+        WorkflowStep(
+            description: "Activate \(appName)",
+            axQuery: nil,
+            fallbackCoordinates: nil,
+            keypress: nil,
+            typeText: nil,
+            appActivationName: appName,
+            delayAfter: delay
+        )
+    }
 
     static func click(
         _ description: String,
@@ -41,6 +63,7 @@ struct WorkflowStep: Identifiable, Sendable {
             fallbackCoordinates: fallback,
             keypress: nil,
             typeText: nil,
+            appActivationName: nil,
             delayAfter: delay
         )
     }
@@ -56,6 +79,7 @@ struct WorkflowStep: Identifiable, Sendable {
             fallbackCoordinates: nil,
             keypress: key,
             typeText: nil,
+            appActivationName: nil,
             delayAfter: delay
         )
     }
@@ -71,6 +95,7 @@ struct WorkflowStep: Identifiable, Sendable {
             fallbackCoordinates: nil,
             keypress: nil,
             typeText: text,
+            appActivationName: nil,
             delayAfter: delay
         )
     }
@@ -86,6 +111,7 @@ struct WorkflowStep: Identifiable, Sendable {
             fallbackCoordinates: xy,
             keypress: nil,
             typeText: nil,
+            appActivationName: nil,
             delayAfter: delay
         )
     }
@@ -100,8 +126,8 @@ enum FcpWorkflowDefinition {
     /// The specific share destination (Master File, YouTube, etc.) is wired per client template.
     static func assemblyWorkflow(shareDestination: String = "Master File…") -> [WorkflowStep] {
         [
-            // 1. Bring FCP to front so input events land on the right app
-            .keypress("Focus Final Cut Pro", key: "cmd+tab", delay: 0.5),
+            // 1. Bring FCP to front deterministically via NSWorkspace (not cmd+tab)
+            .activateApp("Final Cut Pro"),
 
             // 2. Open the Share sheet via menu shortcut (Cmd+E = Share → Master File by default)
             .keypress("Open Share menu (Cmd+E)", key: "cmd+e", delay: 1.0),
@@ -128,7 +154,7 @@ enum FcpWorkflowDefinition {
     /// Monitoring check: read the current background task list via Cmd+9 (Background Tasks window).
     static func monitoringCheck() -> [WorkflowStep] {
         [
-            .keypress("Focus Final Cut Pro", key: "cmd+tab", delay: 0.5),
+            .activateApp("Final Cut Pro"),
             .keypress("Open Background Tasks window (Cmd+9)", key: "cmd+9", delay: 0.8),
         ]
     }
@@ -146,7 +172,17 @@ struct WorkflowExecutor {
         for (index, step) in steps.enumerated() {
             onProgress("[\(index + 1)/\(steps.count)] \(step.description)…")
 
-            if let keypress = step.keypress {
+            if let appName = step.appActivationName {
+                let activated = await MainActor.run {
+                    NSWorkspace.shared.runningApplications
+                        .first { $0.localizedName == appName }?
+                        .activate(options: .activateIgnoringOtherApps)
+                        ?? false
+                }
+                if !activated {
+                    throw WorkflowError.appNotRunning(appName)
+                }
+            } else if let keypress = step.keypress {
                 _ = try await provider.execute(
                     sessionId: sessionId,
                     action: ComputerUseAction(type: .keypress, target: keypress)
@@ -196,11 +232,14 @@ struct WorkflowExecutor {
 
 enum WorkflowError: LocalizedError {
     case elementNotFound(String, String, String)
+    case appNotRunning(String)
 
     var errorDescription: String? {
         switch self {
         case .elementNotFound(let app, let role, let title):
             return "Could not find '\(title)' (\(role)) in \(app). Is the app open?"
+        case .appNotRunning(let name):
+            return "\(name) is not running. Open it before starting the workflow."
         }
     }
 }

--- a/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
+++ b/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
@@ -189,13 +189,16 @@ enum FcpWorkflowDefinition {
 struct WorkflowExecutor {
     let provider: any ComputerUseProvider
 
+    @MainActor
     func run(
         steps: [WorkflowStep],
         sessionId: String,
-        onProgress: @escaping @Sendable (String) -> Void
+        onProgress: @escaping (String) -> Void,
+        onStepResult: ((Int, WorkflowStep, ComputerUseResult) -> Void)? = nil
     ) async throws {
         for (index, step) in steps.enumerated() {
             onProgress("[\(index + 1)/\(steps.count)] \(step.description)…")
+            var stepResult: ComputerUseResult?
 
             if let appName = step.appActivationName {
                 let activated = await MainActor.run {
@@ -208,26 +211,30 @@ struct WorkflowExecutor {
                     throw WorkflowError.appNotRunning(appName)
                 }
             } else if let keypress = step.keypress {
-                _ = try await provider.execute(
+                stepResult = try await provider.execute(
                     sessionId: sessionId,
                     action: ComputerUseAction(type: .keypress, target: keypress)
                 )
             } else if let text = step.typeText {
-                _ = try await provider.execute(
+                stepResult = try await provider.execute(
                     sessionId: sessionId,
                     action: ComputerUseAction(type: .type, target: text)
                 )
             } else if let query = step.axQuery {
                 let target = try resolveAXTarget(query: query, fallback: step.fallbackCoordinates)
-                _ = try await provider.execute(
+                stepResult = try await provider.execute(
                     sessionId: sessionId,
                     action: ComputerUseAction(type: .click, target: target)
                 )
             } else if let coords = step.fallbackCoordinates {
-                _ = try await provider.execute(
+                stepResult = try await provider.execute(
                     sessionId: sessionId,
                     action: ComputerUseAction(type: .click, target: coords)
                 )
+            }
+
+            if let stepResult {
+                onStepResult?(index, step, stepResult)
             }
 
             if step.delayAfter > 0 {

--- a/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
+++ b/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
@@ -220,13 +220,15 @@ struct WorkflowExecutor {
         steps: [WorkflowStep],
         sessionId: String,
         onProgress: @escaping (String) -> Void,
+        shouldRequestApproval: ((Int, WorkflowStep) -> Bool)? = nil,
         onStepResult: ((Int, WorkflowStep, ComputerUseResult) -> Void)? = nil,
         onApprovalRequested: ((Int, WorkflowStep) async -> Bool)? = nil
     ) async throws {
         for (index, step) in steps.enumerated() {
             onProgress("[\(index + 1)/\(steps.count)] \(step.description)…")
 
-            if step.approvalPrompt != nil {
+            let requiresApproval = shouldRequestApproval?(index, step) ?? (step.approvalPrompt != nil)
+            if requiresApproval {
                 let approved = await onApprovalRequested?(index, step) ?? false
                 if !approved {
                     throw WorkflowError.approvalRejected(step.description)

--- a/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
+++ b/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
@@ -129,8 +129,13 @@ enum FcpWorkflowDefinition {
             // 1. Bring FCP to front deterministically via NSWorkspace (not cmd+tab)
             .activateApp("Final Cut Pro"),
 
-            // 2. Open the Share sheet via menu shortcut (Cmd+E = Share → Master File by default)
-            .keypress("Open Share menu (Cmd+E)", key: "cmd+e", delay: 1.0),
+            // 2. Click the verified AX toolbar share button title from the live FCP discovery pass.
+            .click(
+                "Open Share menu",
+                app: "Final Cut Pro",
+                buttonTitled: "Share the project, event clip, or Timeline range",
+                delay: 1.0
+            ),
 
             // 3. If a sheet is now open, click the share destination button
             .click(

--- a/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
+++ b/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
@@ -120,37 +120,53 @@ struct WorkflowStep: Identifiable, Sendable {
 /// Predefined computer-use workflow sequences for Final Cut Pro.
 enum FcpWorkflowDefinition {
 
-    /// Assembly workflow: bring FCP to front, open the Share sheet, select the target format.
+    /// Assembly workflow: bring FCP to front, open the Export File sheet, confirm.
     ///
-    /// Phase 1 scope: gets FCP focused and opens the export dialog.
-    /// The specific share destination (Master File, YouTube, etc.) is wired per client template.
-    static func assemblyWorkflow(shareDestination: String = "Master File…") -> [WorkflowStep] {
+    /// Verified against live Final Cut Pro via AX discovery (2026-03-12):
+    ///   - Toolbar share button: "Share the project, event clip, or Timeline range"
+    ///   - File > Share submenu entry: "Export File (default)…" (greyed unless clip selected)
+    ///   - "Next" and "Save" button titles inside the sheet: TBD — requires clip selected to open
+    ///
+    /// The toolbar button click opens the same sheet as File > Share > Export File (default)…
+    /// Requires a clip or project to be selected in the FCP timeline before running.
+    ///
+    /// - Parameter shareDestination: The share-sheet destination button title to select.
+    ///   Defaults to `"Export File (default)…"` — the verified File > Share item name.
+    ///   Other options from the submenu: `"Apple Devices 1080p…"`, `"Social Platforms…"`, etc.
+    static func assemblyWorkflow(shareDestination: String = "Export File (default)…") -> [WorkflowStep] {
         [
-            // 1. Bring FCP to front deterministically via NSWorkspace (not cmd+tab)
+            // 1. Bring FCP to front deterministically (NSWorkspace, not cmd+tab)
             .activateApp("Final Cut Pro"),
 
-            // 2. Click the verified AX toolbar share button title from the live FCP discovery pass.
+            // 2. Click the toolbar Share button.
+            //    Verified AX title: "Share the project, event clip, or Timeline range"
+            //    Requires a clip/project selected; button is enabled when something is in the timeline.
             .click(
-                "Open Share menu",
+                "Open Share sheet via toolbar",
                 app: "Final Cut Pro",
                 buttonTitled: "Share the project, event clip, or Timeline range",
                 delay: 1.0
             ),
 
-            // 3. If a sheet is now open, click the share destination button
+            // 3. Select the export destination inside the sheet.
+            //    Live AX title for the default path: "Export File (default)…"
+            //    "Next" and "Save" button titles inside the open sheet are TBD —
+            //    run discover_ax_elements.py with a clip selected to get exact strings.
             .click(
-                "Select share destination '\(shareDestination)'",
+                "Select '\(shareDestination)'",
                 app: "Final Cut Pro",
                 buttonTitled: shareDestination,
-                fallback: nil,
                 delay: 0.5
             ),
 
-            // 4. Click "Next…" in the sheet
+            // 4. Advance through the sheet.
+            //    Title TBD — will be "Next…" or "Save" depending on sheet step.
+            //    Update after running: scripts/discover_ax_elements.py --app "Final Cut Pro" --title next
             .click(
-                "Click Next",
+                "Click Next / Save",
                 app: "Final Cut Pro",
                 buttonTitled: "Next",
+                fallback: nil,
                 delay: 0.5
             ),
         ]

--- a/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
+++ b/shell/Sources/MojoShell/Jobs/FcpWorkflowDefinition.swift
@@ -201,7 +201,7 @@ struct WorkflowExecutor {
                 let activated = await MainActor.run {
                     NSWorkspace.shared.runningApplications
                         .first { $0.localizedName == appName }?
-                        .activate(options: .activateIgnoringOtherApps)
+                        .activate()
                         ?? false
                 }
                 if !activated {

--- a/shell/Sources/MojoShell/Jobs/JobEvent.swift
+++ b/shell/Sources/MojoShell/Jobs/JobEvent.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+enum JobEventType: String, Codable, Equatable, Sendable {
+    case queued
+    case started
+    case stepProgress
+    case completed
+    case failed
+    case canceled
+    case info
+}
+
+struct JobEvent: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
+    let jobID: UUID
+    let timestamp: Date
+    let type: JobEventType
+    let message: String
+    let progress: Double?
+    let screenshotPath: String?
+
+    init(
+        id: UUID = UUID(),
+        jobID: UUID,
+        timestamp: Date = Date(),
+        type: JobEventType,
+        message: String,
+        progress: Double? = nil,
+        screenshotPath: String? = nil
+    ) {
+        self.id = id
+        self.jobID = jobID
+        self.timestamp = timestamp
+        self.type = type
+        self.message = message
+        self.progress = progress
+        self.screenshotPath = screenshotPath
+    }
+}

--- a/shell/Sources/MojoShell/Jobs/JobStore.swift
+++ b/shell/Sources/MojoShell/Jobs/JobStore.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+struct JobStore {
+    let fileURL: URL
+    private let fileManager: FileManager
+
+    init(
+        fileURL: URL = JobStore.defaultFileURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func load() throws -> [MediaJob] {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return []
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        guard !data.isEmpty else {
+            return []
+        }
+
+        return try JSONDecoder().decode([MediaJob].self, from: data)
+    }
+
+    func save(_ jobs: [MediaJob]) throws {
+        try ensureParentDirectory()
+        let data = try JSONEncoder().encode(jobs)
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    private func ensureParentDirectory() throws {
+        let parent = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+    }
+
+    static func defaultFileURL() -> URL {
+        appSupportDirectory().appendingPathComponent("jobs.json")
+    }
+}
+
+struct JobEventStore {
+    let fileURL: URL
+    private let fileManager: FileManager
+
+    init(
+        fileURL: URL = JobEventStore.defaultFileURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func load() throws -> [JobEvent] {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return []
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        guard !data.isEmpty else {
+            return []
+        }
+
+        return try JSONDecoder().decode([JobEvent].self, from: data)
+    }
+
+    func loadRecent(limit: Int) throws -> [JobEvent] {
+        let all = try load()
+        guard all.count > limit else {
+            return all
+        }
+        return Array(all.suffix(limit))
+    }
+
+    func append(_ event: JobEvent) throws {
+        var all = try load()
+        all.append(event)
+        try save(all)
+    }
+
+    func save(_ events: [JobEvent]) throws {
+        try ensureParentDirectory()
+        let data = try JSONEncoder().encode(events)
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    private func ensureParentDirectory() throws {
+        let parent = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+    }
+
+    static func defaultFileURL() -> URL {
+        appSupportDirectory().appendingPathComponent("job-events.json")
+    }
+}
+
+struct ScreenshotStore {
+    let directoryURL: URL
+    private let fileManager: FileManager
+
+    init(
+        directoryURL: URL = ScreenshotStore.defaultDirectoryURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.directoryURL = directoryURL
+        self.fileManager = fileManager
+    }
+
+    func save(_ data: Data, jobID: UUID, stepIndex: Int) throws -> URL {
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let stamp = Int(Date().timeIntervalSince1970 * 1000)
+        let fileName = "\(jobID.uuidString)-step\(stepIndex + 1)-\(stamp).png"
+        let url = directoryURL.appendingPathComponent(fileName)
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    static func defaultDirectoryURL() -> URL {
+        appSupportDirectory().appendingPathComponent("screenshots")
+    }
+}
+
+private func appSupportDirectory() -> URL {
+    let fm = FileManager.default
+    if let base = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+        return base.appendingPathComponent("MojoShell", isDirectory: true)
+    }
+
+    return URL(fileURLWithPath: NSHomeDirectory())
+        .appendingPathComponent("Library")
+        .appendingPathComponent("Application Support")
+        .appendingPathComponent("MojoShell", isDirectory: true)
+}

--- a/shell/Sources/MojoShell/Jobs/MediaJob.swift
+++ b/shell/Sources/MojoShell/Jobs/MediaJob.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-enum MediaJobStatus: String, Equatable {
+enum MediaJobStatus: String, Codable, Equatable, Sendable {
     case queued
     case running
     case completed
     case failed
 }
 
-struct MediaJob: Identifiable, Equatable {
-    let id = UUID()
+struct MediaJob: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
     let name: String
     let client: String
     var status: MediaJobStatus
@@ -16,4 +16,24 @@ struct MediaJob: Identifiable, Equatable {
     let createdAt: Date
     var completedAt: Date?
     var errorMessage: String?
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        client: String,
+        status: MediaJobStatus,
+        progress: Double,
+        createdAt: Date,
+        completedAt: Date?,
+        errorMessage: String?
+    ) {
+        self.id = id
+        self.name = name
+        self.client = client
+        self.status = status
+        self.progress = progress
+        self.createdAt = createdAt
+        self.completedAt = completedAt
+        self.errorMessage = errorMessage
+    }
 }

--- a/shell/Sources/MojoShell/Jobs/MediaJob.swift
+++ b/shell/Sources/MojoShell/Jobs/MediaJob.swift
@@ -17,6 +17,10 @@ struct MediaJob: Identifiable, Codable, Equatable, Sendable {
     let createdAt: Date
     var completedAt: Date?
     var errorMessage: String?
+    var workflowPreset: ProductionWorkflowPreset?
+    var appTarget: WorkflowAppTarget?
+    var exportTargetName: String?
+    var exportTargetPath: String?
 
     init(
         id: UUID = UUID(),
@@ -26,7 +30,11 @@ struct MediaJob: Identifiable, Codable, Equatable, Sendable {
         progress: Double,
         createdAt: Date,
         completedAt: Date?,
-        errorMessage: String?
+        errorMessage: String?,
+        workflowPreset: ProductionWorkflowPreset? = nil,
+        appTarget: WorkflowAppTarget? = nil,
+        exportTargetName: String? = nil,
+        exportTargetPath: String? = nil
     ) {
         self.id = id
         self.name = name
@@ -36,5 +44,9 @@ struct MediaJob: Identifiable, Codable, Equatable, Sendable {
         self.createdAt = createdAt
         self.completedAt = completedAt
         self.errorMessage = errorMessage
+        self.workflowPreset = workflowPreset
+        self.appTarget = appTarget
+        self.exportTargetName = exportTargetName
+        self.exportTargetPath = exportTargetPath
     }
 }

--- a/shell/Sources/MojoShell/Jobs/MediaJob.swift
+++ b/shell/Sources/MojoShell/Jobs/MediaJob.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum MediaJobStatus: String, Equatable {
+    case queued
+    case running
+    case completed
+    case failed
+}
+
+struct MediaJob: Identifiable, Equatable {
+    let id = UUID()
+    let name: String
+    let client: String
+    var status: MediaJobStatus
+    var progress: Double
+    let createdAt: Date
+    var completedAt: Date?
+    var errorMessage: String?
+}

--- a/shell/Sources/MojoShell/Jobs/MediaJob.swift
+++ b/shell/Sources/MojoShell/Jobs/MediaJob.swift
@@ -5,6 +5,7 @@ enum MediaJobStatus: String, Codable, Equatable, Sendable {
     case running
     case completed
     case failed
+    case canceled
 }
 
 struct MediaJob: Identifiable, Codable, Equatable, Sendable {

--- a/shell/Sources/MojoShell/Jobs/MediaJob.swift
+++ b/shell/Sources/MojoShell/Jobs/MediaJob.swift
@@ -21,6 +21,10 @@ struct MediaJob: Identifiable, Codable, Equatable, Sendable {
     var appTarget: WorkflowAppTarget?
     var exportTargetName: String?
     var exportTargetPath: String?
+    var sourceAssets: [SourceAsset]
+    var notes: String?
+    var workflowVersion: String
+    var approvalMode: WorkflowApprovalMode
 
     init(
         id: UUID = UUID(),
@@ -34,7 +38,11 @@ struct MediaJob: Identifiable, Codable, Equatable, Sendable {
         workflowPreset: ProductionWorkflowPreset? = nil,
         appTarget: WorkflowAppTarget? = nil,
         exportTargetName: String? = nil,
-        exportTargetPath: String? = nil
+        exportTargetPath: String? = nil,
+        sourceAssets: [SourceAsset] = [],
+        notes: String? = nil,
+        workflowVersion: String = "v1",
+        approvalMode: WorkflowApprovalMode = .smart
     ) {
         self.id = id
         self.name = name
@@ -48,5 +56,9 @@ struct MediaJob: Identifiable, Codable, Equatable, Sendable {
         self.appTarget = appTarget
         self.exportTargetName = exportTargetName
         self.exportTargetPath = exportTargetPath
+        self.sourceAssets = sourceAssets
+        self.notes = notes
+        self.workflowVersion = workflowVersion
+        self.approvalMode = approvalMode
     }
 }

--- a/shell/Sources/MojoShell/Jobs/ProductionController.swift
+++ b/shell/Sources/MojoShell/Jobs/ProductionController.swift
@@ -26,6 +26,7 @@ enum ExportTargetError: LocalizedError {
 @MainActor
 final class ProductionController: ObservableObject {
     @Published private(set) var jobs: [MediaJob] = []
+    @Published private(set) var allEvents: [JobEvent] = []
     @Published private(set) var recentEvents: [JobEvent] = []
     @Published private(set) var exportTargets: [ExportTarget] = []
     @Published var workflowLog = "Ready. Queue a workflow, then run the next job."
@@ -74,6 +75,12 @@ final class ProductionController: ObservableObject {
 
     var defaultExportTarget: ExportTarget? {
         exportTargets.first(where: \.isDefault) ?? exportTargets.first
+    }
+
+    func events(for jobID: UUID) -> [JobEvent] {
+        allEvents
+            .filter { $0.jobID == jobID }
+            .sorted { $0.timestamp > $1.timestamp }
     }
 
     func queueAssemblyJob(name: String, client: String) {
@@ -365,8 +372,10 @@ final class ProductionController: ObservableObject {
         }
 
         do {
-            recentEvents = try eventStore.loadRecent(limit: 100)
+            allEvents = try eventStore.load()
+            recentEvents = Array(allEvents.suffix(100))
         } catch {
+            allEvents = []
             recentEvents = []
             workflowLog = "Unable to load event history: \(error.localizedDescription)"
         }
@@ -414,7 +423,11 @@ final class ProductionController: ObservableObject {
 
         do {
             try eventStore.append(event)
+            allEvents.append(event)
             recentEvents.append(event)
+            if allEvents.count > 5_000 {
+                allEvents.removeFirst(allEvents.count - 5_000)
+            }
             if recentEvents.count > 100 {
                 recentEvents.removeFirst(recentEvents.count - 100)
             }
@@ -427,6 +440,9 @@ final class ProductionController: ObservableObject {
                 if let target = job.exportTargetPath {
                     metadata["export_target"] = target
                 }
+            }
+            if let screenshotPath {
+                metadata["screenshot_path"] = screenshotPath
             }
             auditRecorder(.production, "Job event", message, metadata)
         } catch {

--- a/shell/Sources/MojoShell/Jobs/ProductionController.swift
+++ b/shell/Sources/MojoShell/Jobs/ProductionController.swift
@@ -71,6 +71,7 @@ final class ProductionController: ObservableObject {
         self.auditRecorder = auditRecorder ?? { _, _, _, _ in }
         self.now = now
         loadFromDisk()
+        recoverInterruptedJobs()
     }
 
     var defaultExportTarget: ExportTarget? {
@@ -498,6 +499,33 @@ final class ProductionController: ObservableObject {
             exportTargets = []
             workflowLog = "Unable to load export targets: \(error.localizedDescription)"
         }
+    }
+
+    private func recoverInterruptedJobs() {
+        let interruptedIDs = jobs
+            .filter { $0.status == .running }
+            .map(\.id)
+
+        guard !interruptedIDs.isEmpty else {
+            return
+        }
+
+        for id in interruptedIDs {
+            updateJob(
+                id: id,
+                status: .failed,
+                progress: 0.0,
+                completedAt: nil,
+                errorMessage: "Recovered after unexpected app exit."
+            )
+            recordEvent(
+                jobID: id,
+                type: .failed,
+                message: "Recovered interrupted running job after unexpected app exit"
+            )
+        }
+
+        workflowLog = "Recovered \(interruptedIDs.count) interrupted job(s) from the last session."
     }
 
     private func persistJobs() {

--- a/shell/Sources/MojoShell/Jobs/ProductionController.swift
+++ b/shell/Sources/MojoShell/Jobs/ProductionController.swift
@@ -9,11 +9,26 @@ struct WorkflowApprovalRequest: Identifiable, Equatable, Sendable {
     let createdAt: Date
 }
 
+enum ExportTargetError: LocalizedError {
+    case emptyName
+    case emptyPath
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyName:
+            return "Export target name cannot be empty."
+        case .emptyPath:
+            return "Export target path cannot be empty."
+        }
+    }
+}
+
 @MainActor
 final class ProductionController: ObservableObject {
     @Published private(set) var jobs: [MediaJob] = []
     @Published private(set) var recentEvents: [JobEvent] = []
-    @Published var workflowLog = "Ready. Queue a job, then run the assembly workflow."
+    @Published private(set) var exportTargets: [ExportTarget] = []
+    @Published var workflowLog = "Ready. Queue a workflow, then run the next job."
     @Published var isRunningWorkflow = false
     @Published private(set) var pendingApproval: WorkflowApprovalRequest?
 
@@ -22,8 +37,10 @@ final class ProductionController: ObservableObject {
     private let jobStore: JobStore
     private let eventStore: JobEventStore
     private let screenshotStore: ScreenshotStore
+    private let exportTargetStore: ExportTargetStore
     private let preflightCheck: @MainActor () throws -> Void
-    private let stepsProvider: () -> [WorkflowStep]
+    private let workflowPlanProvider: @MainActor (MediaJob) throws -> WorkflowPlan
+    private let auditRecorder: @MainActor (AuditCategory, String, String, [String: String]) -> Void
     private let now: () -> Date
     private var approvalContinuation: CheckedContinuation<Bool, Never>?
 
@@ -33,8 +50,11 @@ final class ProductionController: ObservableObject {
         jobStore: JobStore = JobStore(),
         eventStore: JobEventStore = JobEventStore(),
         screenshotStore: ScreenshotStore = ScreenshotStore(),
+        exportTargetStore: ExportTargetStore = ExportTargetStore(),
         preflightCheck: @escaping @MainActor () throws -> Void = ProductionController.defaultPreflightCheck,
         stepsProvider: @escaping () -> [WorkflowStep] = { FcpWorkflowDefinition.assemblyWorkflow() },
+        workflowPlanProvider: (@MainActor (MediaJob) throws -> WorkflowPlan)? = nil,
+        auditRecorder: (@MainActor (AuditCategory, String, String, [String: String]) -> Void)? = nil,
         now: @escaping () -> Date = Date.init
     ) {
         self.computerUseProvider = computerUseProvider
@@ -42,25 +62,57 @@ final class ProductionController: ObservableObject {
         self.jobStore = jobStore
         self.eventStore = eventStore
         self.screenshotStore = screenshotStore
+        self.exportTargetStore = exportTargetStore
         self.preflightCheck = preflightCheck
-        self.stepsProvider = stepsProvider
+        self.workflowPlanProvider = workflowPlanProvider ?? { job in
+            try ProductionController.defaultWorkflowPlan(for: job, stepsProvider: stepsProvider)
+        }
+        self.auditRecorder = auditRecorder ?? { _, _, _, _ in }
         self.now = now
         loadFromDisk()
     }
 
+    var defaultExportTarget: ExportTarget? {
+        exportTargets.first(where: \.isDefault) ?? exportTargets.first
+    }
+
     func queueAssemblyJob(name: String, client: String) {
-        let job = MediaJob(
+        queueWorkflowJob(
             name: name,
+            client: client,
+            preset: .fcpExportCurrentTimeline,
+            exportTargetID: defaultExportTarget?.id
+        )
+    }
+
+    func queueWorkflowJob(
+        name: String? = nil,
+        client: String,
+        preset: ProductionWorkflowPreset,
+        exportTargetID: UUID? = nil
+    ) {
+        let exportTarget = resolvedExportTarget(for: preset, requestedID: exportTargetID)
+        let jobName = name ?? defaultJobName(for: preset)
+        let job = MediaJob(
+            name: jobName,
             client: client,
             status: .queued,
             progress: 0.0,
             createdAt: now(),
             completedAt: nil,
-            errorMessage: nil
+            errorMessage: nil,
+            workflowPreset: preset,
+            appTarget: preset.appTarget,
+            exportTargetName: exportTarget?.name,
+            exportTargetPath: exportTarget?.path
         )
+
         jobs.append(job)
         persistJobs()
-        recordEvent(jobID: job.id, type: .queued, message: "Job queued: \(name)", progress: 0.0)
+        recordEvent(jobID: job.id, type: .queued, message: "Job queued: \(jobName)", progress: 0.0)
+        if let exportTarget {
+            recordEvent(jobID: job.id, type: .info, message: "Export target: \(exportTarget.name) -> \(exportTarget.path)")
+        }
     }
 
     func retryFailedJob(id: UUID) {
@@ -74,6 +126,46 @@ final class ProductionController: ObservableObject {
         jobs[index].errorMessage = nil
         persistJobs()
         recordEvent(jobID: id, type: .queued, message: "Job requeued for retry", progress: 0.0)
+    }
+
+    func addExportTarget(name: String, path: String) throws {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPath = (path as NSString).expandingTildeInPath.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedName.isEmpty else {
+            throw ExportTargetError.emptyName
+        }
+        guard !trimmedPath.isEmpty else {
+            throw ExportTargetError.emptyPath
+        }
+
+        var isDirectory: ObjCBool = false
+        if !FileManager.default.fileExists(atPath: trimmedPath, isDirectory: &isDirectory) {
+            try FileManager.default.createDirectory(atPath: trimmedPath, withIntermediateDirectories: true, attributes: nil)
+            isDirectory = true
+        }
+
+        let target = ExportTarget(
+            name: trimmedName,
+            path: trimmedPath,
+            isDefault: exportTargets.isEmpty
+        )
+        exportTargets.append(target)
+        persistExportTargets()
+        auditRecorder(.production, "Export target added", trimmedName, ["path": trimmedPath])
+    }
+
+    func setDefaultExportTarget(id: UUID) {
+        guard exportTargets.contains(where: { $0.id == id }) else {
+            return
+        }
+        for index in exportTargets.indices {
+            exportTargets[index].isDefault = exportTargets[index].id == id
+        }
+        persistExportTargets()
+        if let target = exportTargets.first(where: { $0.id == id }) {
+            auditRecorder(.production, "Default export target set", target.name, ["path": target.path])
+        }
     }
 
     func approvePendingStep() {
@@ -97,6 +189,10 @@ final class ProductionController: ObservableObject {
     }
 
     func runNextAssemblyWorkflow() async {
+        await runNextWorkflow()
+    }
+
+    func runNextWorkflow() async {
         guard !isRunningWorkflow else {
             return
         }
@@ -109,32 +205,64 @@ final class ProductionController: ObservableObject {
         isRunningWorkflow = true
         defer { isRunningWorkflow = false }
 
-        let jobID = jobs[queuedIndex].id
-        workflowLog = "Checking Final Cut Pro export state..."
+        let job = jobs[queuedIndex]
+        let jobID = job.id
+        let preset = job.workflowPreset ?? .fcpExportCurrentTimeline
+        let plan: WorkflowPlan
 
         do {
-            try preflightCheck()
+            plan = try workflowPlanProvider(job)
         } catch {
-            let message = humanReadablePreflightError(error)
+            let message = "Workflow plan error: \(error.localizedDescription)"
             failJob(id: jobID, message: message)
             workflowLog = message
             await notifications.deliver(title: "MojoShell Job Failed", body: jobTitle(for: jobID))
             return
         }
 
-        updateJob(id: jobID, status: .running, progress: 0.1, completedAt: nil, errorMessage: nil)
-        workflowLog = "Starting assembly workflow..."
-        recordEvent(jobID: jobID, type: .started, message: "Assembly workflow started", progress: 0.1)
+        workflowLog = "Preparing \(preset.title)..."
+        if let exportTargetPath = job.exportTargetPath {
+            recordEvent(jobID: jobID, type: .info, message: "Using export target path: \(exportTargetPath)")
+        }
+
+        if plan.requiresExportPreflight {
+            do {
+                try preflightCheck()
+            } catch {
+                let message = humanReadablePreflightError(error)
+                failJob(id: jobID, message: message)
+                workflowLog = message
+                await notifications.deliver(title: "MojoShell Job Failed", body: jobTitle(for: jobID))
+                return
+            }
+        }
+
+        updateJob(id: jobID, status: .running, progress: plan.steps.isEmpty ? 0.9 : 0.1, completedAt: nil, errorMessage: nil)
+        workflowLog = "Starting \(preset.title)..."
+        recordEvent(jobID: jobID, type: .started, message: "\(preset.title) started", progress: plan.steps.isEmpty ? 0.9 : 0.1)
+
+        if let placeholderMessage = plan.placeholderMessage {
+            workflowLog = placeholderMessage
+            recordEvent(jobID: jobID, type: .info, message: placeholderMessage)
+            completeJob(id: jobID, message: plan.completionMessage)
+            await notifications.deliver(title: "MojoShell Job Complete", body: jobTitle(for: jobID))
+            return
+        }
+
+        if plan.steps.isEmpty {
+            completeJob(id: jobID, message: plan.completionMessage)
+            await notifications.deliver(title: "MojoShell Job Complete", body: jobTitle(for: jobID))
+            return
+        }
 
         var sessionId: String?
         do {
             sessionId = try await computerUseProvider.startSession()
-            let steps = stepsProvider()
-            let stepCount = max(steps.count, 1)
+            let stepCount = max(plan.steps.count, 1)
             let executor = WorkflowExecutor(provider: computerUseProvider)
 
             try await executor.run(
-                steps: steps,
+                steps: plan.steps,
                 sessionId: sessionId!,
                 onProgress: { [weak self] message in
                     Task { @MainActor [weak self] in
@@ -155,7 +283,6 @@ final class ProductionController: ObservableObject {
                                 jobID: jobID,
                                 type: .info,
                                 message: "Step \(stepIndex + 1): \(result.message)",
-                                progress: nil,
                                 screenshotPath: url.path
                             )
                         } catch {
@@ -173,9 +300,7 @@ final class ProductionController: ObservableObject {
                 try await computerUseProvider.stopSession(sessionId: sessionId)
             }
 
-            updateJob(id: jobID, status: .completed, progress: 1.0, completedAt: now(), errorMessage: nil)
-            workflowLog = "Assembly workflow complete."
-            recordEvent(jobID: jobID, type: .completed, message: "Assembly workflow complete", progress: 1.0)
+            completeJob(id: jobID, message: plan.completionMessage)
             await notifications.deliver(title: "MojoShell Job Complete", body: jobTitle(for: jobID))
         } catch {
             if let sessionId {
@@ -196,6 +321,12 @@ final class ProductionController: ObservableObject {
                 await notifications.deliver(title: "MojoShell Job Failed", body: jobTitle(for: jobID))
             }
         }
+    }
+
+    private func completeJob(id: UUID, message: String) {
+        updateJob(id: id, status: .completed, progress: 1.0, completedAt: now(), errorMessage: nil)
+        workflowLog = message
+        recordEvent(jobID: id, type: .completed, message: message, progress: 1.0)
     }
 
     private func failJob(id: UUID, message: String) {
@@ -239,6 +370,14 @@ final class ProductionController: ObservableObject {
             recentEvents = []
             workflowLog = "Unable to load event history: \(error.localizedDescription)"
         }
+
+        do {
+            exportTargets = try exportTargetStore.load()
+            persistExportTargets()
+        } catch {
+            exportTargets = []
+            workflowLog = "Unable to load export targets: \(error.localizedDescription)"
+        }
     }
 
     private func persistJobs() {
@@ -246,6 +385,14 @@ final class ProductionController: ObservableObject {
             try jobStore.save(jobs)
         } catch {
             workflowLog = "Job persistence failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func persistExportTargets() {
+        do {
+            try exportTargetStore.save(exportTargets)
+        } catch {
+            workflowLog = "Export target persistence failed: \(error.localizedDescription)"
         }
     }
 
@@ -271,8 +418,82 @@ final class ProductionController: ObservableObject {
             if recentEvents.count > 100 {
                 recentEvents.removeFirst(recentEvents.count - 100)
             }
+
+            var metadata = ["job_id": jobID.uuidString, "event_type": type.rawValue]
+            if let job = jobs.first(where: { $0.id == jobID }) {
+                if let preset = job.workflowPreset?.title {
+                    metadata["preset"] = preset
+                }
+                if let target = job.exportTargetPath {
+                    metadata["export_target"] = target
+                }
+            }
+            auditRecorder(.production, "Job event", message, metadata)
         } catch {
             workflowLog = "Event persistence failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func resolvedExportTarget(for preset: ProductionWorkflowPreset, requestedID: UUID?) -> ExportTarget? {
+        if let requestedID, let target = exportTargets.first(where: { $0.id == requestedID }) {
+            return target
+        }
+        if preset.requiresExportTarget {
+            return defaultExportTarget
+        }
+        return nil
+    }
+
+    private func defaultJobName(for preset: ProductionWorkflowPreset) -> String {
+        let stamp = now().formatted(date: .abbreviated, time: .shortened)
+        return "\(preset.title) - \(stamp)"
+    }
+
+    private static func defaultWorkflowPlan(
+        for job: MediaJob,
+        stepsProvider: @escaping () -> [WorkflowStep]
+    ) throws -> WorkflowPlan {
+        let preset = job.workflowPreset ?? .fcpExportCurrentTimeline
+
+        switch preset {
+        case .fcpExportCurrentTimeline:
+            return WorkflowPlan(
+                preset: preset,
+                steps: job.exportTargetPath == nil
+                    ? stepsProvider()
+                    : FcpWorkflowDefinition.assemblyWorkflow(exportTargetPath: job.exportTargetPath),
+                requiresExportPreflight: true,
+                completionMessage: "FCP export workflow complete.",
+                placeholderMessage: nil
+            )
+
+        case .fcpMonitorBackgroundTasks:
+            return WorkflowPlan(
+                preset: preset,
+                steps: FcpWorkflowDefinition.monitoringCheck(),
+                requiresExportPreflight: false,
+                completionMessage: "FCP background task monitor opened.",
+                placeholderMessage: nil
+            )
+
+        case .motionPlaceholderReview:
+            return WorkflowPlan(
+                preset: preset,
+                steps: [],
+                requiresExportPreflight: false,
+                completionMessage: "Motion placeholder review logged.",
+                placeholderMessage: "Motion review workflow placeholder recorded. Real Motion automation is not implemented yet."
+            )
+
+        case .motionPlaceholderExport:
+            let target = job.exportTargetPath.map { " Planned target: \($0)" } ?? ""
+            return WorkflowPlan(
+                preset: preset,
+                steps: [],
+                requiresExportPreflight: false,
+                completionMessage: "Motion placeholder export logged.",
+                placeholderMessage: "Motion export workflow placeholder recorded.\(target)"
+            )
         }
     }
 
@@ -325,7 +546,7 @@ final class ProductionController: ObservableObject {
     private func humanReadablePreflightError(_ error: Error) -> String {
         if let finderError = error as? AccessibilityElementFinder.FinderError {
             switch finderError {
-            case .appNotRunning(_):
+            case .appNotRunning:
                 return "Final Cut Pro is not running. Open it and load a project first."
             case .accessibilityPermissionDenied:
                 return "Accessibility permission denied. Grant access in System Settings -> Privacy & Security -> Accessibility."

--- a/shell/Sources/MojoShell/Jobs/ProductionController.swift
+++ b/shell/Sources/MojoShell/Jobs/ProductionController.swift
@@ -49,6 +49,19 @@ final class ProductionController: ObservableObject {
         recordEvent(jobID: job.id, type: .queued, message: "Job queued: \(name)", progress: 0.0)
     }
 
+    func retryFailedJob(id: UUID) {
+        guard let index = jobs.firstIndex(where: { $0.id == id && $0.status == .failed }) else {
+            return
+        }
+
+        jobs[index].status = .queued
+        jobs[index].progress = 0.0
+        jobs[index].completedAt = nil
+        jobs[index].errorMessage = nil
+        persistJobs()
+        recordEvent(jobID: id, type: .queued, message: "Job requeued for retry", progress: 0.0)
+    }
+
     func runNextAssemblyWorkflow() async {
         guard !isRunningWorkflow else {
             return

--- a/shell/Sources/MojoShell/Jobs/ProductionController.swift
+++ b/shell/Sources/MojoShell/Jobs/ProductionController.swift
@@ -83,12 +83,21 @@ final class ProductionController: ObservableObject {
             .sorted { $0.timestamp > $1.timestamp }
     }
 
-    func queueAssemblyJob(name: String, client: String) {
+    func queueAssemblyJob(
+        name: String,
+        client: String,
+        sourceAssets: [SourceAsset] = [],
+        notes: String? = nil,
+        approvalMode: WorkflowApprovalMode = .smart
+    ) {
         queueWorkflowJob(
             name: name,
             client: client,
             preset: .fcpExportCurrentTimeline,
-            exportTargetID: defaultExportTarget?.id
+            exportTargetID: defaultExportTarget?.id,
+            sourceAssets: sourceAssets,
+            notes: notes,
+            approvalMode: approvalMode
         )
     }
 
@@ -96,7 +105,10 @@ final class ProductionController: ObservableObject {
         name: String? = nil,
         client: String,
         preset: ProductionWorkflowPreset,
-        exportTargetID: UUID? = nil
+        exportTargetID: UUID? = nil,
+        sourceAssets: [SourceAsset] = [],
+        notes: String? = nil,
+        approvalMode: WorkflowApprovalMode = .smart
     ) {
         let exportTarget = resolvedExportTarget(for: preset, requestedID: exportTargetID)
         let jobName = name ?? defaultJobName(for: preset)
@@ -111,7 +123,11 @@ final class ProductionController: ObservableObject {
             workflowPreset: preset,
             appTarget: preset.appTarget,
             exportTargetName: exportTarget?.name,
-            exportTargetPath: exportTarget?.path
+            exportTargetPath: exportTarget?.path,
+            sourceAssets: sourceAssets,
+            notes: notes?.trimmedNilIfEmpty,
+            workflowVersion: preset.workflowVersion,
+            approvalMode: approvalMode
         )
 
         jobs.append(job)
@@ -119,6 +135,12 @@ final class ProductionController: ObservableObject {
         recordEvent(jobID: job.id, type: .queued, message: "Job queued: \(jobName)", progress: 0.0)
         if let exportTarget {
             recordEvent(jobID: job.id, type: .info, message: "Export target: \(exportTarget.name) -> \(exportTarget.path)")
+        }
+        if !sourceAssets.isEmpty {
+            recordEvent(jobID: job.id, type: .info, message: "Source assets attached: \(sourceAssets.count)")
+        }
+        if let notes = notes?.trimmedNilIfEmpty {
+            recordEvent(jobID: job.id, type: .info, message: "Operator notes: \(notes)")
         }
     }
 
@@ -280,6 +302,12 @@ final class ProductionController: ObservableObject {
                         }
                     }
                 },
+                shouldRequestApproval: { [weak self] _, step in
+                    guard let self else {
+                        return step.approvalPrompt != nil
+                    }
+                    return self.shouldRequestApproval(for: step, mode: job.approvalMode)
+                },
                 onStepResult: { [weak self] stepIndex, _, result in
                     Task { @MainActor [weak self] in
                         guard let self else { return }
@@ -437,6 +465,9 @@ final class ProductionController: ObservableObject {
                 if let preset = job.workflowPreset?.title {
                     metadata["preset"] = preset
                 }
+                metadata["workflow_version"] = job.workflowVersion
+                metadata["approval_mode"] = job.approvalMode.rawValue
+                metadata["source_asset_count"] = "\(job.sourceAssets.count)"
                 if let target = job.exportTargetPath {
                     metadata["export_target"] = target
                 }
@@ -447,6 +478,17 @@ final class ProductionController: ObservableObject {
             auditRecorder(.production, "Job event", message, metadata)
         } catch {
             workflowLog = "Event persistence failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func shouldRequestApproval(for step: WorkflowStep, mode: WorkflowApprovalMode) -> Bool {
+        switch mode {
+        case .smart:
+            return step.approvalPrompt != nil
+        case .alwaysAsk:
+            return true
+        case .neverAsk:
+            return false
         }
     }
 
@@ -576,6 +618,13 @@ final class ProductionController: ObservableObject {
         }
 
         return "Preflight error: \(error.localizedDescription)"
+    }
+}
+
+private extension String {
+    var trimmedNilIfEmpty: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }
 

--- a/shell/Sources/MojoShell/Jobs/ProductionController.swift
+++ b/shell/Sources/MojoShell/Jobs/ProductionController.swift
@@ -1,0 +1,263 @@
+import Foundation
+
+@MainActor
+final class ProductionController: ObservableObject {
+    @Published private(set) var jobs: [MediaJob] = []
+    @Published private(set) var recentEvents: [JobEvent] = []
+    @Published var workflowLog = "Ready. Queue a job, then run the assembly workflow."
+    @Published var isRunningWorkflow = false
+
+    private let computerUseProvider: any ComputerUseProvider
+    private let jobStore: JobStore
+    private let eventStore: JobEventStore
+    private let screenshotStore: ScreenshotStore
+    private let preflightCheck: @MainActor () throws -> Void
+    private let stepsProvider: () -> [WorkflowStep]
+    private let now: () -> Date
+
+    init(
+        computerUseProvider: any ComputerUseProvider,
+        jobStore: JobStore = JobStore(),
+        eventStore: JobEventStore = JobEventStore(),
+        screenshotStore: ScreenshotStore = ScreenshotStore(),
+        preflightCheck: @escaping @MainActor () throws -> Void = ProductionController.defaultPreflightCheck,
+        stepsProvider: @escaping () -> [WorkflowStep] = { FcpWorkflowDefinition.assemblyWorkflow() },
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.computerUseProvider = computerUseProvider
+        self.jobStore = jobStore
+        self.eventStore = eventStore
+        self.screenshotStore = screenshotStore
+        self.preflightCheck = preflightCheck
+        self.stepsProvider = stepsProvider
+        self.now = now
+        loadFromDisk()
+    }
+
+    func queueAssemblyJob(name: String, client: String) {
+        let job = MediaJob(
+            name: name,
+            client: client,
+            status: .queued,
+            progress: 0.0,
+            createdAt: now(),
+            completedAt: nil,
+            errorMessage: nil
+        )
+        jobs.append(job)
+        persistJobs()
+        recordEvent(jobID: job.id, type: .queued, message: "Job queued: \(name)", progress: 0.0)
+    }
+
+    func runNextAssemblyWorkflow() async {
+        guard !isRunningWorkflow else {
+            return
+        }
+
+        guard let queuedIndex = jobs.firstIndex(where: { $0.status == .queued }) else {
+            workflowLog = "No queued media job available."
+            return
+        }
+
+        isRunningWorkflow = true
+        defer { isRunningWorkflow = false }
+
+        let jobID = jobs[queuedIndex].id
+        workflowLog = "Checking Final Cut Pro export state..."
+
+        do {
+            try preflightCheck()
+        } catch {
+            let message = humanReadablePreflightError(error)
+            failJob(id: jobID, message: message)
+            workflowLog = message
+            return
+        }
+
+        updateJob(id: jobID, status: .running, progress: 0.1, completedAt: nil, errorMessage: nil)
+        workflowLog = "Starting assembly workflow..."
+        recordEvent(jobID: jobID, type: .started, message: "Assembly workflow started", progress: 0.1)
+
+        var sessionId: String?
+        do {
+            sessionId = try await computerUseProvider.startSession()
+            let steps = stepsProvider()
+            let stepCount = max(steps.count, 1)
+            let executor = WorkflowExecutor(provider: computerUseProvider)
+
+            try await executor.run(
+                steps: steps,
+                sessionId: sessionId!,
+                onProgress: { [weak self] message in
+                    Task { @MainActor [weak self] in
+                        self?.workflowLog = message
+                        if let progress = Self.progressValue(from: message, totalSteps: stepCount) {
+                            self?.updateJob(id: jobID, status: .running, progress: progress, completedAt: nil, errorMessage: nil)
+                            self?.recordEvent(jobID: jobID, type: .stepProgress, message: message, progress: progress)
+                        }
+                    }
+                },
+                onStepResult: { [weak self] stepIndex, _, result in
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        guard let screenshot = result.screenshotAfter else { return }
+                        do {
+                            let url = try self.screenshotStore.save(screenshot, jobID: jobID, stepIndex: stepIndex)
+                            self.recordEvent(
+                                jobID: jobID,
+                                type: .info,
+                                message: "Step \(stepIndex + 1): \(result.message)",
+                                progress: nil,
+                                screenshotPath: url.path
+                            )
+                        } catch {
+                            self.workflowLog = "Screenshot persistence failed: \(error.localizedDescription)"
+                        }
+                    }
+                }
+            )
+
+            if let sessionId {
+                try await computerUseProvider.stopSession(sessionId: sessionId)
+            }
+
+            updateJob(id: jobID, status: .completed, progress: 1.0, completedAt: now(), errorMessage: nil)
+            workflowLog = "Assembly workflow complete."
+            recordEvent(jobID: jobID, type: .completed, message: "Assembly workflow complete", progress: 1.0)
+        } catch {
+            if let sessionId {
+                try? await computerUseProvider.stopSession(sessionId: sessionId)
+            }
+            let message = error.localizedDescription
+            failJob(id: jobID, message: message)
+            workflowLog = "Error: \(message)"
+        }
+    }
+
+    private func failJob(id: UUID, message: String) {
+        updateJob(id: id, status: .failed, progress: 0.0, completedAt: nil, errorMessage: message)
+        recordEvent(jobID: id, type: .failed, message: message)
+    }
+
+    private func updateJob(
+        id: UUID,
+        status: MediaJobStatus,
+        progress: Double,
+        completedAt: Date?,
+        errorMessage: String?
+    ) {
+        guard let index = jobs.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        jobs[index].status = status
+        jobs[index].progress = progress
+        jobs[index].completedAt = completedAt
+        jobs[index].errorMessage = errorMessage
+        persistJobs()
+    }
+
+    private func loadFromDisk() {
+        do {
+            jobs = try jobStore.load().sorted { $0.createdAt > $1.createdAt }
+        } catch {
+            jobs = []
+            workflowLog = "Unable to load jobs: \(error.localizedDescription)"
+        }
+
+        do {
+            recentEvents = try eventStore.loadRecent(limit: 100)
+        } catch {
+            recentEvents = []
+            workflowLog = "Unable to load event history: \(error.localizedDescription)"
+        }
+    }
+
+    private func persistJobs() {
+        do {
+            try jobStore.save(jobs)
+        } catch {
+            workflowLog = "Job persistence failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func recordEvent(
+        jobID: UUID,
+        type: JobEventType,
+        message: String,
+        progress: Double? = nil,
+        screenshotPath: String? = nil
+    ) {
+        let event = JobEvent(
+            jobID: jobID,
+            timestamp: now(),
+            type: type,
+            message: message,
+            progress: progress,
+            screenshotPath: screenshotPath
+        )
+
+        do {
+            try eventStore.append(event)
+            recentEvents.append(event)
+            if recentEvents.count > 100 {
+                recentEvents.removeFirst(recentEvents.count - 100)
+            }
+        } catch {
+            workflowLog = "Event persistence failed: \(error.localizedDescription)"
+        }
+    }
+
+    private static func progressValue(from message: String, totalSteps: Int) -> Double? {
+        guard message.hasPrefix("[") else { return nil }
+        guard let close = message.firstIndex(of: "]") else { return nil }
+
+        let bracket = message[message.index(after: message.startIndex)..<close]
+        let components = bracket.split(separator: "/")
+        guard components.count == 2 else { return nil }
+        guard let step = Int(components[0]) else { return nil }
+        guard totalSteps > 0 else { return nil }
+
+        return min(max(Double(step) / Double(totalSteps), 0.0), 1.0)
+    }
+
+    private static func defaultPreflightCheck() throws {
+        let exportItems = try AccessibilityElementFinder.findElements(
+            inApp: "Final Cut Pro",
+            roles: ["AXMenuItem"],
+            titleContaining: "Export File"
+        )
+        guard !exportItems.isEmpty else {
+            throw ProductionControllerError.noExportSelection
+        }
+    }
+
+    private func humanReadablePreflightError(_ error: Error) -> String {
+        if let finderError = error as? AccessibilityElementFinder.FinderError {
+            switch finderError {
+            case .appNotRunning(_):
+                return "Final Cut Pro is not running. Open it and load a project first."
+            case .accessibilityPermissionDenied:
+                return "Accessibility permission denied. Grant access in System Settings -> Privacy & Security -> Accessibility."
+            case .noElementsFound(let context):
+                return "No exportable clip selected in Final Cut Pro. \(context)"
+            }
+        }
+
+        if error is ProductionControllerError {
+            return "No exportable clip selected in Final Cut Pro. Select a timeline item and try again."
+        }
+
+        return "Preflight error: \(error.localizedDescription)"
+    }
+}
+
+enum ProductionControllerError: LocalizedError {
+    case noExportSelection
+
+    var errorDescription: String? {
+        switch self {
+        case .noExportSelection:
+            return "No exportable clip selected in Final Cut Pro."
+        }
+    }
+}

--- a/shell/Sources/MojoShell/Jobs/ProductionController.swift
+++ b/shell/Sources/MojoShell/Jobs/ProductionController.swift
@@ -157,6 +157,89 @@ final class ProductionController: ObservableObject {
         recordEvent(jobID: id, type: .queued, message: "Job requeued for retry", progress: 0.0)
     }
 
+    func cancelQueuedJob(id: UUID) {
+        guard let index = jobs.firstIndex(where: { $0.id == id && $0.status == .queued }) else {
+            return
+        }
+
+        jobs[index].status = .canceled
+        jobs[index].completedAt = now()
+        jobs[index].errorMessage = "Canceled before run."
+        persistJobs()
+        recordEvent(jobID: id, type: .canceled, message: "Queued job canceled before run")
+    }
+
+    func duplicateJob(id: UUID) {
+        guard let original = jobs.first(where: { $0.id == id }) else {
+            return
+        }
+
+        let copy = MediaJob(
+            name: "\(original.name) Copy",
+            client: original.client,
+            status: .queued,
+            progress: 0.0,
+            createdAt: now(),
+            completedAt: nil,
+            errorMessage: nil,
+            workflowPreset: original.workflowPreset,
+            appTarget: original.appTarget,
+            exportTargetName: original.exportTargetName,
+            exportTargetPath: original.exportTargetPath,
+            sourceAssets: original.sourceAssets,
+            notes: original.notes,
+            workflowVersion: original.workflowVersion,
+            approvalMode: original.approvalMode
+        )
+
+        jobs.insert(copy, at: 0)
+        persistJobs()
+        recordEvent(jobID: copy.id, type: .queued, message: "Job duplicated from \(original.name)", progress: 0.0)
+    }
+
+    func prioritizeQueuedJob(id: UUID) {
+        guard let index = jobs.firstIndex(where: { $0.id == id && $0.status == .queued }) else {
+            return
+        }
+
+        let job = jobs.remove(at: index)
+        jobs.insert(job, at: 0)
+        persistJobs()
+        recordEvent(jobID: id, type: .info, message: "Queued job moved to front")
+    }
+
+    func removeJob(id: UUID) {
+        guard let index = jobs.firstIndex(where: { $0.id == id && $0.status != .running }) else {
+            return
+        }
+
+        let removed = jobs.remove(at: index)
+        persistJobs()
+        auditRecorder(
+            .production,
+            "Job removed",
+            removed.name,
+            ["job_id": removed.id.uuidString, "status": removed.status.rawValue]
+        )
+    }
+
+    func clearFinishedJobs() {
+        let retained = jobs.filter { $0.status == .queued || $0.status == .running }
+        guard retained.count != jobs.count else {
+            return
+        }
+
+        let removedCount = jobs.count - retained.count
+        jobs = retained
+        persistJobs()
+        auditRecorder(
+            .production,
+            "Finished jobs cleared",
+            "Removed \(removedCount) completed, failed, or canceled jobs.",
+            ["removed_count": "\(removedCount)"]
+        )
+    }
+
     func addExportTarget(name: String, path: String) throws {
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedPath = (path as NSString).expandingTildeInPath.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/shell/Sources/MojoShell/Jobs/ProductionController.swift
+++ b/shell/Sources/MojoShell/Jobs/ProductionController.swift
@@ -1,22 +1,35 @@
 import Foundation
 
+struct WorkflowApprovalRequest: Identifiable, Equatable, Sendable {
+    let id = UUID()
+    let jobID: UUID
+    let stepIndex: Int
+    let stepDescription: String
+    let prompt: String
+    let createdAt: Date
+}
+
 @MainActor
 final class ProductionController: ObservableObject {
     @Published private(set) var jobs: [MediaJob] = []
     @Published private(set) var recentEvents: [JobEvent] = []
     @Published var workflowLog = "Ready. Queue a job, then run the assembly workflow."
     @Published var isRunningWorkflow = false
+    @Published private(set) var pendingApproval: WorkflowApprovalRequest?
 
     private let computerUseProvider: any ComputerUseProvider
+    private let notifications: any AppNotifying
     private let jobStore: JobStore
     private let eventStore: JobEventStore
     private let screenshotStore: ScreenshotStore
     private let preflightCheck: @MainActor () throws -> Void
     private let stepsProvider: () -> [WorkflowStep]
     private let now: () -> Date
+    private var approvalContinuation: CheckedContinuation<Bool, Never>?
 
     init(
         computerUseProvider: any ComputerUseProvider,
+        notifications: (any AppNotifying)? = nil,
         jobStore: JobStore = JobStore(),
         eventStore: JobEventStore = JobEventStore(),
         screenshotStore: ScreenshotStore = ScreenshotStore(),
@@ -25,6 +38,7 @@ final class ProductionController: ObservableObject {
         now: @escaping () -> Date = Date.init
     ) {
         self.computerUseProvider = computerUseProvider
+        self.notifications = notifications ?? NullNotificationManager()
         self.jobStore = jobStore
         self.eventStore = eventStore
         self.screenshotStore = screenshotStore
@@ -50,7 +64,7 @@ final class ProductionController: ObservableObject {
     }
 
     func retryFailedJob(id: UUID) {
-        guard let index = jobs.firstIndex(where: { $0.id == id && $0.status == .failed }) else {
+        guard let index = jobs.firstIndex(where: { $0.id == id && ($0.status == .failed || $0.status == .canceled) }) else {
             return
         }
 
@@ -60,6 +74,26 @@ final class ProductionController: ObservableObject {
         jobs[index].errorMessage = nil
         persistJobs()
         recordEvent(jobID: id, type: .queued, message: "Job requeued for retry", progress: 0.0)
+    }
+
+    func approvePendingStep() {
+        guard let request = pendingApproval else {
+            return
+        }
+        pendingApproval = nil
+        recordEvent(jobID: request.jobID, type: .info, message: "Approval granted for step \(request.stepIndex + 1)")
+        approvalContinuation?.resume(returning: true)
+        approvalContinuation = nil
+    }
+
+    func rejectPendingStep() {
+        guard let request = pendingApproval else {
+            return
+        }
+        pendingApproval = nil
+        recordEvent(jobID: request.jobID, type: .canceled, message: "Approval rejected for step \(request.stepIndex + 1)")
+        approvalContinuation?.resume(returning: false)
+        approvalContinuation = nil
     }
 
     func runNextAssemblyWorkflow() async {
@@ -84,6 +118,7 @@ final class ProductionController: ObservableObject {
             let message = humanReadablePreflightError(error)
             failJob(id: jobID, message: message)
             workflowLog = message
+            await notifications.deliver(title: "MojoShell Job Failed", body: jobTitle(for: jobID))
             return
         }
 
@@ -127,6 +162,10 @@ final class ProductionController: ObservableObject {
                             self.workflowLog = "Screenshot persistence failed: \(error.localizedDescription)"
                         }
                     }
+                },
+                onApprovalRequested: { [weak self] stepIndex, step in
+                    guard let self else { return false }
+                    return await self.requestApproval(jobID: jobID, stepIndex: stepIndex, step: step)
                 }
             )
 
@@ -137,19 +176,36 @@ final class ProductionController: ObservableObject {
             updateJob(id: jobID, status: .completed, progress: 1.0, completedAt: now(), errorMessage: nil)
             workflowLog = "Assembly workflow complete."
             recordEvent(jobID: jobID, type: .completed, message: "Assembly workflow complete", progress: 1.0)
+            await notifications.deliver(title: "MojoShell Job Complete", body: jobTitle(for: jobID))
         } catch {
             if let sessionId {
                 try? await computerUseProvider.stopSession(sessionId: sessionId)
             }
-            let message = error.localizedDescription
-            failJob(id: jobID, message: message)
-            workflowLog = "Error: \(message)"
+            pendingApproval = nil
+
+            if let workflowError = error as? WorkflowError,
+               case .approvalRejected = workflowError {
+                let message = workflowError.localizedDescription
+                cancelJob(id: jobID, message: message)
+                workflowLog = message
+                await notifications.deliver(title: "MojoShell Job Canceled", body: jobTitle(for: jobID))
+            } else {
+                let message = error.localizedDescription
+                failJob(id: jobID, message: message)
+                workflowLog = "Error: \(message)"
+                await notifications.deliver(title: "MojoShell Job Failed", body: jobTitle(for: jobID))
+            }
         }
     }
 
     private func failJob(id: UUID, message: String) {
         updateJob(id: id, status: .failed, progress: 0.0, completedAt: nil, errorMessage: message)
         recordEvent(jobID: id, type: .failed, message: message)
+    }
+
+    private func cancelJob(id: UUID, message: String) {
+        updateJob(id: id, status: .canceled, progress: 0.0, completedAt: nil, errorMessage: message)
+        recordEvent(jobID: id, type: .canceled, message: message)
     }
 
     private func updateJob(
@@ -231,6 +287,28 @@ final class ProductionController: ObservableObject {
         guard totalSteps > 0 else { return nil }
 
         return min(max(Double(step) / Double(totalSteps), 0.0), 1.0)
+    }
+
+    private func requestApproval(jobID: UUID, stepIndex: Int, step: WorkflowStep) async -> Bool {
+        let prompt = step.approvalPrompt ?? "Approve this computer-use action."
+        let request = WorkflowApprovalRequest(
+            jobID: jobID,
+            stepIndex: stepIndex,
+            stepDescription: step.description,
+            prompt: prompt,
+            createdAt: now()
+        )
+        pendingApproval = request
+        workflowLog = "Awaiting approval for step \(stepIndex + 1): \(step.description)"
+        recordEvent(jobID: jobID, type: .info, message: "Approval required for step \(stepIndex + 1): \(step.description)")
+
+        return await withCheckedContinuation { continuation in
+            approvalContinuation = continuation
+        }
+    }
+
+    private func jobTitle(for id: UUID) -> String {
+        jobs.first(where: { $0.id == id })?.name ?? "Unknown Job"
     }
 
     private static func defaultPreflightCheck() throws {

--- a/shell/Sources/MojoShell/Jobs/SourceAsset.swift
+++ b/shell/Sources/MojoShell/Jobs/SourceAsset.swift
@@ -1,0 +1,81 @@
+import Foundation
+import UniformTypeIdentifiers
+
+enum SourceAssetKind: String, Codable, CaseIterable, Equatable, Sendable {
+    case image
+    case video
+    case audio
+    case folder
+    case document
+    case other
+}
+
+struct SourceAsset: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
+    let path: String
+    let name: String
+    let kind: SourceAssetKind
+    let byteSize: Int64?
+
+    init(
+        id: UUID = UUID(),
+        path: String,
+        name: String,
+        kind: SourceAssetKind,
+        byteSize: Int64?
+    ) {
+        self.id = id
+        self.path = path
+        self.name = name
+        self.kind = kind
+        self.byteSize = byteSize
+    }
+
+    static func from(path: String) -> SourceAsset? {
+        let expanded = (path as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: expanded)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return nil
+        }
+
+        let values = try? url.resourceValues(forKeys: [
+            .nameKey,
+            .contentTypeKey,
+            .isDirectoryKey,
+            .fileSizeKey,
+        ])
+
+        let kind = classify(values: values)
+        let byteSize = values?.fileSize.map(Int64.init)
+        return SourceAsset(
+            path: url.path,
+            name: values?.name ?? url.lastPathComponent,
+            kind: kind,
+            byteSize: byteSize
+        )
+    }
+
+    private static func classify(values: URLResourceValues?) -> SourceAssetKind {
+        if values?.isDirectory == true {
+            return .folder
+        }
+
+        guard let type = values?.contentType else {
+            return .other
+        }
+
+        if type.conforms(to: .image) {
+            return .image
+        }
+        if type.conforms(to: .movie) || type.conforms(to: .video) {
+            return .video
+        }
+        if type.conforms(to: .audio) {
+            return .audio
+        }
+        if type.conforms(to: .data) || type.conforms(to: .content) || type.conforms(to: .text) {
+            return .document
+        }
+        return .other
+    }
+}

--- a/shell/Sources/MojoShell/Jobs/WorkflowApprovalMode.swift
+++ b/shell/Sources/MojoShell/Jobs/WorkflowApprovalMode.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum WorkflowApprovalMode: String, Codable, CaseIterable, Identifiable, Sendable {
+    case smart
+    case alwaysAsk
+    case neverAsk
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .smart:
+            return "Smart"
+        case .alwaysAsk:
+            return "Always Ask"
+        case .neverAsk:
+            return "Never Ask"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .smart:
+            return "Only steps that explicitly request approval will pause."
+        case .alwaysAsk:
+            return "Every workflow step pauses for operator approval."
+        case .neverAsk:
+            return "All workflow steps auto-run without pausing."
+        }
+    }
+}

--- a/shell/Sources/MojoShell/Jobs/WorkflowPreset.swift
+++ b/shell/Sources/MojoShell/Jobs/WorkflowPreset.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+enum WorkflowAppTarget: String, Codable, CaseIterable, Equatable, Sendable {
+    case finalCutPro = "Final Cut Pro"
+    case motion = "Motion"
+}
+
+enum ProductionWorkflowPreset: String, Codable, CaseIterable, Identifiable, Sendable {
+    case fcpExportCurrentTimeline
+    case fcpMonitorBackgroundTasks
+    case motionPlaceholderReview
+    case motionPlaceholderExport
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .fcpExportCurrentTimeline:
+            return "FCP Export Current Timeline"
+        case .fcpMonitorBackgroundTasks:
+            return "FCP Monitor Background Tasks"
+        case .motionPlaceholderReview:
+            return "Motion Placeholder Review"
+        case .motionPlaceholderExport:
+            return "Motion Placeholder Export"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .fcpExportCurrentTimeline:
+            return "Open Final Cut Pro, prepare the share sheet, and guide export approval."
+        case .fcpMonitorBackgroundTasks:
+            return "Open Final Cut Pro background tasks for render/export monitoring."
+        case .motionPlaceholderReview:
+            return "Reserve a Motion review workflow slot while real automation is still pending."
+        case .motionPlaceholderExport:
+            return "Reserve a Motion export workflow slot until Motion automation is implemented."
+        }
+    }
+
+    var appTarget: WorkflowAppTarget {
+        switch self {
+        case .fcpExportCurrentTimeline, .fcpMonitorBackgroundTasks:
+            return .finalCutPro
+        case .motionPlaceholderReview, .motionPlaceholderExport:
+            return .motion
+        }
+    }
+
+    var requiresExportTarget: Bool {
+        switch self {
+        case .fcpExportCurrentTimeline, .motionPlaceholderExport:
+            return true
+        case .fcpMonitorBackgroundTasks, .motionPlaceholderReview:
+            return false
+        }
+    }
+
+    var isPlaceholder: Bool {
+        switch self {
+        case .motionPlaceholderReview, .motionPlaceholderExport:
+            return true
+        case .fcpExportCurrentTimeline, .fcpMonitorBackgroundTasks:
+            return false
+        }
+    }
+}
+
+struct WorkflowPlan: Sendable {
+    let preset: ProductionWorkflowPreset
+    let steps: [WorkflowStep]
+    let requiresExportPreflight: Bool
+    let completionMessage: String
+    let placeholderMessage: String?
+}

--- a/shell/Sources/MojoShell/Jobs/WorkflowPreset.swift
+++ b/shell/Sources/MojoShell/Jobs/WorkflowPreset.swift
@@ -65,6 +65,28 @@ enum ProductionWorkflowPreset: String, Codable, CaseIterable, Identifiable, Send
             return false
         }
     }
+
+    var workflowVersion: String {
+        switch self {
+        case .fcpExportCurrentTimeline:
+            return "fcp-export-v2"
+        case .fcpMonitorBackgroundTasks:
+            return "fcp-monitor-v1"
+        case .motionPlaceholderReview:
+            return "motion-review-v1"
+        case .motionPlaceholderExport:
+            return "motion-export-v1"
+        }
+    }
+
+    var supportsSourceAssets: Bool {
+        switch self {
+        case .fcpExportCurrentTimeline, .motionPlaceholderReview, .motionPlaceholderExport:
+            return true
+        case .fcpMonitorBackgroundTasks:
+            return false
+        }
+    }
 }
 
 struct WorkflowPlan: Sendable {

--- a/shell/Sources/MojoShell/LLM/ClaudeProvider.swift
+++ b/shell/Sources/MojoShell/LLM/ClaudeProvider.swift
@@ -96,23 +96,3 @@ struct ClaudeProvider: LLMProvider {
     }
 }
 
-private extension AnyCodable {
-    init(_ value: Any) {
-        switch value {
-        case let string as String:
-            self = .string(string)
-        case let int as Int:
-            self = .int(int)
-        case let double as Double:
-            self = .double(double)
-        case let bool as Bool:
-            self = .bool(bool)
-        case let object as [String: Any]:
-            self = .object(object.mapValues(AnyCodable.init))
-        case let array as [Any]:
-            self = .array(array.map(AnyCodable.init))
-        default:
-            self = .null
-        }
-    }
-}

--- a/shell/Sources/MojoShell/LLM/ClaudeProvider.swift
+++ b/shell/Sources/MojoShell/LLM/ClaudeProvider.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+struct ClaudeProvider: LLMProvider {
+    let name = "claude"
+
+    private let apiKey: String
+    private let model = "claude-sonnet-4-6"
+    private let baseURL = URL(string: "https://api.anthropic.com/v1/messages")!
+
+    init(apiKey: String) {
+        self.apiKey = apiKey
+    }
+
+    func buildURLRequest(prompt: String, tools: [LLMToolDefinition]) throws -> URLRequest {
+        var request = URLRequest(url: baseURL)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+
+        let toolSchemas = tools.map { tool in
+            [
+                "name": tool.name,
+                "description": tool.description,
+                "input_schema": [
+                    "type": "object",
+                    "properties": [:],
+                ] as [String: Any],
+            ] as [String: Any]
+        }
+
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 1024,
+            "system": """
+            You are the MojoShell agent router. Prefer deterministic MCP tool calls.
+            When a tool applies, return JSON like:
+            {"tool":"<tool_name>","server":"<server_name>","arguments":{}}
+            When no tool applies, return JSON like:
+            {"text":"<plain response>"}
+            """,
+            "messages": [
+                [
+                    "role": "user",
+                    "content": prompt,
+                ],
+            ],
+            "tools": toolSchemas,
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    func resolve(prompt: String, availableTools: [LLMToolDefinition]) async throws -> LLMResponse {
+        let request = try buildURLRequest(prompt: prompt, tools: availableTools)
+        let (data, _) = try await URLSession.shared.data(for: request)
+
+        guard
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let content = json["content"] as? [[String: Any]]
+        else {
+            return LLMResponse(text: "No response", resolvedTool: nil)
+        }
+
+        let text = content
+            .compactMap { item in item["text"] as? String }
+            .joined(separator: "\n")
+
+        guard !text.isEmpty else {
+            return LLMResponse(text: "No response", resolvedTool: nil)
+        }
+
+        guard
+            let jsonData = text.data(using: .utf8),
+            let parsed = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        else {
+            return LLMResponse(text: text, resolvedTool: nil)
+        }
+
+        if
+            let tool = parsed["tool"] as? String,
+            let server = parsed["server"] as? String
+        {
+            let arguments = (parsed["arguments"] as? [String: Any] ?? [:]).reduce(into: [String: AnyCodable]()) { partialResult, entry in
+                partialResult[entry.key] = AnyCodable(entry.value)
+            }
+
+            return LLMResponse(
+                text: text,
+                resolvedTool: ResolvedTool(server: server, tool: tool, arguments: arguments)
+            )
+        }
+
+        return LLMResponse(text: text, resolvedTool: nil)
+    }
+}
+
+private extension AnyCodable {
+    init(_ value: Any) {
+        switch value {
+        case let string as String:
+            self = .string(string)
+        case let int as Int:
+            self = .int(int)
+        case let double as Double:
+            self = .double(double)
+        case let bool as Bool:
+            self = .bool(bool)
+        case let object as [String: Any]:
+            self = .object(object.mapValues(AnyCodable.init))
+        case let array as [Any]:
+            self = .array(array.map(AnyCodable.init))
+        default:
+            self = .null
+        }
+    }
+}

--- a/shell/Sources/MojoShell/LLM/LLMProvider.swift
+++ b/shell/Sources/MojoShell/LLM/LLMProvider.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct LLMToolDefinition: Equatable {
+    let name: String
+    let description: String
+    let server: String
+}
+
+struct LLMResponse: Equatable {
+    let text: String
+    let resolvedTool: ResolvedTool?
+}
+
+protocol LLMProvider {
+    var name: String { get }
+    func resolve(prompt: String, availableTools: [LLMToolDefinition]) async throws -> LLMResponse
+    func buildURLRequest(prompt: String, tools: [LLMToolDefinition]) throws -> URLRequest
+}

--- a/shell/Sources/MojoShell/LLM/LLMProvider.swift
+++ b/shell/Sources/MojoShell/LLM/LLMProvider.swift
@@ -16,3 +16,10 @@ protocol LLMProvider {
     func resolve(prompt: String, availableTools: [LLMToolDefinition]) async throws -> LLMResponse
     func buildURLRequest(prompt: String, tools: [LLMToolDefinition]) throws -> URLRequest
 }
+
+enum LLMRoutingError: LocalizedError {
+    case noAPIKey
+    var errorDescription: String? {
+        "ANTHROPIC_API_KEY is not set. Set it in your environment to enable Claude routing."
+    }
+}

--- a/shell/Sources/MojoShell/LLM/LLMProvider.swift
+++ b/shell/Sources/MojoShell/LLM/LLMProvider.swift
@@ -1,17 +1,17 @@
 import Foundation
 
-struct LLMToolDefinition: Equatable {
+struct LLMToolDefinition: Equatable, Sendable {
     let name: String
     let description: String
     let server: String
 }
 
-struct LLMResponse: Equatable {
+struct LLMResponse: Equatable, Sendable {
     let text: String
     let resolvedTool: ResolvedTool?
 }
 
-protocol LLMProvider {
+protocol LLMProvider: Sendable {
     var name: String { get }
     func resolve(prompt: String, availableTools: [LLMToolDefinition]) async throws -> LLMResponse
     func buildURLRequest(prompt: String, tools: [LLMToolDefinition]) throws -> URLRequest

--- a/shell/Sources/MojoShell/LLM/LLMProvider.swift
+++ b/shell/Sources/MojoShell/LLM/LLMProvider.swift
@@ -18,8 +18,15 @@ protocol LLMProvider {
 }
 
 enum LLMRoutingError: LocalizedError {
-    case noAPIKey
+    case noAvailableProviders
+    case providersFailed(String)
+
     var errorDescription: String? {
-        "ANTHROPIC_API_KEY is not set. Set it in your environment to enable Claude routing."
+        switch self {
+        case .noAvailableProviders:
+            return "No LLM providers are configured. Set ANTHROPIC_API_KEY or OPENAI_API_KEY to enable fallback routing."
+        case .providersFailed(let detail):
+            return "All configured LLM providers failed. \(detail)"
+        }
     }
 }

--- a/shell/Sources/MojoShell/LLM/OpenAIProvider.swift
+++ b/shell/Sources/MojoShell/LLM/OpenAIProvider.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+struct OpenAIProvider: LLMProvider {
+    let name = "openai"
+
+    private let apiKey: String
+    private let model: String
+    private let baseURL = URL(string: "https://api.openai.com/v1/chat/completions")!
+
+    init(apiKey: String, model: String = ProcessInfo.processInfo.environment["OPENAI_ROUTER_MODEL"] ?? "gpt-4o-mini") {
+        self.apiKey = apiKey
+        self.model = model
+    }
+
+    func buildURLRequest(prompt: String, tools: [LLMToolDefinition]) throws -> URLRequest {
+        var request = URLRequest(url: baseURL)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let toolList = tools
+            .map { "\($0.server)/\($0.name): \($0.description)" }
+            .joined(separator: "\n")
+
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [
+                [
+                    "role": "system",
+                    "content": """
+                    You are the MojoShell fallback router.
+                    Available tools:
+                    \(toolList)
+
+                    Return JSON like {"tool":"<tool_name>","server":"<server_name>","arguments":{}} when a tool applies.
+                    Otherwise return JSON like {"text":"<plain response>"}.
+                    """,
+                ],
+                [
+                    "role": "user",
+                    "content": prompt,
+                ],
+            ],
+            "temperature": 0,
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    func resolve(prompt: String, availableTools: [LLMToolDefinition]) async throws -> LLMResponse {
+        let request = try buildURLRequest(prompt: prompt, tools: availableTools)
+        let (data, _) = try await URLSession.shared.data(for: request)
+
+        guard
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let choices = json["choices"] as? [[String: Any]],
+            let first = choices.first,
+            let message = first["message"] as? [String: Any],
+            let text = message["content"] as? String,
+            !text.isEmpty
+        else {
+            return LLMResponse(text: "No response", resolvedTool: nil)
+        }
+
+        guard
+            let jsonData = text.data(using: .utf8),
+            let parsed = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        else {
+            return LLMResponse(text: text, resolvedTool: nil)
+        }
+
+        if
+            let tool = parsed["tool"] as? String,
+            let server = parsed["server"] as? String
+        {
+            let arguments = (parsed["arguments"] as? [String: Any] ?? [:]).reduce(into: [String: AnyCodable]()) { partialResult, entry in
+                partialResult[entry.key] = AnyCodable(entry.value)
+            }
+
+            return LLMResponse(
+                text: text,
+                resolvedTool: ResolvedTool(server: server, tool: tool, arguments: arguments)
+            )
+        }
+
+        return LLMResponse(text: text, resolvedTool: nil)
+    }
+}

--- a/shell/Sources/MojoShell/Managers/BrainManager.swift
+++ b/shell/Sources/MojoShell/Managers/BrainManager.swift
@@ -1,0 +1,209 @@
+import Foundation
+
+enum BrainSourceMode: String, Codable, CaseIterable, Identifiable, Sendable {
+    case repoDefault
+    case localCopy
+    case custom
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .repoDefault:
+            return "Repo Brain"
+        case .localCopy:
+            return "Local Brain"
+        case .custom:
+            return "Custom Brain"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .repoDefault:
+            return "Use the repo-bundled operating brain file."
+        case .localCopy:
+            return "Use a user-local copy under Application Support."
+        case .custom:
+            return "Use an operator-selected custom brain path."
+        }
+    }
+}
+
+struct BrainConfiguration: Codable, Equatable, Sendable {
+    var mode: BrainSourceMode
+    var customPath: String?
+}
+
+struct BrainConfigStore {
+    let fileURL: URL
+    private let fileManager: FileManager
+
+    init(
+        fileURL: URL = BrainConfigStore.defaultFileURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func load() throws -> BrainConfiguration? {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return nil
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        guard !data.isEmpty else {
+            return nil
+        }
+
+        return try JSONDecoder().decode(BrainConfiguration.self, from: data)
+    }
+
+    func save(_ configuration: BrainConfiguration) throws {
+        let parent = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(configuration)
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    static func defaultFileURL() -> URL {
+        JobStore.defaultFileURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("brain-config.json")
+    }
+}
+
+enum BrainManagerError: LocalizedError, Equatable {
+    case repoBrainMissing(String)
+    case customBrainMissing(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .repoBrainMissing(let path):
+            return "Repo brain file missing: \(path)"
+        case .customBrainMissing(let path):
+            return "Custom brain file missing: \(path)"
+        }
+    }
+}
+
+@MainActor
+final class BrainManager: ObservableObject {
+    @Published private(set) var sourceMode: BrainSourceMode
+    @Published private(set) var activeBrainPath: String
+
+    let repoDefaultPath: String
+    let localBrainPath: String
+
+    private let store: BrainConfigStore
+    private let fileManager: FileManager
+
+    init(
+        repoRoot: String,
+        localBrainPath: String? = nil,
+        store: BrainConfigStore = BrainConfigStore(),
+        fileManager: FileManager = .default
+    ) {
+        self.repoDefaultPath = "\(repoRoot)/knowledge-corpus/data/mojosolo_operating_brain.json"
+        self.localBrainPath = localBrainPath ?? BrainManager.defaultLocalBrainPath()
+        self.store = store
+        self.fileManager = fileManager
+
+        let configuration = (try? store.load()) ?? nil
+        let mode = configuration?.mode ?? .repoDefault
+        self.sourceMode = mode
+        self.activeBrainPath = BrainManager.resolveActivePath(
+            mode: mode,
+            customPath: configuration?.customPath,
+            repoDefaultPath: self.repoDefaultPath,
+            localBrainPath: self.localBrainPath
+        )
+
+        persist()
+    }
+
+    var activeBrainName: String {
+        URL(fileURLWithPath: activeBrainPath).lastPathComponent
+    }
+
+    func useRepoDefault() {
+        sourceMode = .repoDefault
+        activeBrainPath = repoDefaultPath
+        persist()
+    }
+
+    func useLocalBrain() throws {
+        try seedLocalBrainIfNeeded()
+        sourceMode = .localCopy
+        activeBrainPath = localBrainPath
+        persist()
+    }
+
+    func useCustomBrain(path: String) throws {
+        let resolved = (path as NSString).expandingTildeInPath
+        guard fileManager.fileExists(atPath: resolved) else {
+            throw BrainManagerError.customBrainMissing(resolved)
+        }
+        sourceMode = .custom
+        activeBrainPath = resolved
+        persist(customPath: resolved)
+    }
+
+    func seedLocalBrainIfNeeded() throws {
+        guard fileManager.fileExists(atPath: repoDefaultPath) else {
+            throw BrainManagerError.repoBrainMissing(repoDefaultPath)
+        }
+
+        guard !fileManager.fileExists(atPath: localBrainPath) else {
+            return
+        }
+
+        let targetURL = URL(fileURLWithPath: localBrainPath)
+        try fileManager.createDirectory(at: targetURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try fileManager.copyItem(atPath: repoDefaultPath, toPath: localBrainPath)
+    }
+
+    private func persist(customPath: String? = nil) {
+        let storedCustomPath: String?
+        if sourceMode == .custom {
+            storedCustomPath = customPath ?? activeBrainPath
+        } else {
+            storedCustomPath = nil
+        }
+
+        do {
+            try store.save(
+                BrainConfiguration(
+                    mode: sourceMode,
+                    customPath: storedCustomPath
+                )
+            )
+        } catch {
+            // Brain path persistence must not crash the shell.
+        }
+    }
+
+    private static func resolveActivePath(
+        mode: BrainSourceMode,
+        customPath: String?,
+        repoDefaultPath: String,
+        localBrainPath: String
+    ) -> String {
+        switch mode {
+        case .repoDefault:
+            return repoDefaultPath
+        case .localCopy:
+            return localBrainPath
+        case .custom:
+            return customPath?.isEmpty == false ? customPath! : repoDefaultPath
+        }
+    }
+
+    private static func defaultLocalBrainPath() -> String {
+        JobStore.defaultFileURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("brain.json")
+            .path
+    }
+}

--- a/shell/Sources/MojoShell/Managers/BrainManager.swift
+++ b/shell/Sources/MojoShell/Managers/BrainManager.swift
@@ -77,6 +77,7 @@ struct BrainConfigStore {
 enum BrainManagerError: LocalizedError, Equatable {
     case repoBrainMissing(String)
     case customBrainMissing(String)
+    case importSourceMissing(String)
 
     var errorDescription: String? {
         switch self {
@@ -84,6 +85,8 @@ enum BrainManagerError: LocalizedError, Equatable {
             return "Repo brain file missing: \(path)"
         case .customBrainMissing(let path):
             return "Custom brain file missing: \(path)"
+        case .importSourceMissing(let path):
+            return "Import source missing: \(path)"
         }
     }
 }
@@ -148,6 +151,23 @@ final class BrainManager: ObservableObject {
         sourceMode = .custom
         activeBrainPath = resolved
         persist(customPath: resolved)
+    }
+
+    func importLocalBrain(from path: String) throws {
+        let resolved = (path as NSString).expandingTildeInPath
+        guard fileManager.fileExists(atPath: resolved) else {
+            throw BrainManagerError.importSourceMissing(resolved)
+        }
+
+        let targetURL = URL(fileURLWithPath: localBrainPath)
+        try fileManager.createDirectory(at: targetURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if fileManager.fileExists(atPath: localBrainPath) {
+            try fileManager.removeItem(atPath: localBrainPath)
+        }
+        try fileManager.copyItem(atPath: resolved, toPath: localBrainPath)
+        sourceMode = .localCopy
+        activeBrainPath = localBrainPath
+        persist()
     }
 
     func seedLocalBrainIfNeeded() throws {

--- a/shell/Sources/MojoShell/Managers/DaemonLogStore.swift
+++ b/shell/Sources/MojoShell/Managers/DaemonLogStore.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+enum DaemonLogKind: String, CaseIterable, Sendable {
+    case runtime
+    case build
+}
+
+struct DaemonBuildResult: Equatable, Sendable {
+    let output: String
+    let exitStatus: Int32
+}
+
+enum DaemonBuildStatus: String, Equatable, Sendable {
+    case idle
+    case building
+    case succeeded
+    case failed
+}
+
+struct DaemonBuildState: Identifiable, Equatable, Sendable {
+    let id: String
+    let serverName: String
+    let status: DaemonBuildStatus
+    let command: String
+    let logPath: String
+    let lastOutput: String
+    let updatedAt: Date
+    let startedAt: Date?
+    let finishedAt: Date?
+    let lastExitCode: Int32?
+
+    init(
+        serverName: String,
+        status: DaemonBuildStatus,
+        command: String,
+        logPath: String,
+        lastOutput: String = "",
+        updatedAt: Date = Date(),
+        startedAt: Date? = nil,
+        finishedAt: Date? = nil,
+        lastExitCode: Int32? = nil
+    ) {
+        self.id = serverName
+        self.serverName = serverName
+        self.status = status
+        self.command = command
+        self.logPath = logPath
+        self.lastOutput = lastOutput
+        self.updatedAt = updatedAt
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+        self.lastExitCode = lastExitCode
+    }
+}
+
+struct DaemonLogStore {
+    let directoryURL: URL
+    private let fileManager: FileManager
+
+    init(
+        directoryURL: URL = DaemonLogStore.defaultDirectoryURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.directoryURL = directoryURL
+        self.fileManager = fileManager
+    }
+
+    func logURL(for serverName: String, kind: DaemonLogKind) -> URL {
+        directoryURL
+            .appendingPathComponent(serverName, isDirectory: true)
+            .appendingPathComponent("\(kind.rawValue).log")
+    }
+
+    func reset(serverName: String, kind: DaemonLogKind) throws {
+        let url = logURL(for: serverName, kind: kind)
+        try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data().write(to: url, options: .atomic)
+    }
+
+    func append(_ text: String, serverName: String, kind: DaemonLogKind) throws {
+        let url = logURL(for: serverName, kind: kind)
+        try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let data = Data(text.utf8)
+
+        if fileManager.fileExists(atPath: url.path) {
+            let handle = try FileHandle(forWritingTo: url)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+        } else {
+            try data.write(to: url, options: .atomic)
+        }
+    }
+
+    func load(serverName: String, kind: DaemonLogKind) throws -> String {
+        let url = logURL(for: serverName, kind: kind)
+        guard fileManager.fileExists(atPath: url.path) else {
+            return ""
+        }
+
+        let data = try Data(contentsOf: url)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    static func defaultDirectoryURL() -> URL {
+        JobStore.defaultFileURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("daemon-logs", isDirectory: true)
+    }
+}

--- a/shell/Sources/MojoShell/Managers/DaemonManager.swift
+++ b/shell/Sources/MojoShell/Managers/DaemonManager.swift
@@ -47,9 +47,14 @@ final class DaemonManager: ObservableObject {
     @Published private(set) var runtimeStates: [String: DaemonRuntimeState] = [:]
 
     let repoRoot: String
+    private let onRuntimeStateChanged: @MainActor (DaemonRuntimeState?, DaemonRuntimeState) -> Void
 
-    init(repoRoot: String = DaemonManager.defaultRepoRoot()) {
+    init(
+        repoRoot: String = DaemonManager.defaultRepoRoot(),
+        onRuntimeStateChanged: @escaping @MainActor (DaemonRuntimeState?, DaemonRuntimeState) -> Void = { _, _ in }
+    ) {
         self.repoRoot = repoRoot
+        self.onRuntimeStateChanged = onRuntimeStateChanged
         refreshRuntimeStates()
     }
 
@@ -265,13 +270,20 @@ final class DaemonManager: ObservableObject {
         pid: Int32?,
         lastError: String?
     ) {
-        runtimeStates[definition.name] = DaemonRuntimeState(
+        let previous = runtimeStates[definition.name]
+        let next = DaemonRuntimeState(
             serverName: definition.name,
             scriptPath: definition.scriptPath,
             status: status,
             pid: pid,
             lastError: lastError
         )
+        runtimeStates[definition.name] = next
+
+        guard hasMeaningfulChange(from: previous, to: next) else {
+            return
+        }
+        onRuntimeStateChanged(previous, next)
     }
 
     private func setRuntimeState(
@@ -305,5 +317,15 @@ final class DaemonManager: ObservableObject {
             .deletingLastPathComponent() // shell
             .deletingLastPathComponent() // repo root
             .path
+    }
+
+    private func hasMeaningfulChange(from previous: DaemonRuntimeState?, to next: DaemonRuntimeState) -> Bool {
+        guard let previous else {
+            return true
+        }
+
+        return previous.status != next.status
+            || previous.pid != next.pid
+            || previous.lastError != next.lastError
     }
 }

--- a/shell/Sources/MojoShell/Managers/DaemonManager.swift
+++ b/shell/Sources/MojoShell/Managers/DaemonManager.swift
@@ -1,0 +1,102 @@
+import Combine
+import Foundation
+
+struct MCPServerDefinition: Equatable {
+    let name: String
+    let scriptPath: String
+}
+
+@MainActor
+final class DaemonManager: ObservableObject {
+    @Published private(set) var runningServers: [String: Process] = [:]
+
+    private let repoRoot: String
+
+    init(repoRoot: String = Self.defaultRepoRoot()) {
+        self.repoRoot = repoRoot
+    }
+
+    var serverDefinitions: [MCPServerDefinition] {
+        let mapping: [(name: String, directory: String)] = [
+            ("apple-notes", "notes"),
+            ("apple-messages", "messages"),
+            ("apple-contacts", "contacts"),
+            ("apple-reminders", "reminders"),
+            ("apple-calendar", "calendar"),
+            ("apple-maps", "maps"),
+            ("apple-mail", "mail"),
+            ("apple-music", "music"),
+            ("mail-intelligence", "mail-intelligence"),
+            ("knowledge-corpus", "knowledge-corpus"),
+        ]
+
+        return mapping.map { entry in
+            MCPServerDefinition(
+                name: entry.name,
+                scriptPath: "\(repoRoot)/\(entry.directory)/build/index.js"
+            )
+        }
+    }
+
+    func startAll() {
+        for definition in serverDefinitions {
+            start(definition)
+        }
+    }
+
+    func stopAll() {
+        for process in runningServers.values where process.isRunning {
+            process.terminate()
+        }
+        runningServers.removeAll()
+    }
+
+    func process(for serverName: String) -> Process? {
+        runningServers[serverName]
+    }
+
+    private func start(_ definition: MCPServerDefinition) {
+        guard runningServers[definition.name] == nil else {
+            return
+        }
+
+        guard FileManager.default.fileExists(atPath: definition.scriptPath) else {
+            print("[DaemonManager] Missing build artifact: \(definition.scriptPath)")
+            return
+        }
+
+        let process = Process()
+        let stdin = Pipe()
+        let stdout = Pipe()
+        let stderr = Pipe()
+
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["node", definition.scriptPath]
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        process.standardError = stderr
+        process.terminationHandler = { [weak self] _ in
+            Task { @MainActor in
+                self?.runningServers.removeValue(forKey: definition.name)
+            }
+        }
+
+        do {
+            try process.run()
+            runningServers[definition.name] = process
+            print("[DaemonManager] Started \(definition.name) (pid \(process.processIdentifier))")
+        } catch {
+            print("[DaemonManager] Failed to start \(definition.name): \(error)")
+        }
+    }
+
+    private static func defaultRepoRoot() -> String {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // Managers
+            .deletingLastPathComponent() // MojoShell
+            .deletingLastPathComponent() // Sources
+            .deletingLastPathComponent() // shell
+            .deletingLastPathComponent() // repo root
+            .path
+    }
+}

--- a/shell/Sources/MojoShell/Managers/DaemonManager.swift
+++ b/shell/Sources/MojoShell/Managers/DaemonManager.swift
@@ -12,7 +12,7 @@ final class DaemonManager: ObservableObject {
 
     private let repoRoot: String
 
-    init(repoRoot: String = Self.defaultRepoRoot()) {
+    init(repoRoot: String = DaemonManager.defaultRepoRoot()) {
         self.repoRoot = repoRoot
     }
 

--- a/shell/Sources/MojoShell/Managers/DaemonManager.swift
+++ b/shell/Sources/MojoShell/Managers/DaemonManager.swift
@@ -55,6 +55,19 @@ final class DaemonManager: ObservableObject {
         runningServers[serverName]
     }
 
+    func ensureProcess(for serverName: String) -> Process? {
+        if let existing = runningServers[serverName], existing.isRunning {
+            return existing
+        }
+
+        guard let definition = serverDefinitions.first(where: { $0.name == serverName }) else {
+            return nil
+        }
+
+        start(definition)
+        return runningServers[serverName]
+    }
+
     private func start(_ definition: MCPServerDefinition) {
         guard runningServers[definition.name] == nil else {
             return

--- a/shell/Sources/MojoShell/Managers/DaemonManager.swift
+++ b/shell/Sources/MojoShell/Managers/DaemonManager.swift
@@ -10,7 +10,7 @@ struct MCPServerDefinition: Equatable {
 final class DaemonManager: ObservableObject {
     @Published private(set) var runningServers: [String: Process] = [:]
 
-    private let repoRoot: String
+    let repoRoot: String
 
     init(repoRoot: String = DaemonManager.defaultRepoRoot()) {
         self.repoRoot = repoRoot

--- a/shell/Sources/MojoShell/Managers/DaemonManager.swift
+++ b/shell/Sources/MojoShell/Managers/DaemonManager.swift
@@ -6,14 +6,51 @@ struct MCPServerDefinition: Equatable {
     let scriptPath: String
 }
 
+enum DaemonRuntimeStatus: String, Equatable {
+    case notBuilt
+    case stopped
+    case starting
+    case running
+    case failed
+}
+
+struct DaemonRuntimeState: Identifiable, Equatable {
+    let id: String
+    let serverName: String
+    let scriptPath: String
+    let status: DaemonRuntimeStatus
+    let pid: Int32?
+    let lastError: String?
+    let updatedAt: Date
+
+    init(
+        serverName: String,
+        scriptPath: String,
+        status: DaemonRuntimeStatus,
+        pid: Int32? = nil,
+        lastError: String? = nil,
+        updatedAt: Date = Date()
+    ) {
+        self.id = serverName
+        self.serverName = serverName
+        self.scriptPath = scriptPath
+        self.status = status
+        self.pid = pid
+        self.lastError = lastError
+        self.updatedAt = updatedAt
+    }
+}
+
 @MainActor
 final class DaemonManager: ObservableObject {
     @Published private(set) var runningServers: [String: Process] = [:]
+    @Published private(set) var runtimeStates: [String: DaemonRuntimeState] = [:]
 
     let repoRoot: String
 
     init(repoRoot: String = DaemonManager.defaultRepoRoot()) {
         self.repoRoot = repoRoot
+        refreshRuntimeStates()
     }
 
     var serverDefinitions: [MCPServerDefinition] {
@@ -38,6 +75,12 @@ final class DaemonManager: ObservableObject {
         }
     }
 
+    var allRuntimeStates: [DaemonRuntimeState] {
+        serverDefinitions
+            .map { runtimeStates[$0.name] ?? defaultRuntimeState(for: $0) }
+            .sorted { $0.serverName < $1.serverName }
+    }
+
     func startAll() {
         for definition in serverDefinitions {
             start(definition)
@@ -45,18 +88,60 @@ final class DaemonManager: ObservableObject {
     }
 
     func stopAll() {
-        for process in runningServers.values where process.isRunning {
+        for definition in serverDefinitions {
+            stop(serverName: definition.name)
+        }
+    }
+
+    func stop(serverName: String) {
+        guard let definition = serverDefinitions.first(where: { $0.name == serverName }) else {
+            return
+        }
+
+        if let process = runningServers[serverName], process.isRunning {
             process.terminate()
         }
-        runningServers.removeAll()
+        runningServers.removeValue(forKey: serverName)
+
+        let artifactExists = FileManager.default.fileExists(atPath: definition.scriptPath)
+        setRuntimeState(
+            for: definition,
+            status: artifactExists ? .stopped : .notBuilt,
+            pid: nil,
+            lastError: artifactExists ? nil : "Missing build artifact"
+        )
+    }
+
+    func restart(serverName: String) {
+        stop(serverName: serverName)
+        guard let definition = serverDefinitions.first(where: { $0.name == serverName }) else {
+            return
+        }
+        start(definition)
+    }
+
+    func restartAll() {
+        for definition in serverDefinitions {
+            restart(serverName: definition.name)
+        }
     }
 
     func process(for serverName: String) -> Process? {
         runningServers[serverName]
     }
 
+    func runtimeState(for serverName: String) -> DaemonRuntimeState? {
+        runtimeStates[serverName]
+    }
+
     func ensureProcess(for serverName: String) -> Process? {
         if let existing = runningServers[serverName], existing.isRunning {
+            setRuntimeState(
+                forName: serverName,
+                status: .running,
+                pid: existing.processIdentifier,
+                lastError: nil
+            )
             return existing
         }
 
@@ -68,15 +153,56 @@ final class DaemonManager: ObservableObject {
         return runningServers[serverName]
     }
 
+    func refreshRuntimeStates() {
+        for definition in serverDefinitions {
+            let artifactExists = FileManager.default.fileExists(atPath: definition.scriptPath)
+
+            if let process = runningServers[definition.name], process.isRunning {
+                setRuntimeState(
+                    for: definition,
+                    status: .running,
+                    pid: process.processIdentifier,
+                    lastError: nil
+                )
+                continue
+            }
+
+            runningServers.removeValue(forKey: definition.name)
+            setRuntimeState(
+                for: definition,
+                status: artifactExists ? .stopped : .notBuilt,
+                pid: nil,
+                lastError: artifactExists ? nil : "Missing build artifact"
+            )
+        }
+    }
+
     private func start(_ definition: MCPServerDefinition) {
-        guard runningServers[definition.name] == nil else {
-            return
+        if let existing = runningServers[definition.name] {
+            if existing.isRunning {
+                setRuntimeState(
+                    for: definition,
+                    status: .running,
+                    pid: existing.processIdentifier,
+                    lastError: nil
+                )
+                return
+            }
+            runningServers.removeValue(forKey: definition.name)
         }
 
         guard FileManager.default.fileExists(atPath: definition.scriptPath) else {
             print("[DaemonManager] Missing build artifact: \(definition.scriptPath)")
+            setRuntimeState(
+                for: definition,
+                status: .notBuilt,
+                pid: nil,
+                lastError: "Missing build artifact"
+            )
             return
         }
+
+        setRuntimeState(for: definition, status: .starting, pid: nil, lastError: nil)
 
         let process = Process()
         let stdin = Pipe()
@@ -88,19 +214,87 @@ final class DaemonManager: ObservableObject {
         process.standardInput = stdin
         process.standardOutput = stdout
         process.standardError = stderr
-        process.terminationHandler = { [weak self] _ in
+        process.terminationHandler = { [weak self] process in
             Task { @MainActor in
-                self?.runningServers.removeValue(forKey: definition.name)
+                guard let self else { return }
+                self.runningServers.removeValue(forKey: definition.name)
+
+                let status: DaemonRuntimeStatus
+                let errorMessage: String?
+                if process.terminationReason == .exit && process.terminationStatus == 0 {
+                    status = .stopped
+                    errorMessage = nil
+                } else {
+                    status = .failed
+                    errorMessage = "Exited with status \(process.terminationStatus)"
+                }
+
+                self.setRuntimeState(
+                    for: definition,
+                    status: status,
+                    pid: nil,
+                    lastError: errorMessage
+                )
             }
         }
 
         do {
             try process.run()
             runningServers[definition.name] = process
+            setRuntimeState(
+                for: definition,
+                status: .running,
+                pid: process.processIdentifier,
+                lastError: nil
+            )
             print("[DaemonManager] Started \(definition.name) (pid \(process.processIdentifier))")
         } catch {
+            setRuntimeState(
+                for: definition,
+                status: .failed,
+                pid: nil,
+                lastError: error.localizedDescription
+            )
             print("[DaemonManager] Failed to start \(definition.name): \(error)")
         }
+    }
+
+    private func setRuntimeState(
+        for definition: MCPServerDefinition,
+        status: DaemonRuntimeStatus,
+        pid: Int32?,
+        lastError: String?
+    ) {
+        runtimeStates[definition.name] = DaemonRuntimeState(
+            serverName: definition.name,
+            scriptPath: definition.scriptPath,
+            status: status,
+            pid: pid,
+            lastError: lastError
+        )
+    }
+
+    private func setRuntimeState(
+        forName serverName: String,
+        status: DaemonRuntimeStatus,
+        pid: Int32?,
+        lastError: String?
+    ) {
+        guard let definition = serverDefinitions.first(where: { $0.name == serverName }) else {
+            return
+        }
+        setRuntimeState(for: definition, status: status, pid: pid, lastError: lastError)
+    }
+
+    private func defaultRuntimeState(for definition: MCPServerDefinition) -> DaemonRuntimeState {
+        let artifactExists = FileManager.default.fileExists(atPath: definition.scriptPath)
+        return DaemonRuntimeState(
+            serverName: definition.name,
+            scriptPath: definition.scriptPath,
+            status: artifactExists ? .stopped : .notBuilt,
+            pid: nil,
+            lastError: artifactExists ? nil : "Missing build artifact"
+        )
     }
 
     private static func defaultRepoRoot() -> String {

--- a/shell/Sources/MojoShell/Managers/DaemonManager.swift
+++ b/shell/Sources/MojoShell/Managers/DaemonManager.swift
@@ -281,6 +281,14 @@ final class DaemonManager: ObservableObject {
         runtimeLogSnippets[serverName] ?? ""
     }
 
+    func runtimeLog(for serverName: String) -> String {
+        (try? logStore.load(serverName: serverName, kind: .runtime)) ?? ""
+    }
+
+    func buildLog(for serverName: String) -> String {
+        (try? logStore.load(serverName: serverName, kind: .build)) ?? ""
+    }
+
     func logPath(for serverName: String, kind: DaemonLogKind) -> String {
         logStore.logURL(for: serverName, kind: kind).path
     }

--- a/shell/Sources/MojoShell/Managers/DaemonManager.swift
+++ b/shell/Sources/MojoShell/Managers/DaemonManager.swift
@@ -3,7 +3,20 @@ import Foundation
 
 struct MCPServerDefinition: Equatable {
     let name: String
+    let directoryPath: String
     let scriptPath: String
+
+    var packagePath: String {
+        "\(directoryPath)/package.json"
+    }
+
+    var buildCommand: [String] {
+        ["npm", "run", "build"]
+    }
+
+    var buildCommandDescription: String {
+        buildCommand.joined(separator: " ")
+    }
 }
 
 enum DaemonRuntimeStatus: String, Equatable {
@@ -21,6 +34,7 @@ struct DaemonRuntimeState: Identifiable, Equatable {
     let status: DaemonRuntimeStatus
     let pid: Int32?
     let lastError: String?
+    let logPath: String
     let updatedAt: Date
 
     init(
@@ -29,6 +43,7 @@ struct DaemonRuntimeState: Identifiable, Equatable {
         status: DaemonRuntimeStatus,
         pid: Int32? = nil,
         lastError: String? = nil,
+        logPath: String,
         updatedAt: Date = Date()
     ) {
         self.id = serverName
@@ -37,6 +52,7 @@ struct DaemonRuntimeState: Identifiable, Equatable {
         self.status = status
         self.pid = pid
         self.lastError = lastError
+        self.logPath = logPath
         self.updatedAt = updatedAt
     }
 }
@@ -45,16 +61,27 @@ struct DaemonRuntimeState: Identifiable, Equatable {
 final class DaemonManager: ObservableObject {
     @Published private(set) var runningServers: [String: Process] = [:]
     @Published private(set) var runtimeStates: [String: DaemonRuntimeState] = [:]
+    @Published private(set) var buildStates: [String: DaemonBuildState] = [:]
+    @Published private(set) var runtimeLogSnippets: [String: String] = [:]
 
     let repoRoot: String
+    private let logStore: DaemonLogStore
+    private let brainPathProvider: @MainActor () -> String?
     private let onRuntimeStateChanged: @MainActor (DaemonRuntimeState?, DaemonRuntimeState) -> Void
+    private let buildOperation: @Sendable (MCPServerDefinition) async throws -> DaemonBuildResult
 
     init(
         repoRoot: String = DaemonManager.defaultRepoRoot(),
-        onRuntimeStateChanged: @escaping @MainActor (DaemonRuntimeState?, DaemonRuntimeState) -> Void = { _, _ in }
+        logStore: DaemonLogStore = DaemonLogStore(),
+        brainPathProvider: @escaping @MainActor () -> String? = { nil },
+        onRuntimeStateChanged: @escaping @MainActor (DaemonRuntimeState?, DaemonRuntimeState) -> Void = { _, _ in },
+        buildOperation: (@Sendable (MCPServerDefinition) async throws -> DaemonBuildResult)? = nil
     ) {
         self.repoRoot = repoRoot
+        self.logStore = logStore
+        self.brainPathProvider = brainPathProvider
         self.onRuntimeStateChanged = onRuntimeStateChanged
+        self.buildOperation = buildOperation ?? DaemonManager.defaultBuildOperation
         refreshRuntimeStates()
     }
 
@@ -73,9 +100,11 @@ final class DaemonManager: ObservableObject {
         ]
 
         return mapping.map { entry in
-            MCPServerDefinition(
+            let directoryPath = "\(repoRoot)/\(entry.directory)"
+            return MCPServerDefinition(
                 name: entry.name,
-                scriptPath: "\(repoRoot)/\(entry.directory)/build/index.js"
+                directoryPath: directoryPath,
+                scriptPath: "\(directoryPath)/build/index.js"
             )
         }
     }
@@ -83,6 +112,12 @@ final class DaemonManager: ObservableObject {
     var allRuntimeStates: [DaemonRuntimeState] {
         serverDefinitions
             .map { runtimeStates[$0.name] ?? defaultRuntimeState(for: $0) }
+            .sorted { $0.serverName < $1.serverName }
+    }
+
+    var allBuildStates: [DaemonBuildState] {
+        serverDefinitions
+            .map { buildStates[$0.name] ?? defaultBuildState(for: $0) }
             .sorted { $0.serverName < $1.serverName }
     }
 
@@ -103,7 +138,12 @@ final class DaemonManager: ObservableObject {
             return
         }
 
+        appendRuntimeLog("Stopping \(serverName)\n", serverName: serverName)
+
         if let process = runningServers[serverName], process.isRunning {
+            if let stderr = process.standardError as? Pipe {
+                stderr.fileHandleForReading.readabilityHandler = nil
+            }
             process.terminate()
         }
         runningServers.removeValue(forKey: serverName)
@@ -131,12 +171,118 @@ final class DaemonManager: ObservableObject {
         }
     }
 
+    func build(serverName: String) async {
+        guard let definition = serverDefinitions.first(where: { $0.name == serverName }) else {
+            return
+        }
+
+        let previous = buildStates[definition.name] ?? defaultBuildState(for: definition)
+        guard previous.status != .building else {
+            return
+        }
+
+        do {
+            try logStore.reset(serverName: definition.name, kind: .build)
+        } catch {
+            // Best effort only.
+        }
+
+        let startedAt = Date()
+        setBuildState(
+            DaemonBuildState(
+                serverName: definition.name,
+                status: .building,
+                command: definition.buildCommandDescription,
+                logPath: logStore.logURL(for: definition.name, kind: .build).path,
+                lastOutput: "Building \(definition.name)...",
+                startedAt: startedAt,
+                finishedAt: nil,
+                lastExitCode: nil
+            )
+        )
+        appendBuildLog("$ \(definition.buildCommandDescription)\n", serverName: definition.name)
+
+        do {
+            let result = try await buildOperation(definition)
+            appendBuildLog(result.output, serverName: definition.name)
+
+            let artifactExists = FileManager.default.fileExists(atPath: definition.scriptPath)
+            let finishedAt = Date()
+            if result.exitStatus == 0 && artifactExists {
+                setBuildState(
+                    DaemonBuildState(
+                        serverName: definition.name,
+                        status: .succeeded,
+                        command: definition.buildCommandDescription,
+                        logPath: logStore.logURL(for: definition.name, kind: .build).path,
+                        lastOutput: Self.tailSnippet(result.output, fallback: "Build succeeded."),
+                        startedAt: startedAt,
+                        finishedAt: finishedAt,
+                        lastExitCode: result.exitStatus
+                    )
+                )
+            } else {
+                let failureOutput = result.exitStatus == 0
+                    ? result.output + "\nBuild finished without producing build/index.js."
+                    : result.output
+                setBuildState(
+                    DaemonBuildState(
+                        serverName: definition.name,
+                        status: .failed,
+                        command: definition.buildCommandDescription,
+                        logPath: logStore.logURL(for: definition.name, kind: .build).path,
+                        lastOutput: Self.tailSnippet(failureOutput, fallback: "Build failed."),
+                        startedAt: startedAt,
+                        finishedAt: finishedAt,
+                        lastExitCode: result.exitStatus == 0 ? 1 : result.exitStatus
+                    )
+                )
+            }
+        } catch {
+            let finishedAt = Date()
+            let message = error.localizedDescription
+            appendBuildLog(message + "\n", serverName: definition.name)
+            setBuildState(
+                DaemonBuildState(
+                    serverName: definition.name,
+                    status: .failed,
+                    command: definition.buildCommandDescription,
+                    logPath: logStore.logURL(for: definition.name, kind: .build).path,
+                    lastOutput: Self.tailSnippet(message, fallback: "Build failed."),
+                    startedAt: startedAt,
+                    finishedAt: finishedAt,
+                    lastExitCode: 1
+                )
+            )
+        }
+
+        refreshRuntimeStates()
+    }
+
+    func buildAll() async {
+        for definition in serverDefinitions {
+            await build(serverName: definition.name)
+        }
+    }
+
     func process(for serverName: String) -> Process? {
         runningServers[serverName]
     }
 
     func runtimeState(for serverName: String) -> DaemonRuntimeState? {
         runtimeStates[serverName]
+    }
+
+    func buildState(for serverName: String) -> DaemonBuildState? {
+        buildStates[serverName]
+    }
+
+    func recentRuntimeLog(for serverName: String) -> String {
+        runtimeLogSnippets[serverName] ?? ""
+    }
+
+    func logPath(for serverName: String, kind: DaemonLogKind) -> String {
+        logStore.logURL(for: serverName, kind: kind).path
     }
 
     func ensureProcess(for serverName: String) -> Process? {
@@ -198,6 +344,7 @@ final class DaemonManager: ObservableObject {
 
         guard FileManager.default.fileExists(atPath: definition.scriptPath) else {
             print("[DaemonManager] Missing build artifact: \(definition.scriptPath)")
+            appendRuntimeLog("Missing build artifact: \(definition.scriptPath)\n", serverName: definition.name)
             setRuntimeState(
                 for: definition,
                 status: .notBuilt,
@@ -207,6 +354,13 @@ final class DaemonManager: ObservableObject {
             return
         }
 
+        do {
+            try logStore.reset(serverName: definition.name, kind: .runtime)
+        } catch {
+            // Best effort only.
+        }
+
+        appendRuntimeLog("Starting \(definition.name)\n", serverName: definition.name)
         setRuntimeState(for: definition, status: .starting, pid: nil, lastError: nil)
 
         let process = Process()
@@ -216,12 +370,26 @@ final class DaemonManager: ObservableObject {
 
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = ["node", definition.scriptPath]
+        process.environment = processEnvironment()
         process.standardInput = stdin
         process.standardOutput = stdout
         process.standardError = stderr
+        stderr.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else {
+                return
+            }
+            let chunk = String(decoding: data, as: UTF8.self)
+            Task { @MainActor [weak self] in
+                self?.appendRuntimeLog(chunk, serverName: definition.name)
+            }
+        }
         process.terminationHandler = { [weak self] process in
             Task { @MainActor in
                 guard let self else { return }
+                if let stderr = process.standardError as? Pipe {
+                    stderr.fileHandleForReading.readabilityHandler = nil
+                }
                 self.runningServers.removeValue(forKey: definition.name)
 
                 let status: DaemonRuntimeStatus
@@ -229,9 +397,11 @@ final class DaemonManager: ObservableObject {
                 if process.terminationReason == .exit && process.terminationStatus == 0 {
                     status = .stopped
                     errorMessage = nil
+                    self.appendRuntimeLog("Exited cleanly.\n", serverName: definition.name)
                 } else {
                     status = .failed
                     errorMessage = "Exited with status \(process.terminationStatus)"
+                    self.appendRuntimeLog("Exited with status \(process.terminationStatus).\n", serverName: definition.name)
                 }
 
                 self.setRuntimeState(
@@ -246,6 +416,7 @@ final class DaemonManager: ObservableObject {
         do {
             try process.run()
             runningServers[definition.name] = process
+            appendRuntimeLog("Started pid \(process.processIdentifier).\n", serverName: definition.name)
             setRuntimeState(
                 for: definition,
                 status: .running,
@@ -254,6 +425,7 @@ final class DaemonManager: ObservableObject {
             )
             print("[DaemonManager] Started \(definition.name) (pid \(process.processIdentifier))")
         } catch {
+            appendRuntimeLog("Failed to start: \(error.localizedDescription)\n", serverName: definition.name)
             setRuntimeState(
                 for: definition,
                 status: .failed,
@@ -262,6 +434,36 @@ final class DaemonManager: ObservableObject {
             )
             print("[DaemonManager] Failed to start \(definition.name): \(error)")
         }
+    }
+
+    private func processEnvironment() -> [String: String] {
+        var environment = ProcessInfo.processInfo.environment
+        if let brainPath = brainPathProvider()?.trimmingCharacters(in: .whitespacesAndNewlines), !brainPath.isEmpty {
+            environment["BRAIN_PATH"] = brainPath
+        }
+        return environment
+    }
+
+    private func appendRuntimeLog(_ text: String, serverName: String) {
+        do {
+            try logStore.append(text, serverName: serverName, kind: .runtime)
+        } catch {
+            // Runtime log capture is best effort only.
+        }
+        let combined = (runtimeLogSnippets[serverName] ?? "") + text
+        runtimeLogSnippets[serverName] = Self.tailSnippet(combined, fallback: "")
+    }
+
+    private func appendBuildLog(_ text: String, serverName: String) {
+        do {
+            try logStore.append(text, serverName: serverName, kind: .build)
+        } catch {
+            // Build log capture is best effort only.
+        }
+    }
+
+    private func setBuildState(_ state: DaemonBuildState) {
+        buildStates[state.serverName] = state
     }
 
     private func setRuntimeState(
@@ -276,7 +478,8 @@ final class DaemonManager: ObservableObject {
             scriptPath: definition.scriptPath,
             status: status,
             pid: pid,
-            lastError: lastError
+            lastError: lastError,
+            logPath: logStore.logURL(for: definition.name, kind: .runtime).path
         )
         runtimeStates[definition.name] = next
 
@@ -305,17 +508,28 @@ final class DaemonManager: ObservableObject {
             scriptPath: definition.scriptPath,
             status: artifactExists ? .stopped : .notBuilt,
             pid: nil,
-            lastError: artifactExists ? nil : "Missing build artifact"
+            lastError: artifactExists ? nil : "Missing build artifact",
+            logPath: logStore.logURL(for: definition.name, kind: .runtime).path
         )
     }
 
-    private static func defaultRepoRoot() -> String {
+    private func defaultBuildState(for definition: MCPServerDefinition) -> DaemonBuildState {
+        DaemonBuildState(
+            serverName: definition.name,
+            status: .idle,
+            command: definition.buildCommandDescription,
+            logPath: logStore.logURL(for: definition.name, kind: .build).path,
+            lastOutput: "No build run recorded yet."
+        )
+    }
+
+    static func defaultRepoRoot() -> String {
         URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent() // Managers
-            .deletingLastPathComponent() // MojoShell
-            .deletingLastPathComponent() // Sources
-            .deletingLastPathComponent() // shell
-            .deletingLastPathComponent() // repo root
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
             .path
     }
 
@@ -327,5 +541,53 @@ final class DaemonManager: ObservableObject {
         return previous.status != next.status
             || previous.pid != next.pid
             || previous.lastError != next.lastError
+    }
+
+    private static func tailSnippet(_ text: String, fallback: String) -> String {
+        let lines = text
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .suffix(8)
+            .map(String.init)
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return lines.isEmpty ? fallback : lines
+    }
+
+    private static func defaultBuildOperation(_ definition: MCPServerDefinition) async throws -> DaemonBuildResult {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                let stdout = Pipe()
+                let stderr = Pipe()
+
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+                process.arguments = definition.buildCommand
+                process.currentDirectoryURL = URL(fileURLWithPath: definition.directoryPath)
+                process.standardOutput = stdout
+                process.standardError = stderr
+
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+
+                    let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+                    let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+                    let stdoutText = String(decoding: stdoutData, as: UTF8.self)
+                    let stderrText = String(decoding: stderrData, as: UTF8.self)
+                    let combined = [stdoutText, stderrText]
+                        .filter { !$0.isEmpty }
+                        .joined(separator: stdoutText.isEmpty || stderrText.isEmpty ? "" : "\n")
+
+                    continuation.resume(
+                        returning: DaemonBuildResult(
+                            output: combined,
+                            exitStatus: process.terminationStatus
+                        )
+                    )
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
 }

--- a/shell/Sources/MojoShell/Managers/MCPClient.swift
+++ b/shell/Sources/MojoShell/Managers/MCPClient.swift
@@ -57,7 +57,7 @@ actor MCPClient {
         self.stdoutHandle = stdout.fileHandleForReading
     }
 
-    func call(method: String, params: [String: AnyCodable] = [:]) throws -> MCPResponse {
+    func call(method: String, params: [String: AnyCodable] = [:]) async throws -> MCPResponse {
         let request = MCPRequest(id: nextID, method: method, params: params)
         nextID += 1
 
@@ -69,8 +69,8 @@ actor MCPClient {
         return try readResponse()
     }
 
-    func callTool(name: String, arguments: [String: AnyCodable] = [:]) throws -> MCPResponse {
-        try call(
+    func callTool(name: String, arguments: [String: AnyCodable] = [:]) async throws -> MCPResponse {
+        try await call(
             method: "tools/call",
             params: [
                 "name": .string(name),
@@ -102,6 +102,15 @@ actor MCPClient {
         }
 
         throw MCPClientError.decodingFailed(output)
+    }
+}
+
+extension MCPResponse {
+    var primaryTextContent: String? {
+        result?.content?
+            .compactMap(\.text)
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 

--- a/shell/Sources/MojoShell/Managers/MCPClient.swift
+++ b/shell/Sources/MojoShell/Managers/MCPClient.swift
@@ -105,6 +105,8 @@ actor MCPClient {
     }
 }
 
+extension MCPClient: MCPToolCalling {}
+
 extension MCPResponse {
     var primaryTextContent: String? {
         result?.content?
@@ -114,7 +116,7 @@ extension MCPResponse {
     }
 }
 
-enum AnyCodable: Codable, Equatable {
+enum AnyCodable: Codable, Equatable, Sendable {
     case string(String)
     case int(Int)
     case double(Double)
@@ -163,6 +165,27 @@ enum AnyCodable: Codable, Equatable {
             try container.encode(value)
         case .null:
             try container.encodeNil()
+        }
+    }
+
+    /// Bridge from arbitrary `JSONSerialization` output (Any) to a typed AnyCodable case.
+    /// Bool must precede Int/Double because Swift bridges NSNumber booleans to Bool first.
+    init(_ value: Any) {
+        switch value {
+        case let bool as Bool:
+            self = .bool(bool)
+        case let int as Int:
+            self = .int(int)
+        case let double as Double:
+            self = .double(double)
+        case let string as String:
+            self = .string(string)
+        case let object as [String: Any]:
+            self = .object(object.mapValues(AnyCodable.init))
+        case let array as [Any]:
+            self = .array(array.map(AnyCodable.init))
+        default:
+            self = .null
         }
     }
 }

--- a/shell/Sources/MojoShell/Managers/MCPClient.swift
+++ b/shell/Sources/MojoShell/Managers/MCPClient.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+struct MCPRequest: Encodable {
+    let jsonrpc = "2.0"
+    let id: Int
+    let method: String
+    let params: [String: AnyCodable]
+}
+
+struct MCPResponse: Decodable {
+    let jsonrpc: String
+    let id: Int?
+    let result: MCPResult?
+    let error: MCPError?
+}
+
+struct MCPResult: Decodable {
+    let tools: [MCPTool]?
+    let content: [MCPContent]?
+}
+
+struct MCPTool: Decodable, Equatable {
+    let name: String
+    let description: String
+}
+
+struct MCPContent: Decodable, Equatable {
+    let type: String
+    let text: String?
+}
+
+struct MCPError: Decodable, Equatable, Error {
+    let code: Int
+    let message: String
+}
+
+enum MCPClientError: Error {
+    case invalidProcessPipes
+    case emptyResponse
+    case decodingFailed(String)
+}
+
+actor MCPClient {
+    private let stdinHandle: FileHandle
+    private let stdoutHandle: FileHandle
+    private var nextID = 1
+
+    init(process: Process) throws {
+        guard
+            let stdin = process.standardInput as? Pipe,
+            let stdout = process.standardOutput as? Pipe
+        else {
+            throw MCPClientError.invalidProcessPipes
+        }
+
+        self.stdinHandle = stdin.fileHandleForWriting
+        self.stdoutHandle = stdout.fileHandleForReading
+    }
+
+    func call(method: String, params: [String: AnyCodable] = [:]) throws -> MCPResponse {
+        let request = MCPRequest(id: nextID, method: method, params: params)
+        nextID += 1
+
+        let data = try JSONEncoder().encode(request)
+        var payload = data
+        payload.append(0x0A)
+        stdinHandle.write(payload)
+
+        return try readResponse()
+    }
+
+    func callTool(name: String, arguments: [String: AnyCodable] = [:]) throws -> MCPResponse {
+        try call(
+            method: "tools/call",
+            params: [
+                "name": .string(name),
+                "arguments": .object(arguments),
+            ]
+        )
+    }
+
+    private func readResponse() throws -> MCPResponse {
+        let rawData = stdoutHandle.availableData
+        guard !rawData.isEmpty else {
+            throw MCPClientError.emptyResponse
+        }
+
+        let output = String(decoding: rawData, as: UTF8.self)
+        let lines = output
+            .split(separator: "\n")
+            .map(String.init)
+            .reversed()
+
+        for line in lines {
+            guard let lineData = line.data(using: .utf8) else {
+                continue
+            }
+
+            if let response = try? JSONDecoder().decode(MCPResponse.self, from: lineData) {
+                return response
+            }
+        }
+
+        throw MCPClientError.decodingFailed(output)
+    }
+}
+
+enum AnyCodable: Codable, Equatable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case object([String: AnyCodable])
+    case array([AnyCodable])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode([String: AnyCodable].self) {
+            self = .object(value)
+        } else if let value = try? container.decode([AnyCodable].self) {
+            self = .array(value)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON value")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+}

--- a/shell/Sources/MojoShell/Managers/MCPToolExecutor.swift
+++ b/shell/Sources/MojoShell/Managers/MCPToolExecutor.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol MCPToolCalling {
+protocol MCPToolCalling: Sendable {
     func callTool(name: String, arguments: [String: AnyCodable]) async throws -> MCPResponse
 }
 

--- a/shell/Sources/MojoShell/Managers/MCPToolExecutor.swift
+++ b/shell/Sources/MojoShell/Managers/MCPToolExecutor.swift
@@ -28,6 +28,14 @@ struct MCPToolExecutionResult: Equatable {
     let server: String
     let tool: String
     let text: String
+    let payload: AnyCodable?
+
+    init(server: String, tool: String, text: String, payload: AnyCodable? = nil) {
+        self.server = server
+        self.tool = tool
+        self.text = text
+        self.payload = payload
+    }
 }
 
 @MainActor

--- a/shell/Sources/MojoShell/Managers/MCPToolExecutor.swift
+++ b/shell/Sources/MojoShell/Managers/MCPToolExecutor.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+protocol MCPToolCalling {
+    func callTool(name: String, arguments: [String: AnyCodable]) async throws -> MCPResponse
+}
+
+enum MCPToolExecutionError: LocalizedError, Equatable {
+    case unknownServer(String)
+    case unavailableServer(String)
+    case invalidResponse(String)
+    case rpc(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unknownServer(let server):
+            return "Unknown MCP server: \(server)"
+        case .unavailableServer(let server):
+            return "MCP server is not running: \(server)"
+        case .invalidResponse(let detail):
+            return "Invalid MCP response: \(detail)"
+        case .rpc(let detail):
+            return "MCP tool error: \(detail)"
+        }
+    }
+}
+
+struct MCPToolExecutionResult: Equatable {
+    let server: String
+    let tool: String
+    let text: String
+}
+
+@MainActor
+final class MCPToolExecutor {
+    private let daemonManager: DaemonManager
+    private var liveClients: [String: MCPClient] = [:]
+    private let clientOverrides: [String: any MCPToolCalling]
+
+    init(
+        daemonManager: DaemonManager,
+        clientOverrides: [String: any MCPToolCalling] = [:]
+    ) {
+        self.daemonManager = daemonManager
+        self.clientOverrides = clientOverrides
+    }
+
+    func execute(_ resolvedTool: ResolvedTool) async throws -> MCPToolExecutionResult {
+        try await execute(
+            server: resolvedTool.server,
+            tool: resolvedTool.tool,
+            arguments: resolvedTool.arguments
+        )
+    }
+
+    func execute(
+        server: String,
+        tool: String,
+        arguments: [String: AnyCodable] = [:]
+    ) async throws -> MCPToolExecutionResult {
+        let client = try client(for: server)
+        let response = try await client.callTool(name: tool, arguments: arguments)
+
+        if let error = response.error {
+            throw MCPToolExecutionError.rpc(error.message)
+        }
+
+        guard let text = response.primaryTextContent, !text.isEmpty else {
+            throw MCPToolExecutionError.invalidResponse("\(server)/\(tool) returned no text content")
+        }
+
+        return MCPToolExecutionResult(server: server, tool: tool, text: text)
+    }
+
+    private func client(for server: String) throws -> any MCPToolCalling {
+        if let override = clientOverrides[server] {
+            return override
+        }
+
+        guard daemonManager.serverDefinitions.contains(where: { $0.name == server }) else {
+            throw MCPToolExecutionError.unknownServer(server)
+        }
+
+        if let cached = liveClients[server] {
+            return cached
+        }
+
+        guard let process = daemonManager.ensureProcess(for: server) else {
+            throw MCPToolExecutionError.unavailableServer(server)
+        }
+
+        let client = try MCPClient(process: process)
+        liveClients[server] = client
+        return client
+    }
+}

--- a/shell/Sources/MojoShell/Notifications/AppNotificationManager.swift
+++ b/shell/Sources/MojoShell/Notifications/AppNotificationManager.swift
@@ -1,0 +1,38 @@
+import Foundation
+import UserNotifications
+
+protocol AppNotifying: Sendable {
+    func deliver(title: String, body: String) async
+}
+
+actor AppNotificationManager: AppNotifying {
+    private var didRequestAuthorization = false
+
+    func deliver(title: String, body: String) async {
+        if !didRequestAuthorization {
+            _ = await requestAuthorization()
+        }
+
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: UUID().uuidString,
+            content: content,
+            trigger: nil
+        )
+
+        try? await UNUserNotificationCenter.current().add(request)
+    }
+
+    private func requestAuthorization() async -> Bool {
+        didRequestAuthorization = true
+        return (try? await UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .sound, .alert])) ?? false
+    }
+}
+
+actor NullNotificationManager: AppNotifying {
+    func deliver(title _: String, body _: String) async {}
+}

--- a/shell/Sources/MojoShell/Readiness/CoreIssuesBanner.swift
+++ b/shell/Sources/MojoShell/Readiness/CoreIssuesBanner.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct CoreIssuesBanner: View {
+    @EnvironmentObject private var readiness: ReadinessState
+    @State private var dismissed = false
+
+    private var blockingIssues: [ReadinessIssue] {
+        readiness.coreIssues.filter { $0.severity == .blocking }
+    }
+
+    private var warningCount: Int {
+        readiness.coreIssues.filter { $0.severity != .blocking }.count
+    }
+
+    var body: some View {
+        if dismissed || readiness.coreIssues.isEmpty {
+            EmptyView()
+        } else if !blockingIssues.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                    Text("Environment issues")
+                        .font(.headline)
+                    Spacer()
+                    Button("Dismiss") {
+                        dismissed = true
+                    }
+                    .buttonStyle(.plain)
+                    .font(.caption)
+                }
+
+                ForEach(blockingIssues) { issue in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(issue.title)
+                            .font(.caption.bold())
+                        Text(issue.fixInstruction)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        if let url = issue.actionURL {
+                            Link("Open Settings", destination: url)
+                                .font(.caption)
+                        }
+                    }
+                }
+            }
+            .padding(12)
+            .background(.red.opacity(0.08))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(.red.opacity(0.3), lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .padding(.horizontal)
+            .padding(.top, 8)
+        } else {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(.orange)
+                    .frame(width: 8, height: 8)
+                Text("\(warningCount) environment warning\(warningCount == 1 ? "" : "s")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Dismiss") {
+                    dismissed = true
+                }
+                .buttonStyle(.plain)
+                .font(.caption)
+            }
+            .padding(.horizontal)
+            .padding(.top, 8)
+        }
+    }
+}

--- a/shell/Sources/MojoShell/Readiness/FirstRunSheet.swift
+++ b/shell/Sources/MojoShell/Readiness/FirstRunSheet.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+struct FirstRunSheet: View {
+    @EnvironmentObject private var readiness: ReadinessState
+
+    private var groupedIssues: [(title: String, issues: [ReadinessIssue])] {
+        [
+            ("Blocking", allIssues.filter { $0.severity == .blocking }),
+            ("Warnings", allIssues.filter { $0.severity == .warning }),
+            ("Info", allIssues.filter { $0.severity == .info }),
+        ].filter { !$0.issues.isEmpty }
+    }
+
+    private var allIssues: [ReadinessIssue] {
+        let issues = readiness.coreIssues + readiness.featureIssues.values.flatMap { $0 }
+        return issues.sorted { lhs, rhs in
+            let leftPriority = severityPriority(lhs.severity)
+            let rightPriority = severityPriority(rhs.severity)
+            return leftPriority == rightPriority ? lhs.id < rhs.id : leftPriority < rightPriority
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label("MojoShell Setup", systemImage: "wrench.and.screwdriver")
+                .font(.title2.bold())
+
+            Text("Some environment requirements need attention. Fix them now or continue anyway.")
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    ForEach(groupedIssues, id: \.title) { group in
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text(group.title)
+                                .font(.headline)
+                            ForEach(group.issues) { issue in
+                                HStack(alignment: .top, spacing: 10) {
+                                    Image(systemName: icon(for: issue.severity))
+                                        .foregroundStyle(color(for: issue.severity))
+                                        .frame(width: 20)
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(issue.title)
+                                            .font(.callout.bold())
+                                        Text(issue.fixInstruction)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                        if let url = issue.actionURL {
+                                            Link("Open System Settings", destination: url)
+                                                .font(.caption)
+                                        }
+                                    }
+                                    Spacer()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Divider()
+
+            HStack {
+                Button("Retry") {
+                    Task { await readiness.refresh() }
+                }
+                Spacer()
+                Button("Continue Anyway") {
+                    readiness.markFirstRunShown()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 480, minHeight: 320)
+    }
+
+    private func severityPriority(_ severity: ReadinessSeverity) -> Int {
+        switch severity {
+        case .blocking:
+            return 0
+        case .warning:
+            return 1
+        case .info:
+            return 2
+        }
+    }
+
+    private func icon(for severity: ReadinessSeverity) -> String {
+        switch severity {
+        case .blocking:
+            return "xmark.circle.fill"
+        case .warning:
+            return "exclamationmark.triangle.fill"
+        case .info:
+            return "info.circle"
+        }
+    }
+
+    private func color(for severity: ReadinessSeverity) -> Color {
+        switch severity {
+        case .blocking:
+            return .red
+        case .warning:
+            return .orange
+        case .info:
+            return .blue
+        }
+    }
+}

--- a/shell/Sources/MojoShell/Readiness/ReadinessModels.swift
+++ b/shell/Sources/MojoShell/Readiness/ReadinessModels.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum ReadinessSeverity: Equatable, Sendable {
+    case info
+    case warning
+    case blocking
+}
+
+struct ReadinessIssue: Identifiable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let fixInstruction: String
+    let actionURL: URL?
+    let severity: ReadinessSeverity
+}
+
+enum ReadinessFeature: String, Hashable, Sendable {
+    case computerUse
+    case llm
+}

--- a/shell/Sources/MojoShell/Readiness/ReadinessState.swift
+++ b/shell/Sources/MojoShell/Readiness/ReadinessState.swift
@@ -1,0 +1,210 @@
+import ApplicationServices
+import Combine
+import CoreGraphics
+import Foundation
+
+@MainActor
+final class ReadinessState: ObservableObject {
+    @Published var coreIssues: [ReadinessIssue] = []
+    @Published var featureIssues: [ReadinessFeature: [ReadinessIssue]] = [:]
+    @Published var showFirstRunSheet = false
+    @Published var isRefreshing = false
+
+    private let daemonManager: DaemonManager
+    private let defaults: UserDefaults
+    private let environment: [String: String]
+    private let axCheck: @Sendable () -> Bool
+    private let screenRecordingCheck: @Sendable () -> Bool
+
+    init(
+        daemonManager: DaemonManager,
+        defaults: UserDefaults = .standard,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        axCheck: @escaping @Sendable () -> Bool = { AXIsProcessTrusted() },
+        screenRecordingCheck: @escaping @Sendable () -> Bool = { CGPreflightScreenCaptureAccess() }
+    ) {
+        self.daemonManager = daemonManager
+        self.defaults = defaults
+        self.environment = environment
+        self.axCheck = axCheck
+        self.screenRecordingCheck = screenRecordingCheck
+    }
+
+    func refresh() async {
+        isRefreshing = true
+        defer { isRefreshing = false }
+
+        coreIssues = sortedIssues(buildCoreIssues())
+        featureIssues = [
+            .computerUse: sortedIssues(buildComputerUseIssues()),
+            .llm: sortedIssues(buildLLMIssues()),
+        ]
+
+        let hasAnyIssue = !coreIssues.isEmpty || featureIssues.values.contains(where: { !$0.isEmpty })
+        if hasAnyIssue && !defaults.bool(forKey: Self.firstRunShownKey) {
+            showFirstRunSheet = true
+        }
+    }
+
+    func refreshComputerUse() async {
+        isRefreshing = true
+        defer { isRefreshing = false }
+        featureIssues[.computerUse] = sortedIssues(buildComputerUseIssues())
+    }
+
+    func isReady(for feature: ReadinessFeature) -> Bool {
+        !(featureIssues[feature] ?? []).contains { $0.severity == .blocking }
+    }
+
+    func blockingIssue(for feature: ReadinessFeature) -> ReadinessIssue? {
+        (featureIssues[feature] ?? []).first { $0.severity == .blocking }
+    }
+
+    func axPermissionGranted() -> Bool {
+        axCheck()
+    }
+
+    func markFirstRunShown() {
+        defaults.set(true, forKey: Self.firstRunShownKey)
+        showFirstRunSheet = false
+    }
+
+    private func buildCoreIssues() -> [ReadinessIssue] {
+        var issues: [ReadinessIssue] = []
+
+        var isDirectory = ObjCBool(false)
+        let repoRootExists = FileManager.default.fileExists(
+            atPath: daemonManager.repoRoot,
+            isDirectory: &isDirectory
+        ) && isDirectory.boolValue
+        if !repoRootExists {
+            issues.append(
+                ReadinessIssue(
+                    id: "repo_root",
+                    title: "Repository root not found",
+                    fixInstruction: "Ensure the MojoShell repository is present at: \(daemonManager.repoRoot)",
+                    actionURL: nil,
+                    severity: .blocking
+                )
+            )
+        }
+
+        let brainPath = resolvedBrainPath()
+        if !FileManager.default.fileExists(atPath: brainPath) {
+            issues.append(
+                ReadinessIssue(
+                    id: "brain_file",
+                    title: "Brain file missing",
+                    fixInstruction: "Ensure the brain file exists at: \(brainPath)",
+                    actionURL: nil,
+                    severity: .blocking
+                )
+            )
+        }
+
+        let missingArtifacts = daemonManager.serverDefinitions.filter { !FileManager.default.fileExists(atPath: $0.scriptPath) }
+        if !missingArtifacts.isEmpty {
+            let names = missingArtifacts.map(\.name).joined(separator: ", ")
+            issues.append(
+                ReadinessIssue(
+                    id: "daemon_artifacts",
+                    title: "MCP server build artifacts missing",
+                    fixInstruction: "Run the server builds so each `build/index.js` exists. Missing: \(names)",
+                    actionURL: nil,
+                    severity: .warning
+                )
+            )
+        }
+
+        return issues
+    }
+
+    private func buildComputerUseIssues() -> [ReadinessIssue] {
+        var issues: [ReadinessIssue] = []
+
+        if !axCheck() {
+            issues.append(
+                ReadinessIssue(
+                    id: "accessibility",
+                    title: "Accessibility permission missing",
+                    fixInstruction: "Open System Settings -> Privacy & Security -> Accessibility, then enable MojoShell.",
+                    actionURL: URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"),
+                    severity: .blocking
+                )
+            )
+        }
+
+        if !screenRecordingCheck() {
+            issues.append(
+                ReadinessIssue(
+                    id: "screen_recording",
+                    title: "Screen Recording permission missing",
+                    fixInstruction: "Open System Settings -> Privacy & Security -> Screen Recording, then enable MojoShell.",
+                    actionURL: URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"),
+                    severity: .warning
+                )
+            )
+        }
+
+        return issues
+    }
+
+    private func buildLLMIssues() -> [ReadinessIssue] {
+        let hasAnthropic = !(environment["ANTHROPIC_API_KEY"] ?? "").isEmpty
+        let hasOpenAI = !(environment["OPENAI_API_KEY"] ?? "").isEmpty
+
+        if !hasAnthropic && !hasOpenAI {
+            return [
+                ReadinessIssue(
+                    id: "llm_no_keys",
+                    title: "No LLM API keys configured",
+                    fixInstruction: "Set ANTHROPIC_API_KEY or OPENAI_API_KEY in your environment.",
+                    actionURL: nil,
+                    severity: .blocking
+                ),
+            ]
+        }
+
+        if hasAnthropic != hasOpenAI {
+            return [
+                ReadinessIssue(
+                    id: "llm_single_provider",
+                    title: "Only one LLM provider configured",
+                    fixInstruction: "Optional: set both ANTHROPIC_API_KEY and OPENAI_API_KEY for fallback redundancy.",
+                    actionURL: nil,
+                    severity: .info
+                ),
+            ]
+        }
+
+        return []
+    }
+
+    private func resolvedBrainPath() -> String {
+        if let override = environment["BRAIN_PATH"], !override.isEmpty {
+            return override
+        }
+        return "\(daemonManager.repoRoot)/knowledge-corpus/data/mojosolo_operating_brain.json"
+    }
+
+    private func sortedIssues(_ issues: [ReadinessIssue]) -> [ReadinessIssue] {
+        issues.sorted { lhs, rhs in
+            let leftPriority = severityPriority(lhs.severity)
+            let rightPriority = severityPriority(rhs.severity)
+            return leftPriority == rightPriority ? lhs.id < rhs.id : leftPriority < rightPriority
+        }
+    }
+
+    private func severityPriority(_ severity: ReadinessSeverity) -> Int {
+        switch severity {
+        case .blocking:
+            return 0
+        case .warning:
+            return 1
+        case .info:
+            return 2
+        }
+    }
+
+    private static let firstRunShownKey = "readiness.firstRunShown"
+}

--- a/shell/Sources/MojoShell/Readiness/ReadinessState.swift
+++ b/shell/Sources/MojoShell/Readiness/ReadinessState.swift
@@ -13,6 +13,7 @@ final class ReadinessState: ObservableObject {
     private let daemonManager: DaemonManager
     private let defaults: UserDefaults
     private let environment: [String: String]
+    private let brainPathProvider: @MainActor () -> String?
     private let axCheck: @Sendable () -> Bool
     private let screenRecordingCheck: @Sendable () -> Bool
 
@@ -20,12 +21,14 @@ final class ReadinessState: ObservableObject {
         daemonManager: DaemonManager,
         defaults: UserDefaults = .standard,
         environment: [String: String] = ProcessInfo.processInfo.environment,
+        brainPathProvider: @escaping @MainActor () -> String? = { nil },
         axCheck: @escaping @Sendable () -> Bool = { AXIsProcessTrusted() },
         screenRecordingCheck: @escaping @Sendable () -> Bool = { CGPreflightScreenCaptureAccess() }
     ) {
         self.daemonManager = daemonManager
         self.defaults = defaults
         self.environment = environment
+        self.brainPathProvider = brainPathProvider
         self.axCheck = axCheck
         self.screenRecordingCheck = screenRecordingCheck
     }
@@ -181,6 +184,9 @@ final class ReadinessState: ObservableObject {
     }
 
     private func resolvedBrainPath() -> String {
+        if let provided = brainPathProvider()?.trimmingCharacters(in: .whitespacesAndNewlines), !provided.isEmpty {
+            return provided
+        }
         if let override = environment["BRAIN_PATH"], !override.isEmpty {
             return override
         }

--- a/shell/Sources/MojoShell/Router/DeterministicRouter.swift
+++ b/shell/Sources/MojoShell/Router/DeterministicRouter.swift
@@ -156,6 +156,22 @@ struct DeterministicRouter {
             )
         ),
         Rule(
+            phrases: ["open finder selection in preview", "preview finder selection"],
+            resolvedTool: ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderSelectionOpenInPreview.rawValue,
+                arguments: [:]
+            )
+        ),
+        Rule(
+            phrases: ["open finder selection in photos", "photos finder selection"],
+            resolvedTool: ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderSelectionOpenInPhotos.rawValue,
+                arguments: [:]
+            )
+        ),
+        Rule(
             phrases: ["finder selection", "what is selected in finder", "what's selected in finder"],
             resolvedTool: ResolvedTool(
                 server: NativeToolExecutor.serverName,
@@ -168,6 +184,22 @@ struct DeterministicRouter {
             resolvedTool: ResolvedTool(
                 server: NativeToolExecutor.serverName,
                 tool: NativeToolName.safariCurrentTab.rawValue,
+                arguments: [:]
+            )
+        ),
+        Rule(
+            phrases: ["open repo in terminal", "open terminal in repo", "open repo terminal"],
+            resolvedTool: ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.terminalOpenRepo.rawValue,
+                arguments: [:]
+            )
+        ),
+        Rule(
+            phrases: ["open repo in iterm", "open iterm in repo", "open repo iterm"],
+            resolvedTool: ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.itermOpenRepo.rawValue,
                 arguments: [:]
             )
         ),
@@ -248,6 +280,16 @@ struct DeterministicRouter {
                 description: "Run a named shortcut. Arguments: {name, input?}",
                 server: NativeToolExecutor.serverName
             ),
+            LLMToolDefinition(
+                name: NativeToolName.terminalRunCommand.rawValue,
+                description: "Run a shell command in Terminal. Arguments: {command, path?}",
+                server: NativeToolExecutor.serverName
+            ),
+            LLMToolDefinition(
+                name: NativeToolName.itermRunCommand.rawValue,
+                description: "Run a shell command in iTerm. Arguments: {command, path?}",
+                server: NativeToolExecutor.serverName
+            ),
         ]
     }
 
@@ -300,7 +342,44 @@ struct DeterministicRouter {
             }
         }
 
+        if let route = shellRunRoute(
+            raw: raw,
+            normalized: normalized,
+            suffix: " in terminal",
+            tool: NativeToolName.terminalRunCommand.rawValue
+        ) {
+            return route
+        }
+
+        if let route = shellRunRoute(
+            raw: raw,
+            normalized: normalized,
+            suffix: " in iterm",
+            tool: NativeToolName.itermRunCommand.rawValue
+        ) {
+            return route
+        }
+
         return nil
+    }
+
+    private func shellRunRoute(raw: String, normalized: String, suffix: String, tool: String) -> ResolvedTool? {
+        guard normalized.hasPrefix("run "), normalized.hasSuffix(suffix) else {
+            return nil
+        }
+
+        let start = raw.index(raw.startIndex, offsetBy: 4)
+        let end = raw.index(raw.endIndex, offsetBy: -suffix.count)
+        let command = String(raw[start..<end]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !command.isEmpty else {
+            return nil
+        }
+
+        return ResolvedTool(
+            server: NativeToolExecutor.serverName,
+            tool: tool,
+            arguments: ["command": .string(command)]
+        )
     }
 
     private func safariURL(from target: String) -> String? {

--- a/shell/Sources/MojoShell/Router/DeterministicRouter.swift
+++ b/shell/Sources/MojoShell/Router/DeterministicRouter.swift
@@ -125,6 +125,21 @@ struct DeterministicRouter {
         ),
     ]
 
+    var availableTools: [LLMToolDefinition] {
+        var seen = Set<String>()
+        var tools: [LLMToolDefinition] = []
+        for rule in rules {
+            let key = "\(rule.resolvedTool.server)/\(rule.resolvedTool.tool)"
+            guard seen.insert(key).inserted else { continue }
+            tools.append(LLMToolDefinition(
+                name: rule.resolvedTool.tool,
+                description: rule.phrases.first ?? rule.resolvedTool.tool,
+                server: rule.resolvedTool.server
+            ))
+        }
+        return tools
+    }
+
     func route(_ input: String) -> ResolvedTool? {
         let normalized = input
             .lowercased()

--- a/shell/Sources/MojoShell/Router/DeterministicRouter.swift
+++ b/shell/Sources/MojoShell/Router/DeterministicRouter.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+struct DeterministicRouter {
+    private struct Rule {
+        let phrases: [String]
+        let resolvedTool: ResolvedTool
+    }
+
+    private let rules: [Rule] = [
+        Rule(
+            phrases: ["scan today's inboxes", "scan inboxes", "scan my inboxes", "scan inbox", "daily intel scan"],
+            resolvedTool: ResolvedTool(server: "mail-intelligence", tool: "scan_persona_inboxes", arguments: [:])
+        ),
+        Rule(
+            phrases: ["persona map", "show personas", "inbox personas"],
+            resolvedTool: ResolvedTool(server: "mail-intelligence", tool: "get_persona_map", arguments: [:])
+        ),
+        Rule(
+            phrases: ["signal trends", "signal trend", "compare inbox trends"],
+            resolvedTool: ResolvedTool(server: "mail-intelligence", tool: "analyze_signal_trends", arguments: [:])
+        ),
+        Rule(
+            phrases: ["daily brief", "generate brief", "generate daily intel"],
+            resolvedTool: ResolvedTool(server: "mail-intelligence", tool: "generate_daily_brief", arguments: [:])
+        ),
+        Rule(
+            phrases: ["pause the music", "pause music", "stop music"],
+            resolvedTool: ResolvedTool(server: "apple-music", tool: "pause", arguments: [:])
+        ),
+        Rule(
+            phrases: ["play music", "resume music", "start music"],
+            resolvedTool: ResolvedTool(server: "apple-music", tool: "play", arguments: [:])
+        ),
+        Rule(
+            phrases: ["next track", "next song", "skip track"],
+            resolvedTool: ResolvedTool(server: "apple-music", tool: "next_track", arguments: [:])
+        ),
+        Rule(
+            phrases: ["previous track", "previous song"],
+            resolvedTool: ResolvedTool(server: "apple-music", tool: "previous_track", arguments: [:])
+        ),
+        Rule(
+            phrases: ["now playing", "what's playing", "current track"],
+            resolvedTool: ResolvedTool(server: "apple-music", tool: "now_playing", arguments: [:])
+        ),
+        Rule(
+            phrases: ["create note", "new note"],
+            resolvedTool: ResolvedTool(server: "apple-notes", tool: "create_note", arguments: [:])
+        ),
+        Rule(
+            phrases: ["search notes", "find note"],
+            resolvedTool: ResolvedTool(server: "apple-notes", tool: "search_notes", arguments: [:])
+        ),
+        Rule(
+            phrases: ["list notes", "show my notes"],
+            resolvedTool: ResolvedTool(server: "apple-notes", tool: "list_notes", arguments: [:])
+        ),
+        Rule(
+            phrases: ["today's events", "calendar today", "my schedule", "what's on my calendar"],
+            resolvedTool: ResolvedTool(server: "apple-calendar", tool: "list_all_events", arguments: [:])
+        ),
+        Rule(
+            phrases: ["create event", "new event", "schedule meeting"],
+            resolvedTool: ResolvedTool(server: "apple-calendar", tool: "create_event", arguments: [:])
+        ),
+        Rule(
+            phrases: ["remind me", "add reminder", "create reminder"],
+            resolvedTool: ResolvedTool(server: "apple-reminders", tool: "create_reminder", arguments: [:])
+        ),
+        Rule(
+            phrases: ["my reminders", "list reminders"],
+            resolvedTool: ResolvedTool(server: "apple-reminders", tool: "list_reminders", arguments: [:])
+        ),
+        Rule(
+            phrases: ["search contacts", "find contact"],
+            resolvedTool: ResolvedTool(server: "apple-contacts", tool: "search_contacts", arguments: [:])
+        ),
+        Rule(
+            phrases: ["list contacts", "show contacts"],
+            resolvedTool: ResolvedTool(server: "apple-contacts", tool: "list_contacts", arguments: [:])
+        ),
+        Rule(
+            phrases: ["search messages", "find message"],
+            resolvedTool: ResolvedTool(server: "apple-messages", tool: "search_messages", arguments: [:])
+        ),
+        Rule(
+            phrases: ["list chats", "show my chats"],
+            resolvedTool: ResolvedTool(server: "apple-messages", tool: "list_chats", arguments: [:])
+        ),
+        Rule(
+            phrases: ["search location", "find place", "find location"],
+            resolvedTool: ResolvedTool(server: "apple-maps", tool: "search_location", arguments: [:])
+        ),
+        Rule(
+            phrases: ["get directions", "directions to"],
+            resolvedTool: ResolvedTool(server: "apple-maps", tool: "get_directions", arguments: [:])
+        ),
+        Rule(
+            phrases: ["list messages", "show my email", "show unread mail"],
+            resolvedTool: ResolvedTool(server: "apple-mail", tool: "list_messages", arguments: [:])
+        ),
+        Rule(
+            phrases: ["search email", "search mail"],
+            resolvedTool: ResolvedTool(server: "apple-mail", tool: "search_messages", arguments: [:])
+        ),
+        Rule(
+            phrases: ["unread count", "how many unread emails"],
+            resolvedTool: ResolvedTool(server: "apple-mail", tool: "get_unread_count", arguments: [:])
+        ),
+        Rule(
+            phrases: ["operator rules", "persona rules", "brain rules"],
+            resolvedTool: ResolvedTool(
+                server: "knowledge-corpus",
+                tool: "get_corpus_section",
+                arguments: ["section": .string("persona_architecture")]
+            )
+        ),
+        Rule(
+            phrases: ["search brain", "search corpus"],
+            resolvedTool: ResolvedTool(server: "knowledge-corpus", tool: "search_corpus", arguments: [:])
+        ),
+        Rule(
+            phrases: ["laravel blueprint", "brain blueprint"],
+            resolvedTool: ResolvedTool(server: "knowledge-corpus", tool: "get_laravel_brain_blueprint", arguments: [:])
+        ),
+    ]
+
+    func route(_ input: String) -> ResolvedTool? {
+        let normalized = input
+            .lowercased()
+            .replacingOccurrences(of: "’", with: "'")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !normalized.contains("fcp"), !normalized.contains("final cut"), !normalized.contains("motion") else {
+            return nil
+        }
+
+        return rules.first(where: { rule in
+            rule.phrases.contains(where: { normalized.contains($0) })
+        })?.resolvedTool
+    }
+}

--- a/shell/Sources/MojoShell/Router/DeterministicRouter.swift
+++ b/shell/Sources/MojoShell/Router/DeterministicRouter.swift
@@ -123,6 +123,78 @@ struct DeterministicRouter {
             phrases: ["laravel blueprint", "brain blueprint"],
             resolvedTool: ResolvedTool(server: "knowledge-corpus", tool: "get_laravel_brain_blueprint", arguments: [:])
         ),
+        Rule(
+            phrases: ["open downloads folder", "show downloads"],
+            resolvedTool: ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderOpenPath.rawValue,
+                arguments: ["path": .string("~/Downloads")]
+            )
+        ),
+        Rule(
+            phrases: ["open desktop folder", "show desktop folder"],
+            resolvedTool: ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderOpenPath.rawValue,
+                arguments: ["path": .string("~/Desktop")]
+            )
+        ),
+        Rule(
+            phrases: ["open repo folder", "open repo in finder", "show repo folder"],
+            resolvedTool: ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderOpenRepoRoot.rawValue,
+                arguments: [:]
+            )
+        ),
+        Rule(
+            phrases: ["reveal brain file", "show brain file"],
+            resolvedTool: ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderRevealBrainFile.rawValue,
+                arguments: [:]
+            )
+        ),
+        Rule(
+            phrases: ["finder selection", "what is selected in finder", "what's selected in finder"],
+            resolvedTool: ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderListSelection.rawValue,
+                arguments: [:]
+            )
+        ),
+        Rule(
+            phrases: ["current safari tab", "what's the current safari tab", "what is the current safari tab"],
+            resolvedTool: ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.safariCurrentTab.rawValue,
+                arguments: [:]
+            )
+        ),
+        Rule(
+            phrases: ["list shortcuts", "show shortcuts"],
+            resolvedTool: ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.shortcutsList.rawValue,
+                arguments: [:]
+            )
+        ),
+        Rule(
+            phrases: ["open accessibility settings"],
+            resolvedTool: ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.systemSettingsOpen.rawValue,
+                arguments: ["pane": .string("accessibility")]
+            )
+        ),
+        Rule(
+            phrases: ["open screen recording settings"],
+            resolvedTool: ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.systemSettingsOpen.rawValue,
+                arguments: ["pane": .string("screen_recording")]
+            )
+        ),
     ]
 
     var availableTools: [LLMToolDefinition] {
@@ -137,14 +209,23 @@ struct DeterministicRouter {
                 server: rule.resolvedTool.server
             ))
         }
+        tools.append(contentsOf: dynamicToolDefinitions.filter {
+            seen.insert("\($0.server)/\($0.name)").inserted
+        })
         return tools
     }
 
     func route(_ input: String) -> ResolvedTool? {
-        let normalized = input
-            .lowercased()
+        let raw = input
             .replacingOccurrences(of: "’", with: "'")
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = raw
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let dynamicRoute = dynamicRoute(raw: raw, normalized: normalized) {
+            return dynamicRoute
+        }
 
         guard !normalized.contains("fcp"), !normalized.contains("final cut"), !normalized.contains("motion") else {
             return nil
@@ -153,5 +234,93 @@ struct DeterministicRouter {
         return rules.first(where: { rule in
             rule.phrases.contains(where: { normalized.contains($0) })
         })?.resolvedTool
+    }
+
+    private var dynamicToolDefinitions: [LLMToolDefinition] {
+        [
+            LLMToolDefinition(
+                name: NativeToolName.safariOpenURL.rawValue,
+                description: "Open a URL in Safari. Arguments: {url}",
+                server: NativeToolExecutor.serverName
+            ),
+            LLMToolDefinition(
+                name: NativeToolName.shortcutsRun.rawValue,
+                description: "Run a named shortcut. Arguments: {name, input?}",
+                server: NativeToolExecutor.serverName
+            ),
+        ]
+    }
+
+    private func dynamicRoute(raw: String, normalized: String) -> ResolvedTool? {
+        if normalized.hasPrefix("open "), normalized.hasSuffix(" in safari") {
+            let start = raw.index(raw.startIndex, offsetBy: 5)
+            let end = raw.index(raw.endIndex, offsetBy: -10)
+            let target = String(raw[start..<end]).trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if let url = safariURL(from: target) {
+                return ResolvedTool(
+                    server: NativeToolExecutor.serverName,
+                    tool: NativeToolName.safariOpenURL.rawValue,
+                    arguments: ["url": .string(url)]
+                )
+            }
+        }
+
+        if normalized.hasPrefix("run shortcut ") {
+            let prefixCount = "run shortcut ".count
+            let rawRemainder = String(raw.dropFirst(prefixCount)).trimmingCharacters(in: .whitespacesAndNewlines)
+            let lowerRemainder = String(normalized.dropFirst(prefixCount)).trimmingCharacters(in: .whitespacesAndNewlines)
+            let delimiter = " with input "
+
+            if let range = lowerRemainder.range(of: delimiter) {
+                let lowerName = lowerRemainder[..<range.lowerBound]
+                let nameEndDistance = lowerRemainder.distance(from: lowerRemainder.startIndex, to: lowerName.endIndex)
+                let rawNameEnd = rawRemainder.index(rawRemainder.startIndex, offsetBy: nameEndDistance)
+                let name = String(rawRemainder[..<rawNameEnd]).trimmingCharacters(in: .whitespacesAndNewlines)
+                let inputStart = rawRemainder.index(rawNameEnd, offsetBy: delimiter.count)
+                let input = String(rawRemainder[inputStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
+
+                if !name.isEmpty {
+                    var arguments: [String: AnyCodable] = ["name": .string(name)]
+                    if !input.isEmpty {
+                        arguments["input"] = .string(input)
+                    }
+                    return ResolvedTool(
+                        server: NativeToolExecutor.serverName,
+                        tool: NativeToolName.shortcutsRun.rawValue,
+                        arguments: arguments
+                    )
+                }
+            } else if !rawRemainder.isEmpty {
+                return ResolvedTool(
+                    server: NativeToolExecutor.serverName,
+                    tool: NativeToolName.shortcutsRun.rawValue,
+                    arguments: ["name": .string(rawRemainder)]
+                )
+            }
+        }
+
+        return nil
+    }
+
+    private func safariURL(from target: String) -> String? {
+        let trimmed = target.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        if trimmed.lowercased().hasPrefix("http://") || trimmed.lowercased().hasPrefix("https://") {
+            return trimmed
+        }
+
+        guard !trimmed.contains(" ") else {
+            return nil
+        }
+
+        guard trimmed.contains(".") else {
+            return nil
+        }
+
+        return "https://\(trimmed)"
     }
 }

--- a/shell/Sources/MojoShell/Router/Intent.swift
+++ b/shell/Sources/MojoShell/Router/Intent.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ResolvedTool: Equatable {
+struct ResolvedTool: Equatable, Sendable {
     let server: String
     let tool: String
     let arguments: [String: AnyCodable]

--- a/shell/Sources/MojoShell/Router/Intent.swift
+++ b/shell/Sources/MojoShell/Router/Intent.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct ResolvedTool: Equatable {
+    let server: String
+    let tool: String
+    let arguments: [String: AnyCodable]
+}
+
+struct Intent: Equatable {
+    let raw: String
+    let resolved: ResolvedTool?
+}

--- a/shell/Sources/MojoShell/Views/AgentTerminalView.swift
+++ b/shell/Sources/MojoShell/Views/AgentTerminalView.swift
@@ -89,8 +89,17 @@ struct AgentTerminalView: View {
                 history.append(TerminalEntry(role: .agent, text: "Error: \(error.localizedDescription)"))
             }
         } else {
-            history.append(TerminalEntry(role: .system, text: "→ escalating to Claude..."))
-            history.append(TerminalEntry(role: .agent, text: "LLM routing is not yet wired. Set ANTHROPIC_API_KEY and connect ClaudeProvider in the next integration slice."))
+            history.append(TerminalEntry(role: .system, text: "→ escalating to Claude (\(appState.llmProviderName))..."))
+            let result = await appState.resolveWithLLM(
+                prompt: command,
+                availableTools: deterministicRouter.availableTools
+            )
+            switch result {
+            case .success(let text):
+                history.append(TerminalEntry(role: .agent, text: text))
+            case .failure(let error):
+                history.append(TerminalEntry(role: .agent, text: "LLM error: \(error.localizedDescription)"))
+            }
         }
 
         isProcessing = false

--- a/shell/Sources/MojoShell/Views/AgentTerminalView.swift
+++ b/shell/Sources/MojoShell/Views/AgentTerminalView.swift
@@ -14,6 +14,7 @@ struct TerminalEntry: Identifiable, Equatable {
 }
 
 struct AgentTerminalView: View {
+    @EnvironmentObject private var appState: AppState
     @State private var input = ""
     @State private var history: [TerminalEntry] = [
         TerminalEntry(role: .system, text: "MojoShell Agent Terminal ready. Type a command.")
@@ -80,7 +81,13 @@ struct AgentTerminalView: View {
 
         if let tool = deterministicRouter.route(command) {
             history.append(TerminalEntry(role: .system, text: "→ deterministic route: \(tool.server)/\(tool.tool)"))
-            history.append(TerminalEntry(role: .agent, text: "Routed to \(tool.tool) on \(tool.server). MCP execution is not wired into the terminal yet."))
+            let result = await appState.execute(tool)
+            switch result {
+            case .success(let output):
+                history.append(TerminalEntry(role: .agent, text: output.text))
+            case .failure(let error):
+                history.append(TerminalEntry(role: .agent, text: "Error: \(error.localizedDescription)"))
+            }
         } else {
             history.append(TerminalEntry(role: .system, text: "→ escalating to Claude..."))
             history.append(TerminalEntry(role: .agent, text: "LLM routing is not yet wired. Set ANTHROPIC_API_KEY and connect ClaudeProvider in the next integration slice."))

--- a/shell/Sources/MojoShell/Views/AgentTerminalView.swift
+++ b/shell/Sources/MojoShell/Views/AgentTerminalView.swift
@@ -89,7 +89,7 @@ struct AgentTerminalView: View {
                 history.append(TerminalEntry(role: .agent, text: "Error: \(error.localizedDescription)"))
             }
         } else {
-            history.append(TerminalEntry(role: .system, text: "→ escalating to Claude (\(appState.llmProviderName))..."))
+            history.append(TerminalEntry(role: .system, text: "→ escalating to LLM stack (\(appState.llmProviderStackDescription))..."))
             let result = await appState.resolveWithLLM(
                 prompt: command,
                 availableTools: deterministicRouter.availableTools

--- a/shell/Sources/MojoShell/Views/AgentTerminalView.swift
+++ b/shell/Sources/MojoShell/Views/AgentTerminalView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+struct TerminalEntry: Identifiable, Equatable {
+    let id = UUID()
+    let role: Role
+    let text: String
+    let timestamp = Date()
+
+    enum Role: Equatable {
+        case user
+        case agent
+        case system
+    }
+}
+
+struct AgentTerminalView: View {
+    @State private var input = ""
+    @State private var history: [TerminalEntry] = [
+        TerminalEntry(role: .system, text: "MojoShell Agent Terminal ready. Type a command.")
+    ]
+    @State private var isProcessing = false
+
+    private let deterministicRouter = DeterministicRouter()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 6) {
+                        ForEach(history) { entry in
+                            TerminalEntryRow(entry: entry)
+                                .id(entry.id)
+                        }
+                    }
+                    .padding()
+                }
+                .onChange(of: history.count) { _, _ in
+                    if let id = history.last?.id {
+                        proxy.scrollTo(id, anchor: .bottom)
+                    }
+                }
+            }
+
+            Divider()
+
+            HStack {
+                TextField("Type a command...", text: $input)
+                    .font(.system(.body, design: .monospaced))
+                    .textFieldStyle(.plain)
+                    .onSubmit {
+                        Task {
+                            await submit()
+                        }
+                    }
+                    .disabled(isProcessing)
+
+                Button(isProcessing ? "..." : "↵") {
+                    Task {
+                        await submit()
+                    }
+                }
+                .disabled(input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isProcessing)
+                .keyboardShortcut(.return, modifiers: [])
+            }
+            .padding(10)
+            .background(.background)
+        }
+        .navigationTitle("Agent Terminal")
+    }
+
+    private func submit() async {
+        let command = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !command.isEmpty else {
+            return
+        }
+
+        input = ""
+        isProcessing = true
+        history.append(TerminalEntry(role: .user, text: command))
+
+        if let tool = deterministicRouter.route(command) {
+            history.append(TerminalEntry(role: .system, text: "→ deterministic route: \(tool.server)/\(tool.tool)"))
+            history.append(TerminalEntry(role: .agent, text: "Routed to \(tool.tool) on \(tool.server). MCP execution is not wired into the terminal yet."))
+        } else {
+            history.append(TerminalEntry(role: .system, text: "→ escalating to Claude..."))
+            history.append(TerminalEntry(role: .agent, text: "LLM routing is not yet wired. Set ANTHROPIC_API_KEY and connect ClaudeProvider in the next integration slice."))
+        }
+
+        isProcessing = false
+    }
+}
+
+struct TerminalEntryRow: View {
+    let entry: TerminalEntry
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(prefix)
+                .foregroundStyle(color)
+                .font(.system(.body, design: .monospaced))
+                .frame(width: 60, alignment: .trailing)
+            Text(entry.text)
+                .font(.system(.body, design: .monospaced))
+                .textSelection(.enabled)
+        }
+    }
+
+    private var prefix: String {
+        switch entry.role {
+        case .user:
+            return "you"
+        case .agent:
+            return "agent"
+        case .system:
+            return "sys"
+        }
+    }
+
+    private var color: Color {
+        switch entry.role {
+        case .user:
+            return .primary
+        case .agent:
+            return .blue
+        case .system:
+            return .secondary
+        }
+    }
+}

--- a/shell/Sources/MojoShell/Views/AgentTerminalView.swift
+++ b/shell/Sources/MojoShell/Views/AgentTerminalView.swift
@@ -1,25 +1,40 @@
 import SwiftUI
 
-struct TerminalEntry: Identifiable, Equatable {
-    let id = UUID()
+struct TerminalEntry: Identifiable, Equatable, Codable, Sendable {
+    let id: UUID
     let role: Role
     let text: String
-    let timestamp = Date()
+    let timestamp: Date
 
-    enum Role: Equatable {
+    enum Role: String, Codable, Equatable, Sendable {
         case user
         case agent
         case system
     }
+
+    init(
+        id: UUID = UUID(),
+        role: Role,
+        text: String,
+        timestamp: Date = Date()
+    ) {
+        self.id = id
+        self.role = role
+        self.text = text
+        self.timestamp = timestamp
+    }
+
+    static let initialSystemEntry = TerminalEntry(
+        role: .system,
+        text: "MojoShell Agent Terminal ready. Type a command."
+    )
 }
 
 struct AgentTerminalView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var readiness: ReadinessState
+    @EnvironmentObject private var session: ShellSessionController
     @State private var input = ""
-    @State private var history: [TerminalEntry] = [
-        TerminalEntry(role: .system, text: "MojoShell Agent Terminal ready. Type a command.")
-    ]
     @State private var isProcessing = false
 
     private let deterministicRouter = DeterministicRouter()
@@ -29,15 +44,15 @@ struct AgentTerminalView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 6) {
-                        ForEach(history) { entry in
+                        ForEach(session.terminalHistory) { entry in
                             TerminalEntryRow(entry: entry)
                                 .id(entry.id)
                         }
                     }
                     .padding()
                 }
-                .onChange(of: history.count) { _, _ in
-                    if let id = history.last?.id {
+                .onChange(of: session.terminalHistory.count) { _, _ in
+                    if let id = session.terminalHistory.last?.id {
                         proxy.scrollTo(id, anchor: .bottom)
                     }
                 }
@@ -54,6 +69,11 @@ struct AgentTerminalView: View {
             }
 
             HStack {
+                Button("Clear") {
+                    session.clearTerminalHistory()
+                }
+                .disabled(isProcessing)
+
                 TextField("Type a command...", text: $input)
                     .font(.system(.body, design: .monospaced))
                     .textFieldStyle(.plain)
@@ -86,28 +106,28 @@ struct AgentTerminalView: View {
 
         input = ""
         isProcessing = true
-        history.append(TerminalEntry(role: .user, text: command))
+        session.appendTerminalEntry(TerminalEntry(role: .user, text: command))
 
         if let tool = deterministicRouter.route(command) {
-            history.append(TerminalEntry(role: .system, text: "→ deterministic route: \(tool.server)/\(tool.tool)"))
+            session.appendTerminalEntry(TerminalEntry(role: .system, text: "→ deterministic route: \(tool.server)/\(tool.tool)"))
             let result = await appState.execute(tool)
             switch result {
             case .success(let output):
-                history.append(TerminalEntry(role: .agent, text: output.text))
+                session.appendTerminalEntry(TerminalEntry(role: .agent, text: output.text))
             case .failure(let error):
-                history.append(TerminalEntry(role: .agent, text: "Error: \(error.localizedDescription)"))
+                session.appendTerminalEntry(TerminalEntry(role: .agent, text: "Error: \(error.localizedDescription)"))
             }
         } else {
-            history.append(TerminalEntry(role: .system, text: "→ escalating to LLM stack (\(appState.llmProviderStackDescription))..."))
+            session.appendTerminalEntry(TerminalEntry(role: .system, text: "→ escalating to LLM stack (\(appState.llmProviderStackDescription))..."))
             let result = await appState.resolveWithLLM(
                 prompt: command,
                 availableTools: deterministicRouter.availableTools
             )
             switch result {
             case .success(let text):
-                history.append(TerminalEntry(role: .agent, text: text))
+                session.appendTerminalEntry(TerminalEntry(role: .agent, text: text))
             case .failure(let error):
-                history.append(TerminalEntry(role: .agent, text: "LLM error: \(error.localizedDescription)"))
+                session.appendTerminalEntry(TerminalEntry(role: .agent, text: "LLM error: \(error.localizedDescription)"))
             }
         }
 

--- a/shell/Sources/MojoShell/Views/AgentTerminalView.swift
+++ b/shell/Sources/MojoShell/Views/AgentTerminalView.swift
@@ -15,6 +15,7 @@ struct TerminalEntry: Identifiable, Equatable {
 
 struct AgentTerminalView: View {
     @EnvironmentObject private var appState: AppState
+    @EnvironmentObject private var readiness: ReadinessState
     @State private var input = ""
     @State private var history: [TerminalEntry] = [
         TerminalEntry(role: .system, text: "MojoShell Agent Terminal ready. Type a command.")
@@ -43,6 +44,14 @@ struct AgentTerminalView: View {
             }
 
             Divider()
+
+            if !readiness.isReady(for: .llm) {
+                Text("LLM fallback unavailable; deterministic routing still works.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 10)
+                    .padding(.bottom, 4)
+            }
 
             HStack {
                 TextField("Type a command...", text: $input)

--- a/shell/Sources/MojoShell/Views/AuditView.swift
+++ b/shell/Sources/MojoShell/Views/AuditView.swift
@@ -4,6 +4,7 @@ struct AuditView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var audit: AuditController
     @State private var selectedCategory: AuditCategory?
+    @State private var query = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -11,6 +12,9 @@ struct AuditView: View {
                 Label("Operator Audit", systemImage: "clock.arrow.circlepath")
                     .font(.headline)
                 Spacer()
+                TextField("Search", text: $query)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 240)
                 Picker("Category", selection: $selectedCategory) {
                     Text("All").tag(Optional<AuditCategory>.none)
                     ForEach(AuditCategory.allCases, id: \.self) { category in
@@ -18,6 +22,12 @@ struct AuditView: View {
                     }
                 }
                 .pickerStyle(.menu)
+                Button("Reveal Log") {
+                    Task { _ = await appState.revealFinderPath(audit.filePath) }
+                }
+                Button("Clear") {
+                    audit.clear()
+                }
                 Button("Refresh") {
                     audit.refresh()
                 }
@@ -61,10 +71,22 @@ struct AuditView: View {
     }
 
     private var filteredEvents: [AuditEvent] {
-        guard let selectedCategory else {
-            return audit.events
+        let categoryFiltered = selectedCategory.map { category in
+            audit.events.filter { $0.category == category }
+        } ?? audit.events
+
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty else {
+            return categoryFiltered
         }
-        return audit.events.filter { $0.category == selectedCategory }
+
+        return categoryFiltered.filter { event in
+            event.title.lowercased().contains(trimmed)
+                || event.detail.lowercased().contains(trimmed)
+                || event.metadata.contains(where: { key, value in
+                    key.lowercased().contains(trimmed) || value.lowercased().contains(trimmed)
+                })
+        }
     }
 }
 

--- a/shell/Sources/MojoShell/Views/AuditView.swift
+++ b/shell/Sources/MojoShell/Views/AuditView.swift
@@ -95,6 +95,12 @@ private struct AuditMetadataRow: View {
                     }
                 }
                 .font(.caption2)
+
+                if let metadata = DocumentInspector.inspect(path: path) {
+                    Text(metadataSummary(metadata))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
     }
@@ -108,5 +114,19 @@ private struct AuditMetadataRow: View {
             return nil
         }
         return FileManager.default.fileExists(atPath: trimmed) ? trimmed : nil
+    }
+
+    private func metadataSummary(_ metadata: DocumentMetadata) -> String {
+        var parts: [String] = []
+        if let byteSize = metadata.byteSize {
+            parts.append(ByteCountFormatter.string(fromByteCount: byteSize, countStyle: .file))
+        }
+        if let width = metadata.pixelWidth, let height = metadata.pixelHeight {
+            parts.append("\(width) × \(height)")
+        }
+        if let contentType = metadata.contentType {
+            parts.append(contentType)
+        }
+        return parts.joined(separator: " • ")
     }
 }

--- a/shell/Sources/MojoShell/Views/AuditView.swift
+++ b/shell/Sources/MojoShell/Views/AuditView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct AuditView: View {
+    @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var audit: AuditController
     @State private var selectedCategory: AuditCategory?
 
@@ -46,14 +47,7 @@ struct AuditView: View {
                             .textSelection(.enabled)
                         if !event.metadata.isEmpty {
                             ForEach(event.metadata.keys.sorted(), id: \.self) { key in
-                                HStack(alignment: .top, spacing: 4) {
-                                    Text(key)
-                                        .font(.caption2)
-                                        .foregroundStyle(.secondary)
-                                    Text(event.metadata[key] ?? "")
-                                        .font(.caption2)
-                                        .textSelection(.enabled)
-                                }
+                                AuditMetadataRow(key: key, value: event.metadata[key] ?? "")
                             }
                         }
                     }
@@ -71,5 +65,48 @@ struct AuditView: View {
             return audit.events
         }
         return audit.events.filter { $0.category == selectedCategory }
+    }
+}
+
+private struct AuditMetadataRow: View {
+    @EnvironmentObject private var appState: AppState
+
+    let key: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .top, spacing: 4) {
+                Text(key)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(.caption2)
+                    .textSelection(.enabled)
+            }
+
+            if let path = inspectablePath {
+                HStack {
+                    Button("Preview") {
+                        Task { _ = await appState.openPathInPreview(path) }
+                    }
+                    Button("Reveal") {
+                        Task { _ = await appState.revealFinderPath(path) }
+                    }
+                }
+                .font(.caption2)
+            }
+        }
+    }
+
+    private var inspectablePath: String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+        guard key.lowercased().contains("path") || trimmed.hasPrefix("/") else {
+            return nil
+        }
+        return FileManager.default.fileExists(atPath: trimmed) ? trimmed : nil
     }
 }

--- a/shell/Sources/MojoShell/Views/AuditView.swift
+++ b/shell/Sources/MojoShell/Views/AuditView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct AuditView: View {
+    @EnvironmentObject private var audit: AuditController
+    @State private var selectedCategory: AuditCategory?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label("Operator Audit", systemImage: "clock.arrow.circlepath")
+                    .font(.headline)
+                Spacer()
+                Picker("Category", selection: $selectedCategory) {
+                    Text("All").tag(Optional<AuditCategory>.none)
+                    ForEach(AuditCategory.allCases, id: \.self) { category in
+                        Text(category.rawValue.capitalized).tag(Optional(category))
+                    }
+                }
+                .pickerStyle(.menu)
+                Button("Refresh") {
+                    audit.refresh()
+                }
+            }
+
+            Divider()
+
+            if filteredEvents.isEmpty {
+                Text("No audit events recorded yet.")
+                    .foregroundStyle(.secondary)
+            } else {
+                List(filteredEvents.reversed()) { event in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text(event.timestamp.formatted(date: .abbreviated, time: .standard))
+                                .font(.system(.caption2, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                            Text(event.category.rawValue)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                        }
+                        Text(event.title)
+                            .font(.headline)
+                        Text(event.detail)
+                            .font(.caption)
+                            .textSelection(.enabled)
+                        if !event.metadata.isEmpty {
+                            ForEach(event.metadata.keys.sorted(), id: \.self) { key in
+                                HStack(alignment: .top, spacing: 4) {
+                                    Text(key)
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                    Text(event.metadata[key] ?? "")
+                                        .font(.caption2)
+                                        .textSelection(.enabled)
+                                }
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                .listStyle(.plain)
+            }
+        }
+        .padding()
+        .navigationTitle("Audit")
+    }
+
+    private var filteredEvents: [AuditEvent] {
+        guard let selectedCategory else {
+            return audit.events
+        }
+        return audit.events.filter { $0.category == selectedCategory }
+    }
+}

--- a/shell/Sources/MojoShell/Views/CockpitPanelModels.swift
+++ b/shell/Sources/MojoShell/Views/CockpitPanelModels.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+struct PersonaCardData: Identifiable, Equatable {
+    let id: String
+    let persona: String
+    let account: String
+    let role: String
+    let lane: String
+    let isPrimaryReply: Bool
+    let isCatchAll: Bool
+}
+
+struct BrainOverviewCardData: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let value: String
+    let detail: String
+}
+
+struct BrainOverviewPanelData: Equatable {
+    let headline: String
+    let subtitle: String
+    let cards: [BrainOverviewCardData]
+    let sections: [String]
+    let machineEntities: [String]
+    let corpusPath: String?
+    let reportPath: String?
+}
+
+enum NowPlayingStatus: Equatable {
+    case live
+    case stopped
+    case error
+}
+
+struct NowPlayingPanelData: Equatable {
+    let title: String
+    let subtitle: String
+    let detail: String
+    let status: NowPlayingStatus
+    let rawText: String
+}
+
+func parsePersonas(from json: String) -> [PersonaCardData] {
+    guard
+        let data = json.data(using: .utf8),
+        let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let accounts = root["accounts"] as? [[String: Any]]
+    else { return [] }
+
+    return accounts.compactMap { dict in
+        guard
+            let id = dict["persona_id"] as? String,
+            let persona = dict["persona"] as? String,
+            let account = dict["account"] as? String
+        else { return nil }
+        return PersonaCardData(
+            id: id,
+            persona: persona,
+            account: account,
+            role: dict["role"] as? String ?? "",
+            lane: dict["default_lane"] as? String ?? "",
+            isPrimaryReply: dict["primary_reply_from"] as? Bool ?? false,
+            isCatchAll: dict["catch_all"] as? Bool ?? false
+        )
+    }
+}
+
+func parseBrainOverview(from json: String) -> BrainOverviewPanelData? {
+    guard
+        let data = json.data(using: .utf8),
+        let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else { return nil }
+
+    let corpusName = root["corpus_name"] as? String ?? "Unknown Corpus"
+    let version = root["corpus_version"] as? String ?? "unknown"
+    let company = root["target_company"] as? String ?? "Unknown Company"
+    let domain = root["target_domain"] as? String ?? "unknown"
+    let sectionCount = root["section_count"] as? Int ?? 0
+    let sourceCount = root["source_count"] as? Int ?? 0
+    let reportAvailable = root["report_available"] as? Bool ?? false
+    let reportSectionCount = root["report_section_count"] as? Int ?? 0
+    let machineEntities = stringList(from: root["machine_ingest_entities"])
+    let sections = stringList(from: root["sections"])
+    let generatedOn = root["generated_on"] as? String ?? "unknown"
+
+    let cards = [
+        BrainOverviewCardData(
+            id: "sections",
+            title: "Sections",
+            value: "\(sectionCount)",
+            detail: sections.prefix(3).joined(separator: " • ").ifEmpty("No sections reported")
+        ),
+        BrainOverviewCardData(
+            id: "sources",
+            title: "Sources",
+            value: "\(sourceCount)",
+            detail: "Machine entities: \(machineEntities.count)"
+        ),
+        BrainOverviewCardData(
+            id: "report",
+            title: "Report",
+            value: reportAvailable ? "Ready" : "Missing",
+            detail: "Sections: \(reportSectionCount) • Generated: \(generatedOn)"
+        ),
+    ]
+
+    return BrainOverviewPanelData(
+        headline: "\(corpusName) v\(version)",
+        subtitle: "\(company) • \(domain)",
+        cards: cards,
+        sections: sections,
+        machineEntities: machineEntities,
+        corpusPath: root["corpus_path"] as? String,
+        reportPath: root["report_path"] as? String
+    )
+}
+
+func parseNowPlaying(from text: String) -> NowPlayingPanelData {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+        return NowPlayingPanelData(
+            title: "Music idle",
+            subtitle: "No playback state available yet",
+            detail: "Auto-refresh every 30s",
+            status: .stopped,
+            rawText: text
+        )
+    }
+
+    if trimmed.hasPrefix("Error:") {
+        return NowPlayingPanelData(
+            title: "Music unavailable",
+            subtitle: trimmed.replacingOccurrences(of: "Error: ", with: ""),
+            detail: "Auto-refresh will retry in 30s",
+            status: .error,
+            rawText: text
+        )
+    }
+
+    guard
+        let data = trimmed.data(using: .utf8),
+        let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+        return NowPlayingPanelData(
+            title: "Music response",
+            subtitle: trimmed,
+            detail: "Auto-refresh every 30s",
+            status: .live,
+            rawText: text
+        )
+    }
+
+    let state = (root["state"] as? String ?? "stopped").capitalized
+    let volume = root["volume"] as? Int ?? 0
+    let shuffleEnabled = root["shuffle"] as? Bool ?? false
+    let repeatMode = root["repeat"] as? String ?? "off"
+
+    if let track = root["track"] as? [String: Any] {
+        let trackName = track["name"] as? String ?? "Unknown Track"
+        let artist = track["artist"] as? String ?? "Unknown Artist"
+        let album = track["album"] as? String ?? "Unknown Album"
+        let duration = formatDuration(track["duration"] as? Double)
+        let position = formatDuration(track["position"] as? Double)
+        return NowPlayingPanelData(
+            title: trackName,
+            subtitle: "\(artist) • \(album)",
+            detail: "\(state) • \(position) / \(duration) • Vol \(volume)% • Shuffle \(shuffleEnabled ? "On" : "Off") • Repeat \(repeatMode.capitalized)",
+            status: .live,
+            rawText: text
+        )
+    }
+
+    return NowPlayingPanelData(
+        title: state,
+        subtitle: "Nothing is currently playing",
+        detail: "Vol \(volume)% • Shuffle \(shuffleEnabled ? "On" : "Off") • Repeat \(repeatMode.capitalized)",
+        status: .stopped,
+        rawText: text
+    )
+}
+
+private func stringList(from value: Any?) -> [String] {
+    (value as? [String]) ?? []
+}
+
+private func formatDuration(_ seconds: Double?) -> String {
+    guard let seconds else { return "--:--" }
+    let rounded = max(Int(seconds.rounded()), 0)
+    let minutes = rounded / 60
+    let remainder = rounded % 60
+    return String(format: "%d:%02d", minutes, remainder)
+}
+
+private extension String {
+    func ifEmpty(_ fallback: String) -> String {
+        isEmpty ? fallback : self
+    }
+}

--- a/shell/Sources/MojoShell/Views/CockpitView.swift
+++ b/shell/Sources/MojoShell/Views/CockpitView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct CockpitView: View {
+    @EnvironmentObject private var appState: AppState
+    @State private var scanResult = "Tap Scan to load Daily Intel"
+    @State private var isScanning = false
+
+    var body: some View {
+        HSplitView {
+            VStack(alignment: .leading, spacing: 12) {
+                Label("Inbox Intelligence", systemImage: "envelope.badge.shield.half.filled")
+                    .font(.headline)
+                Divider()
+                ScrollView {
+                    Text(scanResult)
+                        .font(.system(.body, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                Button(isScanning ? "Scanning..." : "Scan Inboxes") {
+                    Task {
+                        await scanInboxes()
+                    }
+                }
+                .disabled(isScanning)
+            }
+            .padding()
+            .frame(minWidth: 360)
+
+            VStack(alignment: .leading, spacing: 12) {
+                Label("Active Servers", systemImage: "server.rack")
+                    .font(.headline)
+                Divider()
+
+                if appState.daemons.runningServers.isEmpty {
+                    Text("No MCP daemons are currently running.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(Array(appState.daemons.runningServers.keys.sorted()), id: \.self) { name in
+                        HStack {
+                            Circle()
+                                .fill(.green)
+                                .frame(width: 8, height: 8)
+                            Text(name)
+                                .font(.system(.body, design: .monospaced))
+                        }
+                    }
+                }
+
+                Spacer()
+            }
+            .padding()
+            .frame(minWidth: 260)
+        }
+        .navigationTitle("Cockpit")
+    }
+
+    private func scanInboxes() async {
+        isScanning = true
+        scanResult = "Scanning..."
+        try? await Task.sleep(nanoseconds: 800_000_000)
+        scanResult = "Scan complete — wire MCPClient to mail-intelligence/scan_persona_inboxes in the next integration slice."
+        isScanning = false
+    }
+}

--- a/shell/Sources/MojoShell/Views/CockpitView.swift
+++ b/shell/Sources/MojoShell/Views/CockpitView.swift
@@ -3,7 +3,13 @@ import SwiftUI
 struct CockpitView: View {
     @EnvironmentObject private var appState: AppState
     @State private var scanResult = "Tap Scan to load Daily Intel"
+    @State private var personaMapResult = "Tap Refresh Persona Map"
+    @State private var brainOverviewResult = "Tap Brain Overview"
+    @State private var nowPlayingResult = "Tap Now Playing"
     @State private var isScanning = false
+    @State private var isLoadingPersonaMap = false
+    @State private var isLoadingBrainOverview = false
+    @State private var isLoadingNowPlaying = false
 
     var body: some View {
         HSplitView {
@@ -27,29 +33,83 @@ struct CockpitView: View {
             .frame(minWidth: 360)
 
             VStack(alignment: .leading, spacing: 12) {
-                Label("Active Servers", systemImage: "server.rack")
+                Label("Live Panels", systemImage: "square.grid.2x2")
                     .font(.headline)
                 Divider()
 
-                if appState.daemons.runningServers.isEmpty {
-                    Text("No MCP daemons are currently running.")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(Array(appState.daemons.runningServers.keys.sorted()), id: \.self) { name in
-                        HStack {
-                            Circle()
-                                .fill(.green)
-                                .frame(width: 8, height: 8)
-                            Text(name)
-                                .font(.system(.body, design: .monospaced))
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(personaMapResult)
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Button(isLoadingPersonaMap ? "Loading..." : "Refresh Persona Map") {
+                            Task {
+                                await loadPersonaMap()
+                            }
+                        }
+                        .disabled(isLoadingPersonaMap)
+                    }
+                } label: {
+                    Label("Persona Map", systemImage: "person.2.badge.gearshape")
+                }
+
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(brainOverviewResult)
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Button(isLoadingBrainOverview ? "Loading..." : "Brain Overview") {
+                            Task {
+                                await loadBrainOverview()
+                            }
+                        }
+                        .disabled(isLoadingBrainOverview)
+                    }
+                } label: {
+                    Label("Brain", systemImage: "brain.head.profile")
+                }
+
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(nowPlayingResult)
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Button(isLoadingNowPlaying ? "Loading..." : "Now Playing") {
+                            Task {
+                                await loadNowPlaying()
+                            }
+                        }
+                        .disabled(isLoadingNowPlaying)
+                    }
+                } label: {
+                    Label("Music", systemImage: "music.note")
+                }
+
+                Divider()
+                Label("Active Servers", systemImage: "server.rack")
+                    .font(.headline)
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 6) {
+                        if appState.daemons.runningServers.isEmpty {
+                            Text("No MCP daemons are currently running.")
+                                .foregroundStyle(.secondary)
+                        } else {
+                            ForEach(Array(appState.daemons.runningServers.keys.sorted()), id: \.self) { name in
+                                HStack {
+                                    Circle()
+                                        .fill(.green)
+                                        .frame(width: 8, height: 8)
+                                    Text(name)
+                                        .font(.system(.body, design: .monospaced))
+                                }
+                            }
                         }
                     }
                 }
-
-                Spacer()
             }
             .padding()
-            .frame(minWidth: 260)
+            .frame(minWidth: 320)
         }
         .navigationTitle("Cockpit")
     }
@@ -67,5 +127,41 @@ struct CockpitView: View {
         }
 
         isScanning = false
+    }
+
+    private func loadPersonaMap() async {
+        isLoadingPersonaMap = true
+        let result = await appState.fetchPersonaMap()
+        switch result {
+        case .success(let output):
+            personaMapResult = output.text
+        case .failure(let error):
+            personaMapResult = "Error: \(error.localizedDescription)"
+        }
+        isLoadingPersonaMap = false
+    }
+
+    private func loadBrainOverview() async {
+        isLoadingBrainOverview = true
+        let result = await appState.fetchBrainOverview()
+        switch result {
+        case .success(let output):
+            brainOverviewResult = output.text
+        case .failure(let error):
+            brainOverviewResult = "Error: \(error.localizedDescription)"
+        }
+        isLoadingBrainOverview = false
+    }
+
+    private func loadNowPlaying() async {
+        isLoadingNowPlaying = true
+        let result = await appState.fetchNowPlaying()
+        switch result {
+        case .success(let output):
+            nowPlayingResult = output.text
+        case .failure(let error):
+            nowPlayingResult = "Error: \(error.localizedDescription)"
+        }
+        isLoadingNowPlaying = false
     }
 }

--- a/shell/Sources/MojoShell/Views/CockpitView.swift
+++ b/shell/Sources/MojoShell/Views/CockpitView.swift
@@ -57,8 +57,15 @@ struct CockpitView: View {
     private func scanInboxes() async {
         isScanning = true
         scanResult = "Scanning..."
-        try? await Task.sleep(nanoseconds: 800_000_000)
-        scanResult = "Scan complete — wire MCPClient to mail-intelligence/scan_persona_inboxes in the next integration slice."
+
+        let result = await appState.scanInboxes()
+        switch result {
+        case .success(let output):
+            scanResult = output.text
+        case .failure(let error):
+            scanResult = "Error: \(error.localizedDescription)"
+        }
+
         isScanning = false
     }
 }

--- a/shell/Sources/MojoShell/Views/CockpitView.swift
+++ b/shell/Sources/MojoShell/Views/CockpitView.swift
@@ -1,15 +1,5 @@
 import SwiftUI
 
-private struct PersonaCardData: Identifiable {
-    let id: String
-    let persona: String
-    let account: String
-    let role: String
-    let lane: String
-    let isPrimaryReply: Bool
-    let isCatchAll: Bool
-}
-
 private struct PersonaCardView: View {
     let data: PersonaCardData
 
@@ -52,28 +42,49 @@ private struct PersonaCardView: View {
     }
 }
 
-private func parsePersonas(from json: String) -> [PersonaCardData] {
-    guard
-        let data = json.data(using: .utf8),
-        let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-        let accounts = root["accounts"] as? [[String: Any]]
-    else { return [] }
+private struct BrainOverviewCardView: View {
+    let data: BrainOverviewCardData
 
-    return accounts.compactMap { dict in
-        guard
-            let id = dict["persona_id"] as? String,
-            let persona = dict["persona"] as? String,
-            let account = dict["account"] as? String
-        else { return nil }
-        return PersonaCardData(
-            id: id,
-            persona: persona,
-            account: account,
-            role: dict["role"] as? String ?? "",
-            lane: dict["default_lane"] as? String ?? "",
-            isPrimaryReply: dict["primary_reply_from"] as? Bool ?? false,
-            isCatchAll: dict["catch_all"] as? Bool ?? false
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(data.title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(data.value)
+                .font(.system(.title3, design: .rounded).bold())
+            Text(data.detail)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.background)
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(.separator, lineWidth: 1)
         )
+    }
+}
+
+private struct StatusDotView: View {
+    let status: NowPlayingStatus
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: 8, height: 8)
+    }
+
+    private var color: Color {
+        switch status {
+        case .live:
+            return .green
+        case .stopped:
+            return .orange
+        case .error:
+            return .red
+        }
     }
 }
 
@@ -83,11 +94,15 @@ struct CockpitView: View {
     @State private var personaMapResult = ""
     @State private var parsedPersonas: [PersonaCardData] = []
     @State private var brainOverviewResult = "Tap Brain Overview"
+    @State private var parsedBrainOverview: BrainOverviewPanelData?
     @State private var nowPlayingResult = "Tap Now Playing"
+    @State private var parsedNowPlaying = parseNowPlaying(from: "")
     @State private var isScanning = false
     @State private var isLoadingPersonaMap = false
     @State private var isLoadingBrainOverview = false
     @State private var isLoadingNowPlaying = false
+    @State private var lastNowPlayingRefresh: Date?
+    @State private var hasLoadedInitialPanels = false
 
     var body: some View {
         HSplitView {
@@ -138,9 +153,43 @@ struct CockpitView: View {
 
                 GroupBox {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text(brainOverviewResult)
-                            .font(.system(.caption, design: .monospaced))
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                        if let parsedBrainOverview {
+                            Text(parsedBrainOverview.headline)
+                                .font(.system(.body, design: .rounded).bold())
+                            Text(parsedBrainOverview.subtitle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+
+                            HStack(alignment: .top, spacing: 8) {
+                                ForEach(parsedBrainOverview.cards) { card in
+                                    BrainOverviewCardView(data: card)
+                                }
+                            }
+
+                            if !parsedBrainOverview.sections.isEmpty {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Sections")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                    Text(parsedBrainOverview.sections.joined(separator: " • "))
+                                        .font(.caption2)
+                                }
+                            }
+
+                            if !parsedBrainOverview.machineEntities.isEmpty {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Machine Entities")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                    Text(parsedBrainOverview.machineEntities.joined(separator: " • "))
+                                        .font(.caption2)
+                                }
+                            }
+                        } else {
+                            Text(brainOverviewResult)
+                                .font(.system(.caption, design: .monospaced))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
                         Button(isLoadingBrainOverview ? "Loading..." : "Brain Overview") {
                             Task {
                                 await loadBrainOverview()
@@ -154,12 +203,29 @@ struct CockpitView: View {
 
                 GroupBox {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text(nowPlayingResult)
-                            .font(.system(.caption, design: .monospaced))
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                        HStack(spacing: 6) {
+                            StatusDotView(status: parsedNowPlaying.status)
+                            Text(parsedNowPlaying.title)
+                                .font(.system(.body, design: .rounded).bold())
+                        }
+                        Text(parsedNowPlaying.subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(parsedNowPlaying.detail)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        if let lastNowPlayingRefresh {
+                            Text("Updated \(lastNowPlayingRefresh.formatted(date: .omitted, time: .shortened)) • Auto-refresh every 30s")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text("Auto-refresh every 30s")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
                         Button(isLoadingNowPlaying ? "Loading..." : "Now Playing") {
                             Task {
-                                await loadNowPlaying()
+                                await loadNowPlaying(triggeredByPoll: false)
                             }
                         }
                         .disabled(isLoadingNowPlaying)
@@ -195,8 +261,21 @@ struct CockpitView: View {
             .frame(minWidth: 320)
         }
         .navigationTitle("Cockpit")
-        .onAppear {
-            Task { await loadPersonaMap() }
+        .task {
+            guard !hasLoadedInitialPanels else { return }
+            hasLoadedInitialPanels = true
+            await loadPersonaMap()
+            await loadBrainOverview()
+            await loadNowPlaying(triggeredByPoll: false)
+        }
+        .task {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 30_000_000_000)
+                if Task.isCancelled {
+                    break
+                }
+                await loadNowPlaying(triggeredByPoll: true)
+            }
         }
     }
 
@@ -235,20 +314,29 @@ struct CockpitView: View {
         switch result {
         case .success(let output):
             brainOverviewResult = output.text
+            parsedBrainOverview = parseBrainOverview(from: output.text)
         case .failure(let error):
             brainOverviewResult = "Error: \(error.localizedDescription)"
+            parsedBrainOverview = nil
         }
         isLoadingBrainOverview = false
     }
 
-    private func loadNowPlaying() async {
+    private func loadNowPlaying(triggeredByPoll: Bool) async {
+        guard !isLoadingNowPlaying else { return }
         isLoadingNowPlaying = true
         let result = await appState.fetchNowPlaying()
         switch result {
         case .success(let output):
             nowPlayingResult = output.text
+            parsedNowPlaying = parseNowPlaying(from: output.text)
+            lastNowPlayingRefresh = Date()
         case .failure(let error):
             nowPlayingResult = "Error: \(error.localizedDescription)"
+            parsedNowPlaying = parseNowPlaying(from: nowPlayingResult)
+            if !triggeredByPoll {
+                lastNowPlayingRefresh = Date()
+            }
         }
         isLoadingNowPlaying = false
     }

--- a/shell/Sources/MojoShell/Views/CockpitView.swift
+++ b/shell/Sources/MojoShell/Views/CockpitView.swift
@@ -1,9 +1,87 @@
 import SwiftUI
 
+private struct PersonaCardData: Identifiable {
+    let id: String
+    let persona: String
+    let account: String
+    let role: String
+    let lane: String
+    let isPrimaryReply: Bool
+    let isCatchAll: Bool
+}
+
+private struct PersonaCardView: View {
+    let data: PersonaCardData
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 4) {
+                Text(data.persona)
+                    .font(.system(.caption, design: .rounded).bold())
+                if data.isPrimaryReply {
+                    badge("primary", color: .blue)
+                }
+                if data.isCatchAll {
+                    badge("catch-all", color: .purple)
+                }
+            }
+            Text(data.account)
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(.secondary)
+            Text(data.role)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.background)
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(.separator, lineWidth: 1)
+        )
+    }
+
+    private func badge(_ label: String, color: Color) -> some View {
+        Text(label)
+            .font(.caption2)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 1)
+            .background(color.opacity(0.15))
+            .foregroundStyle(color)
+            .clipShape(RoundedRectangle(cornerRadius: 3))
+    }
+}
+
+private func parsePersonas(from json: String) -> [PersonaCardData] {
+    guard
+        let data = json.data(using: .utf8),
+        let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let accounts = root["accounts"] as? [[String: Any]]
+    else { return [] }
+
+    return accounts.compactMap { dict in
+        guard
+            let id = dict["persona_id"] as? String,
+            let persona = dict["persona"] as? String,
+            let account = dict["account"] as? String
+        else { return nil }
+        return PersonaCardData(
+            id: id,
+            persona: persona,
+            account: account,
+            role: dict["role"] as? String ?? "",
+            lane: dict["default_lane"] as? String ?? "",
+            isPrimaryReply: dict["primary_reply_from"] as? Bool ?? false,
+            isCatchAll: dict["catch_all"] as? Bool ?? false
+        )
+    }
+}
+
 struct CockpitView: View {
     @EnvironmentObject private var appState: AppState
     @State private var scanResult = "Tap Scan to load Daily Intel"
-    @State private var personaMapResult = "Tap Refresh Persona Map"
+    @State private var personaMapResult = ""
+    @State private var parsedPersonas: [PersonaCardData] = []
     @State private var brainOverviewResult = "Tap Brain Overview"
     @State private var nowPlayingResult = "Tap Now Playing"
     @State private var isScanning = false
@@ -38,14 +116,19 @@ struct CockpitView: View {
                 Divider()
 
                 GroupBox {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text(personaMapResult)
-                            .font(.system(.caption, design: .monospaced))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        Button(isLoadingPersonaMap ? "Loading..." : "Refresh Persona Map") {
-                            Task {
-                                await loadPersonaMap()
+                    VStack(alignment: .leading, spacing: 6) {
+                        if parsedPersonas.isEmpty {
+                            Text(personaMapResult.isEmpty ? "Loading..." : personaMapResult)
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        } else {
+                            ForEach(parsedPersonas) { persona in
+                                PersonaCardView(data: persona)
                             }
+                        }
+                        Button(isLoadingPersonaMap ? "Refreshing..." : "Refresh") {
+                            Task { await loadPersonaMap() }
                         }
                         .disabled(isLoadingPersonaMap)
                     }
@@ -112,6 +195,9 @@ struct CockpitView: View {
             .frame(minWidth: 320)
         }
         .navigationTitle("Cockpit")
+        .onAppear {
+            Task { await loadPersonaMap() }
+        }
     }
 
     private func scanInboxes() async {
@@ -135,8 +221,10 @@ struct CockpitView: View {
         switch result {
         case .success(let output):
             personaMapResult = output.text
+            parsedPersonas = parsePersonas(from: output.text)
         case .failure(let error):
             personaMapResult = "Error: \(error.localizedDescription)"
+            parsedPersonas = []
         }
         isLoadingPersonaMap = false
     }

--- a/shell/Sources/MojoShell/Views/CockpitView.swift
+++ b/shell/Sources/MojoShell/Views/CockpitView.swift
@@ -103,6 +103,8 @@ struct CockpitView: View {
     @State private var isLoadingNowPlaying = false
     @State private var lastNowPlayingRefresh: Date?
     @State private var hasLoadedInitialPanels = false
+    @State private var operatorResult = "Finder, Safari, Shortcuts, and settings controls are ready."
+    @State private var isRunningOperatorAction = false
 
     var body: some View {
         HSplitView {
@@ -232,6 +234,47 @@ struct CockpitView: View {
                     }
                 } label: {
                     Label("Music", systemImage: "music.note")
+                }
+
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(operatorResult)
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                        HStack {
+                            Button("Downloads") {
+                                Task { await runOperatorAction(appState.openDownloadsFolder) }
+                            }
+                            Button("Repo") {
+                                Task { await runOperatorAction(appState.openRepoFolder) }
+                            }
+                            Button("Brain") {
+                                Task { await runOperatorAction(appState.revealBrainFile) }
+                            }
+                        }
+                        .disabled(isRunningOperatorAction)
+
+                        HStack {
+                            Button("Finder Selection") {
+                                Task { await runOperatorAction(appState.fetchFinderSelection) }
+                            }
+                            Button("Safari Tab") {
+                                Task { await runOperatorAction(appState.fetchSafariCurrentTab) }
+                            }
+                            Button("Shortcuts") {
+                                Task { await runOperatorAction(appState.listShortcuts) }
+                            }
+                        }
+                        .disabled(isRunningOperatorAction)
+
+                        Button("Accessibility Settings") {
+                            Task { await runOperatorAction(appState.openAccessibilitySettings) }
+                        }
+                        .disabled(isRunningOperatorAction)
+                    }
+                } label: {
+                    Label("Operator Controls", systemImage: "switch.2")
                 }
 
                 Divider()
@@ -371,5 +414,21 @@ struct CockpitView: View {
             }
         }
         isLoadingNowPlaying = false
+    }
+
+    private func runOperatorAction(
+        _ action: @escaping () async -> Result<MCPToolExecutionResult, Error>
+    ) async {
+        guard !isRunningOperatorAction else { return }
+        isRunningOperatorAction = true
+        defer { isRunningOperatorAction = false }
+
+        let result = await action()
+        switch result {
+        case .success(let output):
+            operatorResult = output.text
+        case .failure(let error):
+            operatorResult = "Error: \(error.localizedDescription)"
+        }
     }
 }

--- a/shell/Sources/MojoShell/Views/CockpitView.swift
+++ b/shell/Sources/MojoShell/Views/CockpitView.swift
@@ -235,22 +235,36 @@ struct CockpitView: View {
                 }
 
                 Divider()
-                Label("Active Servers", systemImage: "server.rack")
-                    .font(.headline)
+                HStack {
+                    Label("Daemon Health", systemImage: "server.rack")
+                        .font(.headline)
+                    Spacer()
+                    Button("Restart All") {
+                        appState.daemons.restartAll()
+                    }
+                }
 
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 6) {
-                        if appState.daemons.runningServers.isEmpty {
-                            Text("No MCP daemons are currently running.")
-                                .foregroundStyle(.secondary)
-                        } else {
-                            ForEach(Array(appState.daemons.runningServers.keys.sorted()), id: \.self) { name in
-                                HStack {
-                                    Circle()
-                                        .fill(.green)
-                                        .frame(width: 8, height: 8)
-                                    Text(name)
-                                        .font(.system(.body, design: .monospaced))
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(appState.daemons.allRuntimeStates) { state in
+                            HStack(spacing: 8) {
+                                Circle()
+                                    .fill(daemonStatusColor(state.status))
+                                    .frame(width: 8, height: 8)
+                                Text(state.serverName)
+                                    .font(.system(.body, design: .monospaced))
+                                Text(state.status.rawValue)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                if let error = state.lastError, !error.isEmpty {
+                                    Text(error)
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                                Spacer()
+                                Button("Restart") {
+                                    appState.daemons.restart(serverName: state.serverName)
                                 }
                             }
                         }
@@ -276,6 +290,24 @@ struct CockpitView: View {
                 }
                 await loadNowPlaying(triggeredByPoll: true)
             }
+        }
+        .onAppear {
+            appState.daemons.refreshRuntimeStates()
+        }
+    }
+
+    private func daemonStatusColor(_ status: DaemonRuntimeStatus) -> Color {
+        switch status {
+        case .running:
+            return .green
+        case .starting:
+            return .blue
+        case .stopped:
+            return .gray
+        case .notBuilt:
+            return .orange
+        case .failed:
+            return .red
         }
     }
 

--- a/shell/Sources/MojoShell/Views/CockpitView.swift
+++ b/shell/Sources/MojoShell/Views/CockpitView.swift
@@ -90,6 +90,8 @@ private struct StatusDotView: View {
 
 struct CockpitView: View {
     @EnvironmentObject private var appState: AppState
+    @EnvironmentObject private var brain: BrainManager
+    @EnvironmentObject private var readiness: ReadinessState
     @State private var scanResult = "Tap Scan to load Daily Intel"
     @State private var personaMapResult = ""
     @State private var parsedPersonas: [PersonaCardData] = []
@@ -105,6 +107,8 @@ struct CockpitView: View {
     @State private var hasLoadedInitialPanels = false
     @State private var operatorResult = "Finder, Safari, Terminal, iTerm, Preview, Photos, Shortcuts, and settings controls are ready."
     @State private var isRunningOperatorAction = false
+    @State private var isRunningBrainAction = false
+    @State private var isRunningDaemonAction = false
 
     var body: some View {
         HSplitView {
@@ -155,6 +159,26 @@ struct CockpitView: View {
 
                 GroupBox {
                     VStack(alignment: .leading, spacing: 8) {
+                        Text(brain.sourceMode.title)
+                            .font(.system(.body, design: .rounded).bold())
+                        Text(brain.activeBrainPath)
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+
+                        HStack {
+                            Button("Use Repo") {
+                                Task { await switchToRepoBrain() }
+                            }
+                            Button("Use Local") {
+                                Task { await switchToLocalBrain() }
+                            }
+                            Button("Reveal") {
+                                Task { await runOperatorAction(appState.revealBrainFile) }
+                            }
+                        }
+                        .disabled(isRunningBrainAction || isRunningOperatorAction)
+
                         if let parsedBrainOverview {
                             Text(parsedBrainOverview.headline)
                                 .font(.system(.body, design: .rounded).bold())
@@ -197,7 +221,7 @@ struct CockpitView: View {
                                 await loadBrainOverview()
                             }
                         }
-                        .disabled(isLoadingBrainOverview)
+                        .disabled(isLoadingBrainOverview || isRunningBrainAction)
                     }
                 } label: {
                     Label("Brain", systemImage: "brain.head.profile")
@@ -308,34 +332,73 @@ struct CockpitView: View {
                     Label("Daemon Health", systemImage: "server.rack")
                         .font(.headline)
                     Spacer()
+                    Button("Build All") {
+                        Task { await runDaemonBuildAll() }
+                    }
+                    .disabled(isRunningDaemonAction)
                     Button("Restart All") {
                         appState.daemons.restartAll()
                     }
+                    .disabled(isRunningDaemonAction)
                 }
 
                 ScrollView {
                     VStack(alignment: .leading, spacing: 8) {
                         ForEach(appState.daemons.allRuntimeStates) { state in
-                            HStack(spacing: 8) {
-                                Circle()
-                                    .fill(daemonStatusColor(state.status))
-                                    .frame(width: 8, height: 8)
-                                Text(state.serverName)
-                                    .font(.system(.body, design: .monospaced))
-                                Text(state.status.rawValue)
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
+                            VStack(alignment: .leading, spacing: 6) {
+                                HStack(spacing: 8) {
+                                    Circle()
+                                        .fill(daemonStatusColor(state.status))
+                                        .frame(width: 8, height: 8)
+                                    Text(state.serverName)
+                                        .font(.system(.body, design: .monospaced))
+                                    Text(state.status.rawValue)
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                    let buildState = appState.daemons.buildState(for: state.serverName)
+                                    Text(buildState?.status.rawValue ?? DaemonBuildStatus.idle.rawValue)
+                                        .font(.caption2)
+                                        .foregroundStyle(buildStatusColor(buildState?.status ?? .idle))
+                                    Spacer()
+                                    Button("Build") {
+                                        Task { await runDaemonBuild(state.serverName) }
+                                    }
+                                    .disabled(isRunningDaemonAction)
+                                    Button("Restart") {
+                                        appState.daemons.restart(serverName: state.serverName)
+                                    }
+                                    .disabled(isRunningDaemonAction)
+                                    Button("Log") {
+                                        Task { _ = await appState.revealFinderPath(state.logPath) }
+                                    }
+                                    Button("Script") {
+                                        Task { _ = await appState.revealFinderPath(state.scriptPath) }
+                                    }
+                                }
+
                                 if let error = state.lastError, !error.isEmpty {
                                     Text(error)
                                         .font(.caption2)
                                         .foregroundStyle(.secondary)
-                                        .lineLimit(1)
+                                        .lineLimit(2)
                                 }
-                                Spacer()
-                                Button("Restart") {
-                                    appState.daemons.restart(serverName: state.serverName)
+
+                                if let buildState = appState.daemons.buildState(for: state.serverName) {
+                                    Text(buildState.lastOutput)
+                                        .font(.system(.caption2, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(4)
+                                }
+
+                                let runtimeSnippet = appState.daemons.recentRuntimeLog(for: state.serverName)
+                                if !runtimeSnippet.isEmpty {
+                                    Text(runtimeSnippet)
+                                        .font(.system(.caption2, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(4)
                                 }
                             }
+                            .padding(.vertical, 4)
                         }
                     }
                 }
@@ -375,6 +438,19 @@ struct CockpitView: View {
             return .gray
         case .notBuilt:
             return .orange
+        case .failed:
+            return .red
+        }
+    }
+
+    private func buildStatusColor(_ status: DaemonBuildStatus) -> Color {
+        switch status {
+        case .idle:
+            return .secondary
+        case .building:
+            return .blue
+        case .succeeded:
+            return .green
         case .failed:
             return .red
         }
@@ -456,5 +532,47 @@ struct CockpitView: View {
         case .failure(let error):
             operatorResult = "Error: \(error.localizedDescription)"
         }
+    }
+
+    private func switchToRepoBrain() async {
+        guard !isRunningBrainAction else { return }
+        isRunningBrainAction = true
+        defer { isRunningBrainAction = false }
+
+        brain.useRepoDefault()
+        appState.daemons.restart(serverName: "knowledge-corpus")
+        await readiness.refresh()
+        await loadBrainOverview()
+        operatorResult = "Using repo brain: \(brain.activeBrainPath)"
+    }
+
+    private func switchToLocalBrain() async {
+        guard !isRunningBrainAction else { return }
+        isRunningBrainAction = true
+        defer { isRunningBrainAction = false }
+
+        do {
+            try brain.useLocalBrain()
+            appState.daemons.restart(serverName: "knowledge-corpus")
+            await readiness.refresh()
+            await loadBrainOverview()
+            operatorResult = "Using local brain: \(brain.activeBrainPath)"
+        } catch {
+            operatorResult = "Brain error: \(error.localizedDescription)"
+        }
+    }
+
+    private func runDaemonBuild(_ serverName: String) async {
+        guard !isRunningDaemonAction else { return }
+        isRunningDaemonAction = true
+        defer { isRunningDaemonAction = false }
+        await appState.daemons.build(serverName: serverName)
+    }
+
+    private func runDaemonBuildAll() async {
+        guard !isRunningDaemonAction else { return }
+        isRunningDaemonAction = true
+        defer { isRunningDaemonAction = false }
+        await appState.daemons.buildAll()
     }
 }

--- a/shell/Sources/MojoShell/Views/CockpitView.swift
+++ b/shell/Sources/MojoShell/Views/CockpitView.swift
@@ -1,4 +1,6 @@
+import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 private struct PersonaCardView: View {
     let data: PersonaCardData
@@ -91,7 +93,9 @@ private struct StatusDotView: View {
 struct CockpitView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var brain: BrainManager
+    @EnvironmentObject private var preferences: ShellPreferencesController
     @EnvironmentObject private var readiness: ReadinessState
+    @EnvironmentObject private var session: ShellSessionController
     @State private var scanResult = "Tap Scan to load Daily Intel"
     @State private var personaMapResult = ""
     @State private var parsedPersonas: [PersonaCardData] = []
@@ -109,6 +113,15 @@ struct CockpitView: View {
     @State private var isRunningOperatorAction = false
     @State private var isRunningBrainAction = false
     @State private var isRunningDaemonAction = false
+    @State private var isRunningMorningOps = false
+    @State private var isSelectingBrainFile = false
+    @State private var brainSelectionMode: BrainSelectionMode = .custom
+    @State private var selectedDaemonName: String?
+
+    private enum BrainSelectionMode {
+        case custom
+        case importLocal
+    }
 
     var body: some View {
         HSplitView {
@@ -173,11 +186,25 @@ struct CockpitView: View {
                             Button("Use Local") {
                                 Task { await switchToLocalBrain() }
                             }
+                            Button("Use Custom...") {
+                                brainSelectionMode = .custom
+                                isSelectingBrainFile = true
+                            }
+                            Button("Import Local...") {
+                                brainSelectionMode = .importLocal
+                                isSelectingBrainFile = true
+                            }
                             Button("Reveal") {
                                 Task { await runOperatorAction(appState.revealBrainFile) }
                             }
                         }
                         .disabled(isRunningBrainAction || isRunningOperatorAction)
+
+                        if let metadata = DocumentInspector.inspect(path: brain.activeBrainPath) {
+                            Text(brainMetadataSummary(metadata))
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
 
                         if let parsedBrainOverview {
                             Text(parsedBrainOverview.headline)
@@ -258,6 +285,38 @@ struct CockpitView: View {
                     }
                 } label: {
                     Label("Music", systemImage: "music.note")
+                }
+
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Button(isRunningMorningOps ? "Running..." : "Run Morning Ops") {
+                                Task { await runMorningOps(trigger: "manual") }
+                            }
+                            .disabled(isRunningMorningOps)
+
+                            Toggle("Launch Morning Ops", isOn: $preferences.morningOpsOnLaunch)
+                                .toggleStyle(.switch)
+                        }
+
+                        Toggle("Auto-refresh Now Playing", isOn: $preferences.autoRefreshNowPlaying)
+                            .toggleStyle(.switch)
+
+                        Toggle("Auto-start Daemons on Next Launch", isOn: $preferences.autoStartDaemonsOnLaunch)
+                            .toggleStyle(.switch)
+
+                        if let lastRun = preferences.lastMorningOpsRunAt {
+                            Text("Last run \(lastRun.formatted(date: .abbreviated, time: .shortened))")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text("Morning Ops has not run yet.")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                } label: {
+                    Label("Morning Ops", systemImage: "sun.max")
                 }
 
                 GroupBox {
@@ -374,6 +433,9 @@ struct CockpitView: View {
                                     Button("Script") {
                                         Task { _ = await appState.revealFinderPath(state.scriptPath) }
                                     }
+                                    Button("Inspect") {
+                                        selectedDaemonName = state.serverName
+                                    }
                                 }
 
                                 if let error = state.lastError, !error.isEmpty {
@@ -402,6 +464,38 @@ struct CockpitView: View {
                         }
                     }
                 }
+
+                if let selectedDaemonName,
+                   let selectedState = appState.daemons.runtimeState(for: selectedDaemonName) {
+                    GroupBox {
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text(selectedDaemonName)
+                                    .font(.headline)
+                                Spacer()
+                                Button("Copy Runtime") {
+                                    copyToPasteboard(appState.daemons.runtimeLog(for: selectedDaemonName))
+                                }
+                                Button("Copy Build") {
+                                    copyToPasteboard(appState.daemons.buildLog(for: selectedDaemonName))
+                                }
+                            }
+
+                            Text(selectedState.scriptPath)
+                                .font(.system(.caption2, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+
+                            HSplitView {
+                                logPanel(title: "Runtime Log", text: appState.daemons.runtimeLog(for: selectedDaemonName))
+                                logPanel(title: "Build Log", text: appState.daemons.buildLog(for: selectedDaemonName))
+                            }
+                            .frame(minHeight: 220)
+                        }
+                    } label: {
+                        Label("Daemon Inspector", systemImage: "doc.text.magnifyingglass")
+                    }
+                }
             }
             .padding()
             .frame(minWidth: 320)
@@ -410,9 +504,17 @@ struct CockpitView: View {
         .task {
             guard !hasLoadedInitialPanels else { return }
             hasLoadedInitialPanels = true
-            await loadPersonaMap()
-            await loadBrainOverview()
-            await loadNowPlaying(triggeredByPoll: false)
+            if session.morningOpsRequestID != nil {
+                await runMorningOps(trigger: "request")
+            } else if preferences.morningOpsOnLaunch {
+                await runMorningOps(trigger: "launch")
+            } else {
+                await loadPersonaMap()
+                await loadBrainOverview()
+                if preferences.autoRefreshNowPlaying {
+                    await loadNowPlaying(triggeredByPoll: false)
+                }
+            }
         }
         .task {
             while !Task.isCancelled {
@@ -420,8 +522,22 @@ struct CockpitView: View {
                 if Task.isCancelled {
                     break
                 }
+                guard preferences.autoRefreshNowPlaying else {
+                    continue
+                }
                 await loadNowPlaying(triggeredByPoll: true)
             }
+        }
+        .fileImporter(
+            isPresented: $isSelectingBrainFile,
+            allowedContentTypes: [.json, .item],
+            allowsMultipleSelection: false
+        ) { result in
+            handleBrainSelection(result)
+        }
+        .onChange(of: session.morningOpsRequestID) { _, newValue in
+            guard newValue != nil else { return }
+            Task { await runMorningOps(trigger: "request") }
         }
         .onAppear {
             appState.daemons.refreshRuntimeStates()
@@ -574,5 +690,87 @@ struct CockpitView: View {
         isRunningDaemonAction = true
         defer { isRunningDaemonAction = false }
         await appState.daemons.buildAll()
+    }
+
+    private func runMorningOps(trigger: String) async {
+        guard !isRunningMorningOps else { return }
+        isRunningMorningOps = true
+        defer { isRunningMorningOps = false }
+
+        appState.daemons.refreshRuntimeStates()
+        await scanInboxes()
+        await loadPersonaMap()
+        await loadBrainOverview()
+        if preferences.autoRefreshNowPlaying {
+            await loadNowPlaying(triggeredByPoll: false)
+        }
+        preferences.recordMorningOpsRun()
+        session.morningOpsRequestID = nil
+        operatorResult = "Morning Ops complete (\(trigger))."
+    }
+
+    private func handleBrainSelection(_ result: Result<[URL], Error>) {
+        guard case .success(let urls) = result, let url = urls.first else {
+            if case .failure(let error) = result {
+                operatorResult = "Brain import error: \(error.localizedDescription)"
+            }
+            return
+        }
+
+        Task {
+            await applyBrainSelection(url.path)
+        }
+    }
+
+    private func applyBrainSelection(_ path: String) async {
+        guard !isRunningBrainAction else { return }
+        isRunningBrainAction = true
+        defer { isRunningBrainAction = false }
+
+        do {
+            switch brainSelectionMode {
+            case .custom:
+                try brain.useCustomBrain(path: path)
+            case .importLocal:
+                try brain.importLocalBrain(from: path)
+            }
+            appState.daemons.restart(serverName: "knowledge-corpus")
+            await readiness.refresh()
+            await loadBrainOverview()
+            operatorResult = "Active brain updated: \(brain.activeBrainPath)"
+        } catch {
+            operatorResult = "Brain error: \(error.localizedDescription)"
+        }
+    }
+
+    private func brainMetadataSummary(_ metadata: DocumentMetadata) -> String {
+        var parts: [String] = [metadata.kind.rawValue]
+        if let byteSize = metadata.byteSize {
+            parts.append(ByteCountFormatter.string(fromByteCount: byteSize, countStyle: .file))
+        }
+        if let modifiedAt = metadata.modifiedAt {
+            parts.append("Modified \(modifiedAt.formatted(date: .abbreviated, time: .shortened))")
+        }
+        return parts.joined(separator: " • ")
+    }
+
+    private func logPanel(title: String, text: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            ScrollView {
+                Text(text.isEmpty ? "No log output yet." : text)
+                    .font(.system(.caption2, design: .monospaced))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private func copyToPasteboard(_ text: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        operatorResult = "Copied log output to the clipboard."
     }
 }

--- a/shell/Sources/MojoShell/Views/CockpitView.swift
+++ b/shell/Sources/MojoShell/Views/CockpitView.swift
@@ -103,7 +103,7 @@ struct CockpitView: View {
     @State private var isLoadingNowPlaying = false
     @State private var lastNowPlayingRefresh: Date?
     @State private var hasLoadedInitialPanels = false
-    @State private var operatorResult = "Finder, Safari, Shortcuts, and settings controls are ready."
+    @State private var operatorResult = "Finder, Safari, Terminal, iTerm, Preview, Photos, Shortcuts, and settings controls are ready."
     @State private var isRunningOperatorAction = false
 
     var body: some View {
@@ -259,11 +259,37 @@ struct CockpitView: View {
                             Button("Finder Selection") {
                                 Task { await runOperatorAction(appState.fetchFinderSelection) }
                             }
+                            Button("Preview Selection") {
+                                Task { await runOperatorAction(appState.openFinderSelectionInPreview) }
+                            }
+                            Button("Photos Selection") {
+                                Task { await runOperatorAction(appState.openFinderSelectionInPhotos) }
+                            }
+                        }
+                        .disabled(isRunningOperatorAction)
+
+                        HStack {
+                            Button("Terminal Repo") {
+                                Task { await runOperatorAction(appState.openRepoInTerminal) }
+                            }
+                            Button("iTerm Repo") {
+                                Task { await runOperatorAction(appState.openRepoInITerm) }
+                            }
                             Button("Safari Tab") {
                                 Task { await runOperatorAction(appState.fetchSafariCurrentTab) }
                             }
+                        }
+                        .disabled(isRunningOperatorAction)
+
+                        HStack {
                             Button("Shortcuts") {
                                 Task { await runOperatorAction(appState.listShortcuts) }
+                            }
+                            Button("Screen Recording") {
+                                Task { await runOperatorAction(appState.openScreenRecordingSettings) }
+                            }
+                            Button("Automation") {
+                                Task { await runOperatorAction(appState.openAutomationSettings) }
                             }
                         }
                         .disabled(isRunningOperatorAction)

--- a/shell/Sources/MojoShell/Views/CommandPaletteView.swift
+++ b/shell/Sources/MojoShell/Views/CommandPaletteView.swift
@@ -15,6 +15,7 @@ struct CommandPaletteView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var audit: AuditController
     @EnvironmentObject private var production: ProductionController
+    @EnvironmentObject private var session: ShellSessionController
 
     @State private var query = ""
 
@@ -79,6 +80,15 @@ struct CommandPaletteView: View {
             ) {
                 selectedView = .terminal
                 audit.record(category: .navigation, title: "Open view", detail: ShellView.terminal.rawValue)
+            },
+            PaletteAction(
+                id: "clear-terminal-history",
+                title: "Clear Terminal History",
+                subtitle: "Reset the persisted Agent Terminal transcript.",
+                keywords: ["terminal", "history", "clear", "reset"]
+            ) {
+                session.clearTerminalHistory()
+                selectedView = .terminal
             },
             PaletteAction(
                 id: "nav-production",

--- a/shell/Sources/MojoShell/Views/CommandPaletteView.swift
+++ b/shell/Sources/MojoShell/Views/CommandPaletteView.swift
@@ -14,6 +14,7 @@ struct CommandPaletteView: View {
 
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var audit: AuditController
+    @EnvironmentObject private var brain: BrainManager
     @EnvironmentObject private var production: ProductionController
     @EnvironmentObject private var session: ShellSessionController
 
@@ -117,6 +118,14 @@ struct CommandPaletteView: View {
                 appState.daemons.restartAll()
             },
             PaletteAction(
+                id: "build-all-daemons",
+                title: "Build All Daemons",
+                subtitle: "Run npm build for every MCP server package.",
+                keywords: ["daemon", "build", "mcp", "all"]
+            ) {
+                await appState.daemons.buildAll()
+            },
+            PaletteAction(
                 id: "run-next-workflow",
                 title: "Run Next Workflow",
                 subtitle: "Start the next queued production job.",
@@ -170,6 +179,15 @@ struct CommandPaletteView: View {
                 )
             },
             PaletteAction(
+                id: "clear-finished-jobs",
+                title: "Clear Finished Jobs",
+                subtitle: "Remove completed, failed, and canceled jobs from the active queue.",
+                keywords: ["jobs", "queue", "clear", "finished"]
+            ) {
+                selectedView = .production
+                production.clearFinishedJobs()
+            },
+            PaletteAction(
                 id: "open-downloads",
                 title: "Open Downloads in Finder",
                 subtitle: "Open the Downloads folder.",
@@ -184,6 +202,36 @@ struct CommandPaletteView: View {
                 keywords: ["finder", "repo"]
             ) {
                 _ = await appState.openRepoFolder()
+            },
+            PaletteAction(
+                id: "reveal-active-brain",
+                title: "Reveal Active Brain",
+                subtitle: "Show the current operating brain file in Finder.",
+                keywords: ["brain", "finder", "reveal"]
+            ) {
+                _ = await appState.revealBrainFile()
+            },
+            PaletteAction(
+                id: "use-repo-brain",
+                title: "Use Repo Brain",
+                subtitle: "Switch back to the repo-bundled brain file.",
+                keywords: ["brain", "repo", "default"]
+            ) {
+                brain.useRepoDefault()
+                appState.daemons.restart(serverName: "knowledge-corpus")
+            },
+            PaletteAction(
+                id: "use-local-brain",
+                title: "Use Local Brain",
+                subtitle: "Seed and switch to the user-local brain copy.",
+                keywords: ["brain", "local", "seed"]
+            ) {
+                do {
+                    try brain.useLocalBrain()
+                    appState.daemons.restart(serverName: "knowledge-corpus")
+                } catch {
+                    audit.record(category: .system, title: "Local brain switch failed", detail: error.localizedDescription)
+                }
             },
             PaletteAction(
                 id: "open-repo-terminal",
@@ -256,6 +304,14 @@ struct CommandPaletteView: View {
                 keywords: ["shortcuts", "list"]
             ) {
                 _ = await appState.listShortcuts()
+            },
+            PaletteAction(
+                id: "reveal-audit-log",
+                title: "Reveal Audit Log",
+                subtitle: "Open the persisted audit log location in Finder.",
+                keywords: ["audit", "log", "finder"]
+            ) {
+                _ = await appState.revealFinderPath(audit.filePath)
             },
         ]
 

--- a/shell/Sources/MojoShell/Views/CommandPaletteView.swift
+++ b/shell/Sources/MojoShell/Views/CommandPaletteView.swift
@@ -1,0 +1,246 @@
+import SwiftUI
+
+private struct PaletteAction: Identifiable {
+    let id: String
+    let title: String
+    let subtitle: String
+    let keywords: [String]
+    let perform: @MainActor () async -> Void
+}
+
+struct CommandPaletteView: View {
+    @Binding var isPresented: Bool
+    @Binding var selectedView: ShellView?
+
+    @EnvironmentObject private var appState: AppState
+    @EnvironmentObject private var audit: AuditController
+    @EnvironmentObject private var production: ProductionController
+
+    @State private var query = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            TextField("Search commands", text: $query)
+                .textFieldStyle(.roundedBorder)
+
+            List(filteredActions) { action in
+                Button {
+                    Task {
+                        audit.record(category: .commandPalette, title: "Palette action", detail: action.title)
+                        await action.perform()
+                        isPresented = false
+                    }
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(action.title)
+                        Text(action.subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.plain)
+            }
+            .listStyle(.plain)
+        }
+        .padding()
+        .frame(minWidth: 640, minHeight: 420)
+    }
+
+    private var filteredActions: [PaletteAction] {
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalized.isEmpty else {
+            return actions
+        }
+
+        return actions.filter { action in
+            action.title.lowercased().contains(normalized)
+                || action.subtitle.lowercased().contains(normalized)
+                || action.keywords.contains(where: { $0.lowercased().contains(normalized) })
+        }
+    }
+
+    private var actions: [PaletteAction] {
+        var items: [PaletteAction] = [
+            PaletteAction(
+                id: "nav-cockpit",
+                title: "Open Cockpit",
+                subtitle: "Switch to the shell cockpit.",
+                keywords: ["cockpit", "home", "dashboard"]
+            ) {
+                selectedView = .cockpit
+                audit.record(category: .navigation, title: "Open view", detail: ShellView.cockpit.rawValue)
+            },
+            PaletteAction(
+                id: "nav-terminal",
+                title: "Open Agent Terminal",
+                subtitle: "Switch to the terminal.",
+                keywords: ["terminal", "agent", "command"]
+            ) {
+                selectedView = .terminal
+                audit.record(category: .navigation, title: "Open view", detail: ShellView.terminal.rawValue)
+            },
+            PaletteAction(
+                id: "nav-production",
+                title: "Open Production",
+                subtitle: "Switch to the production runtime.",
+                keywords: ["production", "fcp", "motion"]
+            ) {
+                selectedView = .production
+                audit.record(category: .navigation, title: "Open view", detail: ShellView.production.rawValue)
+            },
+            PaletteAction(
+                id: "nav-audit",
+                title: "Open Audit",
+                subtitle: "Switch to the audit timeline.",
+                keywords: ["audit", "log", "history"]
+            ) {
+                selectedView = .audit
+                audit.record(category: .navigation, title: "Open view", detail: ShellView.audit.rawValue)
+            },
+            PaletteAction(
+                id: "restart-all-daemons",
+                title: "Restart All Daemons",
+                subtitle: "Restart every MCP child process.",
+                keywords: ["daemon", "restart", "mcp", "all"]
+            ) {
+                appState.daemons.restartAll()
+            },
+            PaletteAction(
+                id: "run-next-workflow",
+                title: "Run Next Workflow",
+                subtitle: "Start the next queued production job.",
+                keywords: ["workflow", "run", "queue", "production"]
+            ) {
+                selectedView = .production
+                await production.runNextWorkflow()
+            },
+            PaletteAction(
+                id: "queue-fcp-export",
+                title: "Queue FCP Export",
+                subtitle: "Queue the current timeline export preset.",
+                keywords: ["fcp", "export", "timeline"]
+            ) {
+                selectedView = .production
+                production.queueWorkflowJob(
+                    client: "Palette",
+                    preset: .fcpExportCurrentTimeline,
+                    exportTargetID: production.defaultExportTarget?.id
+                )
+            },
+            PaletteAction(
+                id: "queue-fcp-monitor",
+                title: "Queue FCP Monitor",
+                subtitle: "Queue the background task monitor preset.",
+                keywords: ["fcp", "monitor", "background", "tasks"]
+            ) {
+                selectedView = .production
+                production.queueWorkflowJob(client: "Palette", preset: .fcpMonitorBackgroundTasks)
+            },
+            PaletteAction(
+                id: "queue-motion-review",
+                title: "Queue Motion Review Placeholder",
+                subtitle: "Queue the Motion placeholder review preset.",
+                keywords: ["motion", "placeholder", "review"]
+            ) {
+                selectedView = .production
+                production.queueWorkflowJob(client: "Palette", preset: .motionPlaceholderReview)
+            },
+            PaletteAction(
+                id: "queue-motion-export",
+                title: "Queue Motion Export Placeholder",
+                subtitle: "Queue the Motion placeholder export preset.",
+                keywords: ["motion", "placeholder", "export"]
+            ) {
+                selectedView = .production
+                production.queueWorkflowJob(
+                    client: "Palette",
+                    preset: .motionPlaceholderExport,
+                    exportTargetID: production.defaultExportTarget?.id
+                )
+            },
+            PaletteAction(
+                id: "open-downloads",
+                title: "Open Downloads in Finder",
+                subtitle: "Open the Downloads folder.",
+                keywords: ["finder", "downloads"]
+            ) {
+                _ = await appState.openDownloadsFolder()
+            },
+            PaletteAction(
+                id: "open-repo",
+                title: "Open Repo in Finder",
+                subtitle: "Open the repo root.",
+                keywords: ["finder", "repo"]
+            ) {
+                _ = await appState.openRepoFolder()
+            },
+            PaletteAction(
+                id: "open-accessibility",
+                title: "Open Accessibility Settings",
+                subtitle: "Jump directly to the Accessibility privacy pane.",
+                keywords: ["settings", "accessibility", "tcc"]
+            ) {
+                _ = await appState.openAccessibilitySettings()
+            },
+            PaletteAction(
+                id: "open-screen-recording",
+                title: "Open Screen Recording Settings",
+                subtitle: "Jump directly to the Screen Recording privacy pane.",
+                keywords: ["settings", "screen recording", "tcc"]
+            ) {
+                _ = await appState.openScreenRecordingSettings()
+            },
+            PaletteAction(
+                id: "open-automation-settings",
+                title: "Open Automation Settings",
+                subtitle: "Jump directly to the Automation privacy pane.",
+                keywords: ["settings", "automation", "tcc"]
+            ) {
+                _ = await appState.openAutomationSettings()
+            },
+            PaletteAction(
+                id: "open-full-disk-settings",
+                title: "Open Full Disk Access Settings",
+                subtitle: "Jump directly to the Full Disk Access pane.",
+                keywords: ["settings", "full disk access", "tcc"]
+            ) {
+                _ = await appState.openFullDiskAccessSettings()
+            },
+            PaletteAction(
+                id: "list-shortcuts",
+                title: "List Shortcuts",
+                subtitle: "Run the native shortcuts list action.",
+                keywords: ["shortcuts", "list"]
+            ) {
+                _ = await appState.listShortcuts()
+            },
+        ]
+
+        if let target = production.defaultExportTarget {
+            items.append(
+                PaletteAction(
+                    id: "open-default-export-target",
+                    title: "Open Default Export Target",
+                    subtitle: target.path,
+                    keywords: ["export", "target", "finder"]
+                ) {
+                    _ = await appState.openFinderPath(target.path)
+                }
+            )
+        }
+
+        items.append(contentsOf: appState.daemons.allRuntimeStates.map { state in
+            PaletteAction(
+                id: "restart-\(state.serverName)",
+                title: "Restart \(state.serverName)",
+                subtitle: "Current state: \(state.status.rawValue)",
+                keywords: ["daemon", "restart", state.serverName]
+            ) {
+                appState.daemons.restart(serverName: state.serverName)
+            }
+        })
+
+        return items
+    }
+}

--- a/shell/Sources/MojoShell/Views/CommandPaletteView.swift
+++ b/shell/Sources/MojoShell/Views/CommandPaletteView.swift
@@ -176,6 +176,38 @@ struct CommandPaletteView: View {
                 _ = await appState.openRepoFolder()
             },
             PaletteAction(
+                id: "open-repo-terminal",
+                title: "Open Repo in Terminal",
+                subtitle: "Launch Terminal at the repo root.",
+                keywords: ["terminal", "repo", "shell"]
+            ) {
+                _ = await appState.openRepoInTerminal()
+            },
+            PaletteAction(
+                id: "open-repo-iterm",
+                title: "Open Repo in iTerm",
+                subtitle: "Launch iTerm at the repo root.",
+                keywords: ["iterm", "repo", "shell"]
+            ) {
+                _ = await appState.openRepoInITerm()
+            },
+            PaletteAction(
+                id: "preview-finder-selection",
+                title: "Open Finder Selection in Preview",
+                subtitle: "Preview the first selected Finder item.",
+                keywords: ["preview", "finder", "selection", "artifact"]
+            ) {
+                _ = await appState.openFinderSelectionInPreview()
+            },
+            PaletteAction(
+                id: "photos-finder-selection",
+                title: "Open Finder Selection in Photos",
+                subtitle: "Open the first selected Finder item in Photos.",
+                keywords: ["photos", "finder", "selection", "artifact"]
+            ) {
+                _ = await appState.openFinderSelectionInPhotos()
+            },
+            PaletteAction(
                 id: "open-accessibility",
                 title: "Open Accessibility Settings",
                 subtitle: "Jump directly to the Accessibility privacy pane.",

--- a/shell/Sources/MojoShell/Views/CommandPaletteView.swift
+++ b/shell/Sources/MojoShell/Views/CommandPaletteView.swift
@@ -15,6 +15,7 @@ struct CommandPaletteView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var audit: AuditController
     @EnvironmentObject private var brain: BrainManager
+    @EnvironmentObject private var preferences: ShellPreferencesController
     @EnvironmentObject private var production: ProductionController
     @EnvironmentObject private var session: ShellSessionController
 
@@ -135,6 +136,15 @@ struct CommandPaletteView: View {
                 await production.runNextWorkflow()
             },
             PaletteAction(
+                id: "run-morning-ops",
+                title: "Run Morning Ops",
+                subtitle: "Open Cockpit and run the morning operating refresh.",
+                keywords: ["morning", "ops", "cockpit", "refresh"]
+            ) {
+                selectedView = .cockpit
+                session.requestMorningOpsRun()
+            },
+            PaletteAction(
                 id: "queue-fcp-export",
                 title: "Queue FCP Export",
                 subtitle: "Queue the current timeline export preset.",
@@ -232,6 +242,14 @@ struct CommandPaletteView: View {
                 } catch {
                     audit.record(category: .system, title: "Local brain switch failed", detail: error.localizedDescription)
                 }
+            },
+            PaletteAction(
+                id: "toggle-morning-ops-launch",
+                title: preferences.morningOpsOnLaunch ? "Disable Morning Ops on Launch" : "Enable Morning Ops on Launch",
+                subtitle: "Toggle launch-time morning refresh behavior.",
+                keywords: ["morning", "ops", "launch", "toggle"]
+            ) {
+                preferences.morningOpsOnLaunch.toggle()
             },
             PaletteAction(
                 id: "open-repo-terminal",

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -3,49 +3,39 @@ import SwiftUI
 struct ProductionDashboardView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var readiness: ReadinessState
-    @State private var jobs: [MediaJob] = [
-        MediaJob(
-            name: "Appalachian Community FCU — Benefits Overview",
-            client: "ElanPresentation",
-            status: .completed,
-            progress: 1.0,
-            createdAt: Date().addingTimeInterval(-3600),
-            completedAt: Date(),
-            errorMessage: nil
-        ),
-        MediaJob(
-            name: "FedChoice FCU — Enrollment Video",
-            client: "ElanPresentation",
-            status: .running,
-            progress: 0.62,
-            createdAt: Date().addingTimeInterval(-600),
-            completedAt: nil,
-            errorMessage: nil
-        ),
-        MediaJob(
-            name: "Credit Union 1 — Annual Benefits",
-            client: "ElanPresentation",
-            status: .queued,
-            progress: 0.0,
-            createdAt: Date(),
-            completedAt: nil,
-            errorMessage: nil
-        ),
-    ]
-    @State private var workflowLog = "Ready. Use 'Discover FCP Elements' first to verify accessibility access, then 'Run Assembly Workflow' to trigger the share dialog."
-    @State private var isRunningWorkflow = false
+    @EnvironmentObject private var production: ProductionController
+
     @State private var discoveredElements: [FoundAXElement] = []
     @State private var isDiscovering = false
 
     var body: some View {
         HSplitView {
             VStack(alignment: .leading, spacing: 0) {
-                Label("Job Queue", systemImage: "list.bullet.rectangle")
-                    .font(.headline)
-                    .padding()
+                HStack {
+                    Label("Job Queue", systemImage: "list.bullet.rectangle")
+                        .font(.headline)
+                    Spacer()
+                    Button("Queue Job") {
+                        queueDefaultJob()
+                    }
+                }
+                .padding()
+
                 Divider()
-                List(jobs) { job in
-                    JobRow(job: job)
+
+                if production.jobs.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("No jobs yet")
+                            .font(.headline)
+                        Text("Queue a job, then run assembly.")
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .padding()
+                } else {
+                    List(production.jobs) { job in
+                        JobRow(job: job)
+                    }
                 }
             }
             .frame(minWidth: 360)
@@ -54,6 +44,7 @@ struct ProductionDashboardView: View {
                 Label("FCP / Motion", systemImage: "film.stack")
                     .font(.headline)
                 Divider()
+
                 HStack {
                     Text("Provider: \(appState.computerUseProviderName)")
                     Spacer()
@@ -83,22 +74,40 @@ struct ProductionDashboardView: View {
                             }
                         }
                     } label: {
-                        Label("Final Cut Pro — \(discoveredElements.count) elements", systemImage: "list.bullet.rectangle.portrait")
+                        Label("Final Cut Pro - \(discoveredElements.count) elements", systemImage: "list.bullet.rectangle.portrait")
                     }
                 }
 
                 Divider()
+
                 ScrollView {
-                    Text(workflowLog)
+                    Text(production.workflowLog)
                         .font(.system(.caption, design: .monospaced))
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                Spacer()
-                VStack(alignment: .leading, spacing: 4) {
-                    Button(isRunningWorkflow ? "Running..." : "Run Assembly Workflow") {
-                        Task { await runAssemblyWorkflow() }
+
+                GroupBox {
+                    if production.recentEvents.isEmpty {
+                        Text("No events yet")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    } else {
+                        ForEach(Array(production.recentEvents.suffix(8).reversed())) { event in
+                            EventRow(event: event)
+                        }
                     }
-                    .disabled(isRunningWorkflow || !readiness.isReady(for: .computerUse))
+                } label: {
+                    Label("Recent Events", systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                }
+
+                Spacer()
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Button(production.isRunningWorkflow ? "Running..." : "Run Assembly Workflow") {
+                        Task { await production.runNextAssemblyWorkflow() }
+                    }
+                    .disabled(production.isRunningWorkflow || !readiness.isReady(for: .computerUse))
 
                     if !readiness.isReady(for: .computerUse),
                        let issue = readiness.blockingIssue(for: .computerUse) {
@@ -109,7 +118,7 @@ struct ProductionDashboardView: View {
                 }
             }
             .padding()
-            .frame(minWidth: 280)
+            .frame(minWidth: 320)
         }
         .navigationTitle("Production")
         .task {
@@ -117,87 +126,23 @@ struct ProductionDashboardView: View {
         }
     }
 
+    private func queueDefaultJob() {
+        let stamp = Date().formatted(date: .abbreviated, time: .shortened)
+        production.queueAssemblyJob(name: "Assembly - \(stamp)", client: "Manual")
+    }
+
     private func discoverFcpElements() async {
         isDiscovering = true
-        workflowLog = "Scanning Final Cut Pro accessibility tree…"
+        production.workflowLog = "Scanning Final Cut Pro accessibility tree..."
         do {
             let elements = try AccessibilityElementFinder.findButtons(inApp: "Final Cut Pro")
             discoveredElements = elements
-            workflowLog = "Found \(elements.count) buttons in Final Cut Pro. Coordinates are in global screen space (origin = top-left of primary display)."
+            production.workflowLog = "Found \(elements.count) buttons in Final Cut Pro. Coordinates are in global screen space (origin = top-left of primary display)."
         } catch {
-            workflowLog = "Discovery error: \(error.localizedDescription)"
+            production.workflowLog = "Discovery error: \(error.localizedDescription)"
             discoveredElements = []
         }
         isDiscovering = false
-    }
-
-    private func runAssemblyWorkflow() async {
-        guard let queuedIndex = jobs.firstIndex(where: { $0.status == .queued }) else {
-            workflowLog = "No queued media job available."
-            return
-        }
-
-        isRunningWorkflow = true
-
-        // Preflight: verify FCP is running and has an exportable selection before starting a session.
-        // "Export File (default)…" only appears in the AX tree when a project/clip is selected.
-        workflowLog = "Checking Final Cut Pro export state…"
-        do {
-            let exportItems = try AccessibilityElementFinder.findElements(
-                inApp: "Final Cut Pro",
-                roles: ["AXMenuItem"],
-                titleContaining: "Export File"
-            )
-            guard !exportItems.isEmpty else {
-                workflowLog = "No exportable clip selected in Final Cut Pro. Select a timeline item and try again."
-                isRunningWorkflow = false
-                return
-            }
-        } catch AccessibilityElementFinder.FinderError.appNotRunning {
-            workflowLog = "Final Cut Pro is not running. Open it and load a project first."
-            isRunningWorkflow = false
-            return
-        } catch AccessibilityElementFinder.FinderError.accessibilityPermissionDenied {
-            workflowLog = "Accessibility permission denied. Grant access in System Settings → Privacy & Security → Accessibility."
-            isRunningWorkflow = false
-            return
-        } catch {
-            workflowLog = "Preflight error: \(error.localizedDescription)"
-            isRunningWorkflow = false
-            return
-        }
-
-        jobs[queuedIndex].status = .running
-        jobs[queuedIndex].progress = 0.15
-        workflowLog = "Starting assembly workflow…"
-
-        var sessionId: String?
-        do {
-            sessionId = try await appState.computerUseProvider.startSession()
-            let steps = FcpWorkflowDefinition.assemblyWorkflow()
-            let executor = WorkflowExecutor(provider: appState.computerUseProvider)
-
-            try await executor.run(steps: steps, sessionId: sessionId!) { [self] message in
-                Task { @MainActor in
-                    workflowLog = message
-                }
-            }
-
-            try await appState.computerUseProvider.stopSession(sessionId: sessionId!)
-            sessionId = nil
-            jobs[queuedIndex].status = .completed
-            jobs[queuedIndex].progress = 1.0
-            jobs[queuedIndex].completedAt = Date()
-        } catch {
-            if let id = sessionId {
-                try? await appState.computerUseProvider.stopSession(sessionId: id)
-            }
-            jobs[queuedIndex].status = .failed
-            jobs[queuedIndex].errorMessage = error.localizedDescription
-            workflowLog = "Error: \(error.localizedDescription)"
-        }
-
-        isRunningWorkflow = false
     }
 }
 
@@ -222,6 +167,11 @@ struct JobRow: View {
             Text(job.client)
                 .font(.caption)
                 .foregroundStyle(.secondary)
+            if let error = job.errorMessage, job.status == .failed {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+            }
         }
         .padding(.vertical, 4)
     }
@@ -236,6 +186,33 @@ struct JobRow: View {
             return .green
         case .failed:
             return .red
+        }
+    }
+}
+
+private struct EventRow: View {
+    let event: JobEvent
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(event.timestamp.formatted(date: .omitted, time: .standard))
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 80, alignment: .leading)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(event.type.rawValue)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(event.message)
+                    .font(.caption)
+                if let screenshotPath = event.screenshotPath {
+                    Text(screenshotPath)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
         }
     }
 }

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+struct ProductionDashboardView: View {
+    @State private var jobs: [MediaJob] = [
+        MediaJob(
+            name: "Appalachian Community FCU — Benefits Overview",
+            client: "ElanPresentation",
+            status: .completed,
+            progress: 1.0,
+            createdAt: Date().addingTimeInterval(-3600),
+            completedAt: Date(),
+            errorMessage: nil
+        ),
+        MediaJob(
+            name: "FedChoice FCU — Enrollment Video",
+            client: "ElanPresentation",
+            status: .running,
+            progress: 0.62,
+            createdAt: Date().addingTimeInterval(-600),
+            completedAt: nil,
+            errorMessage: nil
+        ),
+        MediaJob(
+            name: "Credit Union 1 — Annual Benefits",
+            client: "ElanPresentation",
+            status: .queued,
+            progress: 0.0,
+            createdAt: Date(),
+            completedAt: nil,
+            errorMessage: nil
+        ),
+    ]
+
+    var body: some View {
+        HSplitView {
+            VStack(alignment: .leading, spacing: 0) {
+                Label("Job Queue", systemImage: "list.bullet.rectangle")
+                    .font(.headline)
+                    .padding()
+                Divider()
+                List(jobs) { job in
+                    JobRow(job: job)
+                }
+            }
+            .frame(minWidth: 360)
+
+            VStack(alignment: .leading, spacing: 12) {
+                Label("FCP / Motion", systemImage: "film.stack")
+                    .font(.headline)
+                Divider()
+                Text("Computer-use provider: Stub")
+                    .foregroundStyle(.secondary)
+                Text("Real FCP control is deferred to a future computer-use integration.")
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+                Spacer()
+                Button("Run Assembly Workflow (Stub)") {
+                    runAssemblyWorkflow()
+                }
+            }
+            .padding()
+            .frame(minWidth: 280)
+        }
+        .navigationTitle("Production")
+    }
+
+    private func runAssemblyWorkflow() {
+        print("[ProductionDashboard] Assembly workflow triggered — stub provider active")
+    }
+}
+
+struct JobRow: View {
+    let job: MediaJob
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 8, height: 8)
+                Text(job.name).bold()
+                Spacer()
+                Text(job.status.rawValue.capitalized)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+            if job.status == .running {
+                ProgressView(value: job.progress)
+            }
+            Text(job.client)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var statusColor: Color {
+        switch job.status {
+        case .queued:
+            return .gray
+        case .running:
+            return .blue
+        case .completed:
+            return .green
+        case .failed:
+            return .red
+        }
+    }
+}

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ProductionDashboardView: View {
     @EnvironmentObject private var appState: AppState
+    @EnvironmentObject private var readiness: ReadinessState
     @State private var jobs: [MediaJob] = [
         MediaJob(
             name: "Appalachian Community FCU — Benefits Overview",
@@ -59,7 +60,7 @@ struct ProductionDashboardView: View {
                     Button(isDiscovering ? "Scanning..." : "Discover FCP Elements") {
                         Task { await discoverFcpElements() }
                     }
-                    .disabled(isDiscovering)
+                    .disabled(isDiscovering || !readiness.axPermissionGranted())
                 }
                 .foregroundStyle(.secondary)
 
@@ -93,15 +94,27 @@ struct ProductionDashboardView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 Spacer()
-                Button(isRunningWorkflow ? "Running..." : "Run Assembly Workflow") {
-                    Task { await runAssemblyWorkflow() }
+                VStack(alignment: .leading, spacing: 4) {
+                    Button(isRunningWorkflow ? "Running..." : "Run Assembly Workflow") {
+                        Task { await runAssemblyWorkflow() }
+                    }
+                    .disabled(isRunningWorkflow || !readiness.isReady(for: .computerUse))
+
+                    if !readiness.isReady(for: .computerUse),
+                       let issue = readiness.blockingIssue(for: .computerUse) {
+                        Text(issue.fixInstruction)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
-                .disabled(isRunningWorkflow)
             }
             .padding()
             .frame(minWidth: 280)
         }
         .navigationTitle("Production")
+        .task {
+            await readiness.refreshComputerUse()
+        }
     }
 
     private func discoverFcpElements() async {

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct ProductionDashboardView: View {
+    @EnvironmentObject private var appState: AppState
     @State private var jobs: [MediaJob] = [
         MediaJob(
             name: "Appalachian Community FCU — Benefits Overview",
@@ -30,6 +31,8 @@ struct ProductionDashboardView: View {
             errorMessage: nil
         ),
     ]
+    @State private var workflowLog = "Run the stub assembly workflow to exercise the computer-use seam."
+    @State private var isRunningWorkflow = false
 
     var body: some View {
         HSplitView {
@@ -53,10 +56,19 @@ struct ProductionDashboardView: View {
                 Text("Real FCP control is deferred to a future computer-use integration.")
                     .foregroundStyle(.secondary)
                     .font(.callout)
-                Spacer()
-                Button("Run Assembly Workflow (Stub)") {
-                    runAssemblyWorkflow()
+                Divider()
+                ScrollView {
+                    Text(workflowLog)
+                        .font(.system(.caption, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
+                Spacer()
+                Button(isRunningWorkflow ? "Running..." : "Run Assembly Workflow (Stub)") {
+                    Task {
+                        await runAssemblyWorkflow()
+                    }
+                }
+                .disabled(isRunningWorkflow)
             }
             .padding()
             .frame(minWidth: 280)
@@ -64,8 +76,32 @@ struct ProductionDashboardView: View {
         .navigationTitle("Production")
     }
 
-    private func runAssemblyWorkflow() {
-        print("[ProductionDashboard] Assembly workflow triggered — stub provider active")
+    private func runAssemblyWorkflow() async {
+        guard let queuedIndex = jobs.firstIndex(where: { $0.status == .queued }) else {
+            workflowLog = "No queued media job available."
+            return
+        }
+
+        isRunningWorkflow = true
+        jobs[queuedIndex].status = .running
+        jobs[queuedIndex].progress = 0.15
+
+        let jobName = jobs[queuedIndex].name
+        let result = await appState.runAssemblyWorkflow(jobName: jobName)
+
+        switch result {
+        case .success(let output):
+            jobs[queuedIndex].status = .completed
+            jobs[queuedIndex].progress = 1.0
+            jobs[queuedIndex].completedAt = Date()
+            workflowLog = output
+        case .failure(let error):
+            jobs[queuedIndex].status = .failed
+            jobs[queuedIndex].errorMessage = error.localizedDescription
+            workflowLog = "Error: \(error.localizedDescription)"
+        }
+
+        isRunningWorkflow = false
     }
 }
 

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -129,23 +129,27 @@ struct ProductionDashboardView: View {
         jobs[queuedIndex].progress = 0.15
         workflowLog = "Starting assembly workflow…"
 
+        var sessionId: String?
         do {
-            let sessionId = try await appState.computerUseProvider.startSession()
+            sessionId = try await appState.computerUseProvider.startSession()
             let steps = FcpWorkflowDefinition.assemblyWorkflow()
             let executor = WorkflowExecutor(provider: appState.computerUseProvider)
 
-            try await executor.run(steps: steps, sessionId: sessionId) { [self] message in
-                // @MainActor not automatically captured in closure — update on main
+            try await executor.run(steps: steps, sessionId: sessionId!) { [self] message in
                 Task { @MainActor in
                     workflowLog = message
                 }
             }
 
-            try await appState.computerUseProvider.stopSession(sessionId: sessionId)
+            try await appState.computerUseProvider.stopSession(sessionId: sessionId!)
+            sessionId = nil
             jobs[queuedIndex].status = .completed
             jobs[queuedIndex].progress = 1.0
             jobs[queuedIndex].completedAt = Date()
         } catch {
+            if let id = sessionId {
+                try? await appState.computerUseProvider.stopSession(sessionId: id)
+            }
             jobs[queuedIndex].status = .failed
             jobs[queuedIndex].errorMessage = error.localizedDescription
             workflowLog = "Error: \(error.localizedDescription)"

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -7,43 +7,100 @@ struct ProductionDashboardView: View {
 
     @State private var discoveredElements: [FoundAXElement] = []
     @State private var isDiscovering = false
+    @State private var selectedPreset: ProductionWorkflowPreset = .fcpExportCurrentTimeline
+    @State private var selectedExportTargetID: UUID?
+    @State private var newExportTargetName = ""
+    @State private var newExportTargetPath = ""
+    @State private var exportTargetStatus = ""
 
     var body: some View {
         HSplitView {
-            VStack(alignment: .leading, spacing: 0) {
-                HStack {
-                    Label("Job Queue", systemImage: "list.bullet.rectangle")
-                        .font(.headline)
-                    Spacer()
-                    Button("Queue Job") {
-                        queueDefaultJob()
-                    }
-                }
-                .padding()
-
-                Divider()
-
-                if production.jobs.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                GroupBox {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("No jobs yet")
-                            .font(.headline)
-                        Text("Queue a job, then run assembly.")
+                        Picker("Workflow Preset", selection: $selectedPreset) {
+                            ForEach(ProductionWorkflowPreset.allCases) { preset in
+                                Text(preset.title).tag(preset)
+                            }
+                        }
+
+                        Text(selectedPreset.summary)
+                            .font(.caption)
                             .foregroundStyle(.secondary)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                    .padding()
-                } else {
-                    List(production.jobs) { job in
-                        JobRow(job: job) {
-                            production.retryFailedJob(id: job.id)
+
+                        Picker("Export Target", selection: $selectedExportTargetID) {
+                            Text(defaultTargetLabel).tag(Optional<UUID>.none)
+                            ForEach(production.exportTargets) { target in
+                                Text(targetLabel(for: target)).tag(Optional(target.id))
+                            }
+                        }
+                        .disabled(!selectedPreset.requiresExportTarget && production.exportTargets.isEmpty)
+
+                        HStack {
+                            Button("Queue Workflow") {
+                                queueSelectedWorkflow()
+                            }
+
+                            Button("Set Default Target") {
+                                setSelectedDefaultTarget()
+                            }
+                            .disabled(selectedExportTargetID == nil)
+
+                            Button("Open Target") {
+                                Task { await openSelectedExportTarget() }
+                            }
+                            .disabled(activeExportTarget == nil)
+                        }
+
+                        Divider()
+
+                        Text("Add Export Target")
+                            .font(.subheadline)
+                        TextField("Name", text: $newExportTargetName)
+                        TextField("Path", text: $newExportTargetPath)
+                            .textFieldStyle(.roundedBorder)
+                        HStack {
+                            Button("Add Target") {
+                                addExportTarget()
+                            }
+                            Spacer()
+                            if !exportTargetStatus.isEmpty {
+                                Text(exportTargetStatus)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
                         }
                     }
+                } label: {
+                    Label("Queue Builder", systemImage: "shippingbox")
+                }
+
+                GroupBox {
+                    if production.jobs.isEmpty {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("No jobs yet")
+                                .font(.headline)
+                            Text("Queue a workflow preset, then run the next job.")
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    } else {
+                        List(production.jobs) { job in
+                            JobRow(job: job) {
+                                production.retryFailedJob(id: job.id)
+                            }
+                        }
+                        .frame(minHeight: 260)
+                    }
+                } label: {
+                    Label("Job Queue", systemImage: "list.bullet.rectangle")
                 }
             }
-            .frame(minWidth: 360)
+            .padding()
+            .frame(minWidth: 420)
 
             VStack(alignment: .leading, spacing: 12) {
-                Label("FCP / Motion", systemImage: "film.stack")
+                Label("Production Runtime", systemImage: "film.stack")
                     .font(.headline)
                 Divider()
 
@@ -56,6 +113,29 @@ struct ProductionDashboardView: View {
                     .disabled(isDiscovering || !readiness.axPermissionGranted())
                 }
                 .foregroundStyle(.secondary)
+
+                GroupBox {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Selected preset")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(selectedPreset.title)
+                            .font(.headline)
+                        Text(selectedPreset.summary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        if let target = activeExportTarget {
+                            Text("Export target: \(target.name)")
+                                .font(.caption)
+                            Text(target.path)
+                                .font(.system(.caption2, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                    }
+                } label: {
+                    Label("Preset Detail", systemImage: "slider.horizontal.3")
+                }
 
                 if !discoveredElements.isEmpty {
                     GroupBox {
@@ -80,12 +160,15 @@ struct ProductionDashboardView: View {
                     }
                 }
 
-                Divider()
-
-                ScrollView {
-                    Text(production.workflowLog)
-                        .font(.system(.caption, design: .monospaced))
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                GroupBox {
+                    ScrollView {
+                        Text(production.workflowLog)
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .frame(minHeight: 110)
+                } label: {
+                    Label("Workflow Log", systemImage: "terminal")
                 }
 
                 GroupBox {
@@ -95,7 +178,7 @@ struct ProductionDashboardView: View {
                             .foregroundStyle(.secondary)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     } else {
-                        ForEach(Array(production.recentEvents.suffix(8).reversed())) { event in
+                        ForEach(Array(production.recentEvents.suffix(12).reversed())) { event in
                             EventRow(event: event)
                         }
                     }
@@ -128,8 +211,8 @@ struct ProductionDashboardView: View {
                 Spacer()
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Button(production.isRunningWorkflow ? "Running..." : "Run Assembly Workflow") {
-                        Task { await production.runNextAssemblyWorkflow() }
+                    Button(production.isRunningWorkflow ? "Running..." : "Run Next Workflow") {
+                        Task { await production.runNextWorkflow() }
                     }
                     .disabled(production.isRunningWorkflow || !readiness.isReady(for: .computerUse))
 
@@ -142,17 +225,68 @@ struct ProductionDashboardView: View {
                 }
             }
             .padding()
-            .frame(minWidth: 320)
+            .frame(minWidth: 360)
         }
         .navigationTitle("Production")
         .task {
             await readiness.refreshComputerUse()
+            if selectedExportTargetID == nil {
+                selectedExportTargetID = production.defaultExportTarget?.id
+            }
         }
     }
 
-    private func queueDefaultJob() {
-        let stamp = Date().formatted(date: .abbreviated, time: .shortened)
-        production.queueAssemblyJob(name: "Assembly - \(stamp)", client: "Manual")
+    private var activeExportTarget: ExportTarget? {
+        if let selectedExportTargetID {
+            return production.exportTargets.first(where: { $0.id == selectedExportTargetID })
+        }
+        return production.defaultExportTarget
+    }
+
+    private var defaultTargetLabel: String {
+        if let target = production.defaultExportTarget {
+            return "Default (\(target.name))"
+        }
+        return "No default target"
+    }
+
+    private func targetLabel(for target: ExportTarget) -> String {
+        target.isDefault ? "\(target.name) • default" : target.name
+    }
+
+    private func queueSelectedWorkflow() {
+        production.queueWorkflowJob(
+            client: "Manual",
+            preset: selectedPreset,
+            exportTargetID: selectedExportTargetID
+        )
+    }
+
+    private func setSelectedDefaultTarget() {
+        guard let selectedExportTargetID else {
+            return
+        }
+        production.setDefaultExportTarget(id: selectedExportTargetID)
+        exportTargetStatus = "Default target updated."
+    }
+
+    private func addExportTarget() {
+        do {
+            try production.addExportTarget(name: newExportTargetName, path: newExportTargetPath)
+            newExportTargetName = ""
+            newExportTargetPath = ""
+            selectedExportTargetID = production.defaultExportTarget?.id
+            exportTargetStatus = "Export target added."
+        } catch {
+            exportTargetStatus = error.localizedDescription
+        }
+    }
+
+    private func openSelectedExportTarget() async {
+        guard let target = activeExportTarget else {
+            return
+        }
+        _ = await appState.openFinderPath(target.path)
     }
 
     private func discoverFcpElements() async {
@@ -186,12 +320,28 @@ struct JobRow: View {
                     .foregroundStyle(.secondary)
                     .font(.caption)
             }
+
+            if let preset = job.workflowPreset {
+                Text(preset.title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             if job.status == .running {
                 ProgressView(value: job.progress)
             }
+
             Text(job.client)
                 .font(.caption)
                 .foregroundStyle(.secondary)
+
+            if let target = job.exportTargetName ?? job.exportTargetPath {
+                Text(target)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
             if let error = job.errorMessage, (job.status == .failed || job.status == .canceled) {
                 Text(error)
                     .font(.caption2)

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -34,7 +34,9 @@ struct ProductionDashboardView: View {
                     .padding()
                 } else {
                     List(production.jobs) { job in
-                        JobRow(job: job)
+                        JobRow(job: job) {
+                            production.retryFailedJob(id: job.id)
+                        }
                     }
                 }
             }
@@ -148,6 +150,7 @@ struct ProductionDashboardView: View {
 
 struct JobRow: View {
     let job: MediaJob
+    let onRetry: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -171,6 +174,10 @@ struct JobRow: View {
                 Text(error)
                     .font(.caption2)
                     .foregroundStyle(.red)
+                Button("Retry") {
+                    onRetry()
+                }
+                .buttonStyle(.link)
             }
         }
         .padding(.vertical, 4)

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct ProductionDashboardView: View {
@@ -12,6 +13,8 @@ struct ProductionDashboardView: View {
     @State private var newExportTargetName = ""
     @State private var newExportTargetPath = ""
     @State private var exportTargetStatus = ""
+    @State private var selectedJobID: UUID?
+    @State private var selectedArtifactPath: String?
 
     var body: some View {
         HSplitView {
@@ -85,9 +88,12 @@ struct ProductionDashboardView: View {
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                     } else {
-                        List(production.jobs) { job in
-                            JobRow(job: job) {
-                                production.retryFailedJob(id: job.id)
+                        List(selection: $selectedJobID) {
+                            ForEach(production.jobs) { job in
+                                JobRow(job: job) {
+                                    production.retryFailedJob(id: job.id)
+                                }
+                                .tag(job.id)
                             }
                         }
                         .frame(minHeight: 260)
@@ -135,6 +141,101 @@ struct ProductionDashboardView: View {
                     }
                 } label: {
                     Label("Preset Detail", systemImage: "slider.horizontal.3")
+                }
+
+                if let selectedJob {
+                    GroupBox {
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(selectedJob.name)
+                                        .font(.headline)
+                                    Text(selectedJob.client)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Text(selectedJob.status.rawValue.capitalized)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            HStack(spacing: 12) {
+                                Text("Created \(selectedJob.createdAt.formatted(date: .abbreviated, time: .shortened))")
+                                if let completedAt = selectedJob.completedAt {
+                                    Text("Completed \(completedAt.formatted(date: .abbreviated, time: .shortened))")
+                                }
+                            }
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+
+                            if let preset = selectedJob.workflowPreset {
+                                Text("Preset: \(preset.title)")
+                                    .font(.caption)
+                            }
+
+                            if let targetPath = selectedJob.exportTargetPath {
+                                HStack {
+                                    Text(targetPath)
+                                        .font(.system(.caption2, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(2)
+                                    Spacer()
+                                    Button("Open Target") {
+                                        Task { _ = await appState.openFinderPath(targetPath) }
+                                    }
+                                }
+                            }
+
+                            let jobEvents = selectedJobEvents
+                            if jobEvents.isEmpty {
+                                Text("No recorded events for this job yet.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            } else {
+                                ScrollView {
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        ForEach(jobEvents) { event in
+                                            InspectableEventRow(
+                                                event: event,
+                                                isSelectedArtifact: event.screenshotPath == activeArtifactPath
+                                            ) { artifactPath in
+                                                selectedArtifactPath = artifactPath
+                                            }
+                                        }
+                                    }
+                                }
+                                .frame(minHeight: 180)
+                            }
+                        }
+                    } label: {
+                        Label("Selected Job", systemImage: "doc.text.magnifyingglass")
+                    }
+
+                    if let artifactPath = activeArtifactPath {
+                        GroupBox {
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(artifactPath)
+                                    .font(.system(.caption2, design: .monospaced))
+                                    .foregroundStyle(.secondary)
+                                    .textSelection(.enabled)
+                                    .lineLimit(2)
+
+                                ArtifactPreview(path: artifactPath)
+
+                                HStack {
+                                    Button("Preview") {
+                                        Task { _ = await appState.openPathInPreview(artifactPath) }
+                                    }
+                                    Button("Reveal") {
+                                        Task { _ = await appState.revealFinderPath(artifactPath) }
+                                    }
+                                }
+                            }
+                        } label: {
+                            Label("Artifact Preview", systemImage: "photo")
+                        }
+                    }
                 }
 
                 if !discoveredElements.isEmpty {
@@ -233,6 +334,9 @@ struct ProductionDashboardView: View {
             if selectedExportTargetID == nil {
                 selectedExportTargetID = production.defaultExportTarget?.id
             }
+            if selectedJobID == nil {
+                selectedJobID = production.jobs.first?.id
+            }
         }
     }
 
@@ -248,6 +352,28 @@ struct ProductionDashboardView: View {
             return "Default (\(target.name))"
         }
         return "No default target"
+    }
+
+    private var selectedJob: MediaJob? {
+        if let selectedJobID, let selected = production.jobs.first(where: { $0.id == selectedJobID }) {
+            return selected
+        }
+        return production.jobs.first
+    }
+
+    private var selectedJobEvents: [JobEvent] {
+        guard let selectedJob else {
+            return []
+        }
+        return production.events(for: selectedJob.id)
+    }
+
+    private var activeArtifactPath: String? {
+        if let selectedArtifactPath,
+           selectedJobEvents.contains(where: { $0.screenshotPath == selectedArtifactPath }) {
+            return selectedArtifactPath
+        }
+        return selectedJobEvents.compactMap(\.screenshotPath).first
     }
 
     private func targetLabel(for target: ExportTarget) -> String {
@@ -394,6 +520,72 @@ private struct EventRow: View {
                 }
             }
             Spacer()
+        }
+    }
+}
+
+private struct InspectableEventRow: View {
+    let event: JobEvent
+    let isSelectedArtifact: Bool
+    let onSelectArtifact: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .top, spacing: 8) {
+                Text(event.timestamp.formatted(date: .omitted, time: .standard))
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 80, alignment: .leading)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(event.type.rawValue)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(event.message)
+                        .font(.caption)
+                    if let progress = event.progress {
+                        Text("Progress \(Int(progress * 100))%")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+            }
+
+            if let screenshotPath = event.screenshotPath {
+                HStack {
+                    Text(screenshotPath)
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                    Spacer()
+                    Button(isSelectedArtifact ? "Selected" : "Inspect") {
+                        onSelectArtifact(screenshotPath)
+                    }
+                    .disabled(isSelectedArtifact)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+private struct ArtifactPreview: View {
+    let path: String
+
+    var body: some View {
+        Group {
+            if let image = NSImage(contentsOfFile: path) {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity, minHeight: 180, maxHeight: 220)
+                    .background(.background)
+            } else {
+                Text("No image preview available for this artifact.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 120, alignment: .leading)
+            }
         }
     }
 }

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -31,7 +31,7 @@ struct ProductionDashboardView: View {
             errorMessage: nil
         ),
     ]
-    @State private var workflowLog = "Run the stub assembly workflow to exercise the computer-use seam."
+    @State private var workflowLog = "Configure MOJOSHELL_ASSEMBLY_CLICK_TARGET=x,y to run a real assembly action."
     @State private var isRunningWorkflow = false
 
     var body: some View {
@@ -51,9 +51,9 @@ struct ProductionDashboardView: View {
                 Label("FCP / Motion", systemImage: "film.stack")
                     .font(.headline)
                 Divider()
-                Text("Computer-use provider: Stub")
+                Text("Computer-use provider: \(appState.computerUseProviderName)")
                     .foregroundStyle(.secondary)
-                Text("Real FCP control is deferred to a future computer-use integration.")
+                Text("Phase 1 uses coordinate-driven computer use. Configure the assembly click target before running a live action.")
                     .foregroundStyle(.secondary)
                     .font(.callout)
                 Divider()
@@ -63,7 +63,7 @@ struct ProductionDashboardView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 Spacer()
-                Button(isRunningWorkflow ? "Running..." : "Run Assembly Workflow (Stub)") {
+                Button(isRunningWorkflow ? "Running..." : "Run Assembly Workflow") {
                     Task {
                         await runAssemblyWorkflow()
                     }

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -103,6 +103,28 @@ struct ProductionDashboardView: View {
                     Label("Recent Events", systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90")
                 }
 
+                if let approval = production.pendingApproval {
+                    GroupBox {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Step \(approval.stepIndex + 1): \(approval.stepDescription)")
+                                .font(.headline)
+                            Text(approval.prompt)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            HStack {
+                                Button("Approve") {
+                                    production.approvePendingStep()
+                                }
+                                Button("Reject") {
+                                    production.rejectPendingStep()
+                                }
+                            }
+                        }
+                    } label: {
+                        Label("Approval Required", systemImage: "hand.raised")
+                    }
+                }
+
                 Spacer()
 
                 VStack(alignment: .leading, spacing: 4) {
@@ -170,10 +192,10 @@ struct JobRow: View {
             Text(job.client)
                 .font(.caption)
                 .foregroundStyle(.secondary)
-            if let error = job.errorMessage, job.status == .failed {
+            if let error = job.errorMessage, (job.status == .failed || job.status == .canceled) {
                 Text(error)
                     .font(.caption2)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(job.status == .canceled ? .orange : .red)
                 Button("Retry") {
                     onRetry()
                 }
@@ -193,6 +215,8 @@ struct JobRow: View {
             return .green
         case .failed:
             return .red
+        case .canceled:
+            return .orange
         }
     }
 }

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -1,20 +1,26 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct ProductionDashboardView: View {
     @EnvironmentObject private var appState: AppState
     @EnvironmentObject private var readiness: ReadinessState
     @EnvironmentObject private var production: ProductionController
+    @EnvironmentObject private var session: ShellSessionController
 
     @State private var discoveredElements: [FoundAXElement] = []
     @State private var isDiscovering = false
     @State private var selectedPreset: ProductionWorkflowPreset = .fcpExportCurrentTimeline
     @State private var selectedExportTargetID: UUID?
+    @State private var selectedApprovalMode: WorkflowApprovalMode = .smart
     @State private var newExportTargetName = ""
     @State private var newExportTargetPath = ""
     @State private var exportTargetStatus = ""
     @State private var selectedJobID: UUID?
     @State private var selectedArtifactPath: String?
+    @State private var queuedSourceAssets: [SourceAsset] = []
+    @State private var workflowNotes = ""
+    @State private var isImportingSourceAssets = false
 
     var body: some View {
         HSplitView {
@@ -39,6 +45,16 @@ struct ProductionDashboardView: View {
                         }
                         .disabled(!selectedPreset.requiresExportTarget && production.exportTargets.isEmpty)
 
+                        Picker("Approval Policy", selection: $selectedApprovalMode) {
+                            ForEach(WorkflowApprovalMode.allCases) { mode in
+                                Text(mode.title).tag(mode)
+                            }
+                        }
+
+                        Text(selectedApprovalMode.summary)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
                         HStack {
                             Button("Queue Workflow") {
                                 queueSelectedWorkflow()
@@ -53,6 +69,69 @@ struct ProductionDashboardView: View {
                                 Task { await openSelectedExportTarget() }
                             }
                             .disabled(activeExportTarget == nil)
+                        }
+
+                        if selectedPreset.supportsSourceAssets {
+                            Divider()
+
+                            Text("Source Assets")
+                                .font(.subheadline)
+
+                            HStack {
+                                Button("Add Files") {
+                                    isImportingSourceAssets = true
+                                }
+                                Button("Use Finder Selection") {
+                                    Task { await useFinderSelectionAsSourceAssets() }
+                                }
+                                Button("Clear") {
+                                    queuedSourceAssets.removeAll()
+                                }
+                                .disabled(queuedSourceAssets.isEmpty)
+                            }
+
+                            if queuedSourceAssets.isEmpty {
+                                Text("No source assets attached.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            } else {
+                                VStack(alignment: .leading, spacing: 6) {
+                                    ForEach(queuedSourceAssets) { asset in
+                                        HStack {
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                Text(asset.name)
+                                                    .font(.caption)
+                                                Text(asset.path)
+                                                    .font(.system(.caption2, design: .monospaced))
+                                                    .foregroundStyle(.secondary)
+                                                    .lineLimit(1)
+                                            }
+                                            Spacer()
+                                            Text(asset.kind.rawValue)
+                                                .font(.caption2)
+                                                .foregroundStyle(.secondary)
+                                            if let byteSize = asset.byteSize {
+                                                Text(ByteCountFormatter.string(fromByteCount: byteSize, countStyle: .file))
+                                                    .font(.caption2)
+                                                    .foregroundStyle(.secondary)
+                                            }
+                                            Button("Remove") {
+                                                removeSourceAsset(id: asset.id)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            Text("Operator Notes")
+                                .font(.subheadline)
+                            TextEditor(text: $workflowNotes)
+                                .font(.system(.caption, design: .monospaced))
+                                .frame(minHeight: 80)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .stroke(.separator, lineWidth: 1)
+                                )
                         }
 
                         Divider()
@@ -174,6 +253,13 @@ struct ProductionDashboardView: View {
                                     .font(.caption)
                             }
 
+                            Text("Workflow version: \(selectedJob.workflowVersion)")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Text("Approval policy: \(selectedJob.approvalMode.title)")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+
                             if let targetPath = selectedJob.exportTargetPath {
                                 HStack {
                                     Text(targetPath)
@@ -183,6 +269,41 @@ struct ProductionDashboardView: View {
                                     Spacer()
                                     Button("Open Target") {
                                         Task { _ = await appState.openFinderPath(targetPath) }
+                                    }
+                                }
+                            }
+
+                            if let notes = selectedJob.notes {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text("Notes")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                    Text(notes)
+                                        .font(.caption)
+                                        .textSelection(.enabled)
+                                }
+                            }
+
+                            if !selectedJob.sourceAssets.isEmpty {
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text("Source Assets")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                    ForEach(selectedJob.sourceAssets) { asset in
+                                        HStack {
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                Text(asset.name)
+                                                    .font(.caption)
+                                                Text(asset.path)
+                                                    .font(.system(.caption2, design: .monospaced))
+                                                    .foregroundStyle(.secondary)
+                                                    .lineLimit(1)
+                                            }
+                                            Spacer()
+                                            Button("Open") {
+                                                Task { _ = await appState.openFinderPath(asset.path) }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -220,6 +341,10 @@ struct ProductionDashboardView: View {
                                     .foregroundStyle(.secondary)
                                     .textSelection(.enabled)
                                     .lineLimit(2)
+
+                                if let metadata = activeArtifactMetadata {
+                                    ArtifactMetadataView(metadata: metadata)
+                                }
 
                                 ArtifactPreview(path: artifactPath)
 
@@ -331,11 +456,31 @@ struct ProductionDashboardView: View {
         .navigationTitle("Production")
         .task {
             await readiness.refreshComputerUse()
-            if selectedExportTargetID == nil {
-                selectedExportTargetID = production.defaultExportTarget?.id
+            hydrateSessionPreferencesIfNeeded()
+        }
+        .fileImporter(
+            isPresented: $isImportingSourceAssets,
+            allowedContentTypes: [.item],
+            allowsMultipleSelection: true
+        ) { result in
+            handleImportedSourceAssets(result)
+        }
+        .onChange(of: selectedPreset) { _, newValue in
+            session.preferredPreset = newValue
+            if !newValue.supportsSourceAssets {
+                queuedSourceAssets.removeAll()
+                workflowNotes = ""
             }
-            if selectedJobID == nil {
-                selectedJobID = production.jobs.first?.id
+        }
+        .onChange(of: selectedExportTargetID) { _, newValue in
+            session.preferredExportTargetID = newValue
+        }
+        .onChange(of: selectedApprovalMode) { _, newValue in
+            session.preferredApprovalMode = newValue
+        }
+        .onChange(of: selectedJobID) { _, newValue in
+            if let newValue, production.jobs.contains(where: { $0.id == newValue }) {
+                selectedArtifactPath = production.events(for: newValue).compactMap(\.screenshotPath).first
             }
         }
     }
@@ -376,6 +521,13 @@ struct ProductionDashboardView: View {
         return selectedJobEvents.compactMap(\.screenshotPath).first
     }
 
+    private var activeArtifactMetadata: DocumentMetadata? {
+        guard let activeArtifactPath else {
+            return nil
+        }
+        return DocumentInspector.inspect(path: activeArtifactPath)
+    }
+
     private func targetLabel(for target: ExportTarget) -> String {
         target.isDefault ? "\(target.name) • default" : target.name
     }
@@ -384,8 +536,13 @@ struct ProductionDashboardView: View {
         production.queueWorkflowJob(
             client: "Manual",
             preset: selectedPreset,
-            exportTargetID: selectedExportTargetID
+            exportTargetID: selectedExportTargetID,
+            sourceAssets: queuedSourceAssets,
+            notes: workflowNotes,
+            approvalMode: selectedApprovalMode
         )
+        queuedSourceAssets.removeAll()
+        workflowNotes = ""
     }
 
     private func setSelectedDefaultTarget() {
@@ -413,6 +570,54 @@ struct ProductionDashboardView: View {
             return
         }
         _ = await appState.openFinderPath(target.path)
+    }
+
+    private func handleImportedSourceAssets(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            appendSourceAssets(paths: urls.map(\.path))
+        case .failure(let error):
+            exportTargetStatus = error.localizedDescription
+        }
+    }
+
+    private func appendSourceAssets(paths: [String]) {
+        let existingPaths = Set(queuedSourceAssets.map(\.path))
+        let additions = paths.compactMap(SourceAsset.from).filter { !existingPaths.contains($0.path) }
+        queuedSourceAssets.append(contentsOf: additions)
+    }
+
+    private func removeSourceAsset(id: UUID) {
+        queuedSourceAssets.removeAll { $0.id == id }
+    }
+
+    private func useFinderSelectionAsSourceAssets() async {
+        let result = await appState.fetchFinderSelectionPaths()
+        switch result {
+        case .success(let paths):
+            appendSourceAssets(paths: paths)
+            exportTargetStatus = paths.isEmpty ? "Finder selection is empty." : "Added \(paths.count) Finder-selected item(s)."
+        case .failure(let error):
+            exportTargetStatus = error.localizedDescription
+        }
+    }
+
+    private func hydrateSessionPreferencesIfNeeded() {
+        if selectedPreset != session.preferredPreset {
+            selectedPreset = session.preferredPreset
+        }
+        if selectedExportTargetID == nil {
+            selectedExportTargetID = session.preferredExportTargetID ?? production.defaultExportTarget?.id
+        }
+        if selectedApprovalMode != session.preferredApprovalMode {
+            selectedApprovalMode = session.preferredApprovalMode
+        }
+        if selectedJobID == nil {
+            selectedJobID = production.jobs.first?.id
+        }
+        if let selectedJobID {
+            selectedArtifactPath = production.events(for: selectedJobID).compactMap(\.screenshotPath).first
+        }
     }
 
     private func discoverFcpElements() async {
@@ -450,6 +655,12 @@ struct JobRow: View {
             if let preset = job.workflowPreset {
                 Text(preset.title)
                     .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !job.sourceAssets.isEmpty {
+                Text("\(job.sourceAssets.count) source asset(s)")
+                    .font(.caption2)
                     .foregroundStyle(.secondary)
             }
 
@@ -585,6 +796,38 @@ private struct ArtifactPreview: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, minHeight: 120, alignment: .leading)
+            }
+        }
+    }
+}
+
+private struct ArtifactMetadataView: View {
+    let metadata: DocumentMetadata
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let byteSize = metadata.byteSize {
+                Text("Size: \(ByteCountFormatter.string(fromByteCount: byteSize, countStyle: .file))")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let width = metadata.pixelWidth, let height = metadata.pixelHeight {
+                Text("Dimensions: \(width) × \(height)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let contentType = metadata.contentType {
+                Text("Type: \(contentType)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let modifiedAt = metadata.modifiedAt {
+                Text("Modified: \(modifiedAt.formatted(date: .abbreviated, time: .shortened))")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
             }
         }
     }

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -59,6 +59,9 @@ struct ProductionDashboardView: View {
                             Button("Queue Workflow") {
                                 queueSelectedWorkflow()
                             }
+                            Button("Clear Finished") {
+                                production.clearFinishedJobs()
+                            }
 
                             Button("Set Default Target") {
                                 setSelectedDefaultTarget()
@@ -259,6 +262,35 @@ struct ProductionDashboardView: View {
                             Text("Approval policy: \(selectedJob.approvalMode.title)")
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
+
+                            HStack {
+                                if selectedJob.status == .failed || selectedJob.status == .canceled {
+                                    Button("Retry") {
+                                        production.retryFailedJob(id: selectedJob.id)
+                                    }
+                                }
+                                Button("Duplicate") {
+                                    production.duplicateJob(id: selectedJob.id)
+                                }
+                                if selectedJob.status == .queued {
+                                    Button("Prioritize") {
+                                        production.prioritizeQueuedJob(id: selectedJob.id)
+                                    }
+                                    Button("Cancel") {
+                                        production.cancelQueuedJob(id: selectedJob.id)
+                                    }
+                                }
+                                if selectedJob.status != .running {
+                                    Button("Remove") {
+                                        let removedID = selectedJob.id
+                                        production.removeJob(id: removedID)
+                                        if selectedJobID == removedID {
+                                            selectedJobID = production.jobs.first?.id
+                                        }
+                                    }
+                                }
+                            }
+                            .font(.caption)
 
                             if let targetPath = selectedJob.exportTargetPath {
                                 HStack {

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -125,6 +125,35 @@ struct ProductionDashboardView: View {
         }
 
         isRunningWorkflow = true
+
+        // Preflight: verify FCP is running and has an exportable selection before starting a session.
+        // "Export File (default)…" only appears in the AX tree when a project/clip is selected.
+        workflowLog = "Checking Final Cut Pro export state…"
+        do {
+            let exportItems = try AccessibilityElementFinder.findElements(
+                inApp: "Final Cut Pro",
+                roles: ["AXMenuItem"],
+                titleContaining: "Export File"
+            )
+            guard !exportItems.isEmpty else {
+                workflowLog = "No exportable clip selected in Final Cut Pro. Select a timeline item and try again."
+                isRunningWorkflow = false
+                return
+            }
+        } catch AccessibilityElementFinder.FinderError.appNotRunning {
+            workflowLog = "Final Cut Pro is not running. Open it and load a project first."
+            isRunningWorkflow = false
+            return
+        } catch AccessibilityElementFinder.FinderError.accessibilityPermissionDenied {
+            workflowLog = "Accessibility permission denied. Grant access in System Settings → Privacy & Security → Accessibility."
+            isRunningWorkflow = false
+            return
+        } catch {
+            workflowLog = "Preflight error: \(error.localizedDescription)"
+            isRunningWorkflow = false
+            return
+        }
+
         jobs[queuedIndex].status = .running
         jobs[queuedIndex].progress = 0.15
         workflowLog = "Starting assembly workflow…"

--- a/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
+++ b/shell/Sources/MojoShell/Views/ProductionDashboardView.swift
@@ -31,8 +31,10 @@ struct ProductionDashboardView: View {
             errorMessage: nil
         ),
     ]
-    @State private var workflowLog = "Configure MOJOSHELL_ASSEMBLY_CLICK_TARGET=x,y to run a real assembly action."
+    @State private var workflowLog = "Ready. Use 'Discover FCP Elements' first to verify accessibility access, then 'Run Assembly Workflow' to trigger the share dialog."
     @State private var isRunningWorkflow = false
+    @State private var discoveredElements: [FoundAXElement] = []
+    @State private var isDiscovering = false
 
     var body: some View {
         HSplitView {
@@ -51,11 +53,39 @@ struct ProductionDashboardView: View {
                 Label("FCP / Motion", systemImage: "film.stack")
                     .font(.headline)
                 Divider()
-                Text("Computer-use provider: \(appState.computerUseProviderName)")
-                    .foregroundStyle(.secondary)
-                Text("Phase 1 uses coordinate-driven computer use. Configure the assembly click target before running a live action.")
-                    .foregroundStyle(.secondary)
-                    .font(.callout)
+                HStack {
+                    Text("Provider: \(appState.computerUseProviderName)")
+                    Spacer()
+                    Button(isDiscovering ? "Scanning..." : "Discover FCP Elements") {
+                        Task { await discoverFcpElements() }
+                    }
+                    .disabled(isDiscovering)
+                }
+                .foregroundStyle(.secondary)
+
+                if !discoveredElements.isEmpty {
+                    GroupBox {
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(discoveredElements) { element in
+                                HStack(spacing: 8) {
+                                    Text("\(Int(element.screenPoint.x)),\(Int(element.screenPoint.y))")
+                                        .font(.system(.caption2, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                        .frame(width: 90, alignment: .leading)
+                                    Text(element.title.isEmpty ? "(untitled)" : element.title)
+                                        .font(.caption)
+                                    Spacer()
+                                    Text(element.role)
+                                        .font(.caption2)
+                                        .foregroundStyle(.tertiary)
+                                }
+                            }
+                        }
+                    } label: {
+                        Label("Final Cut Pro — \(discoveredElements.count) elements", systemImage: "list.bullet.rectangle.portrait")
+                    }
+                }
+
                 Divider()
                 ScrollView {
                     Text(workflowLog)
@@ -64,9 +94,7 @@ struct ProductionDashboardView: View {
                 }
                 Spacer()
                 Button(isRunningWorkflow ? "Running..." : "Run Assembly Workflow") {
-                    Task {
-                        await runAssemblyWorkflow()
-                    }
+                    Task { await runAssemblyWorkflow() }
                 }
                 .disabled(isRunningWorkflow)
             }
@@ -74,6 +102,20 @@ struct ProductionDashboardView: View {
             .frame(minWidth: 280)
         }
         .navigationTitle("Production")
+    }
+
+    private func discoverFcpElements() async {
+        isDiscovering = true
+        workflowLog = "Scanning Final Cut Pro accessibility tree…"
+        do {
+            let elements = try AccessibilityElementFinder.findButtons(inApp: "Final Cut Pro")
+            discoveredElements = elements
+            workflowLog = "Found \(elements.count) buttons in Final Cut Pro. Coordinates are in global screen space (origin = top-left of primary display)."
+        } catch {
+            workflowLog = "Discovery error: \(error.localizedDescription)"
+            discoveredElements = []
+        }
+        isDiscovering = false
     }
 
     private func runAssemblyWorkflow() async {
@@ -85,17 +127,25 @@ struct ProductionDashboardView: View {
         isRunningWorkflow = true
         jobs[queuedIndex].status = .running
         jobs[queuedIndex].progress = 0.15
+        workflowLog = "Starting assembly workflow…"
 
-        let jobName = jobs[queuedIndex].name
-        let result = await appState.runAssemblyWorkflow(jobName: jobName)
+        do {
+            let sessionId = try await appState.computerUseProvider.startSession()
+            let steps = FcpWorkflowDefinition.assemblyWorkflow()
+            let executor = WorkflowExecutor(provider: appState.computerUseProvider)
 
-        switch result {
-        case .success(let output):
+            try await executor.run(steps: steps, sessionId: sessionId) { [self] message in
+                // @MainActor not automatically captured in closure — update on main
+                Task { @MainActor in
+                    workflowLog = message
+                }
+            }
+
+            try await appState.computerUseProvider.stopSession(sessionId: sessionId)
             jobs[queuedIndex].status = .completed
             jobs[queuedIndex].progress = 1.0
             jobs[queuedIndex].completedAt = Date()
-            workflowLog = output
-        case .failure(let error):
+        } catch {
             jobs[queuedIndex].status = .failed
             jobs[queuedIndex].errorMessage = error.localizedDescription
             workflowLog = "Error: \(error.localizedDescription)"

--- a/shell/Tests/MojoShellTests/AppStateTests.swift
+++ b/shell/Tests/MojoShellTests/AppStateTests.swift
@@ -150,6 +150,50 @@ final class AppStateTests: XCTestCase {
             XCTFail("Expected native tool execution success, got \(error)")
         }
     }
+
+    func testOpenFinderSelectionInPreviewUsesNativeSelectionTool() async {
+        let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
+        let executor = MCPToolExecutor(daemonManager: daemonManager)
+        let nativeExecutor = FakeNativeToolExecutor()
+        let appState = AppState(
+            daemons: daemonManager,
+            executor: executor,
+            computerUseProvider: FakeComputerUseProvider(),
+            nativeExecutor: nativeExecutor
+        )
+
+        let result = await appState.openFinderSelectionInPreview()
+
+        switch result {
+        case .success:
+            let invocation = await nativeExecutor.invocations.last
+            XCTAssertEqual(invocation?.tool, NativeToolName.finderSelectionOpenInPreview.rawValue)
+        case .failure(let error):
+            XCTFail("Expected preview selection success, got \(error)")
+        }
+    }
+
+    func testOpenRepoInTerminalUsesNativeTerminalTool() async {
+        let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
+        let executor = MCPToolExecutor(daemonManager: daemonManager)
+        let nativeExecutor = FakeNativeToolExecutor()
+        let appState = AppState(
+            daemons: daemonManager,
+            executor: executor,
+            computerUseProvider: FakeComputerUseProvider(),
+            nativeExecutor: nativeExecutor
+        )
+
+        let result = await appState.openRepoInTerminal()
+
+        switch result {
+        case .success:
+            let invocation = await nativeExecutor.invocations.last
+            XCTAssertEqual(invocation?.tool, NativeToolName.terminalOpenRepo.rawValue)
+        case .failure(let error):
+            XCTFail("Expected terminal open success, got \(error)")
+        }
+    }
 }
 
 // MARK: - Test doubles
@@ -171,8 +215,16 @@ actor FakeComputerUseProvider: ComputerUseProvider {
 }
 
 actor FakeNativeToolExecutor: NativeToolExecuting {
-    func execute(tool: String, arguments _: [String: AnyCodable]) async throws -> MCPToolExecutionResult {
-        MCPToolExecutionResult(server: NativeToolExecutor.serverName, tool: tool, text: "native result")
+    struct Invocation: Equatable {
+        let tool: String
+        let arguments: [String: AnyCodable]
+    }
+
+    private(set) var invocations: [Invocation] = []
+
+    func execute(tool: String, arguments: [String: AnyCodable]) async throws -> MCPToolExecutionResult {
+        invocations.append(Invocation(tool: tool, arguments: arguments))
+        return MCPToolExecutionResult(server: NativeToolExecutor.serverName, tool: tool, text: "native result")
     }
 }
 

--- a/shell/Tests/MojoShellTests/AppStateTests.swift
+++ b/shell/Tests/MojoShellTests/AppStateTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import MojoShell
+
+@MainActor
+final class AppStateTests: XCTestCase {
+    func testRunAssemblyWorkflowIncludesJobNameAndProviderState() async {
+        let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
+        let executor = MCPToolExecutor(daemonManager: daemonManager)
+        let provider = FakeComputerUseProvider()
+        let appState = AppState(
+            daemons: daemonManager,
+            executor: executor,
+            computerUseProvider: provider
+        )
+
+        let result = await appState.runAssemblyWorkflow(jobName: "Demo Job")
+
+        switch result {
+        case .success(let output):
+            XCTAssertTrue(output.contains("Demo Job"))
+            XCTAssertTrue(output.contains("fake-cu"))
+            XCTAssertTrue(output.contains("executed"))
+        case .failure(let error):
+            XCTFail("Expected success, got \(error)")
+        }
+    }
+}
+
+actor FakeComputerUseProvider: ComputerUseProvider {
+    let name = "fake-cu"
+
+    func startSession() async throws -> String {
+        "fake-session"
+    }
+
+    func captureState(sessionId _: String) async throws -> ComputerUseState {
+        ComputerUseState(appName: "fake-cu", screenshotData: nil, timestamp: Date())
+    }
+
+    func execute(sessionId _: String, action _: ComputerUseAction) async throws -> ComputerUseResult {
+        ComputerUseResult(success: true, message: "executed", screenshotAfter: nil)
+    }
+
+    func stopSession(sessionId _: String) async throws {}
+}

--- a/shell/Tests/MojoShellTests/AppStateTests.swift
+++ b/shell/Tests/MojoShellTests/AppStateTests.swift
@@ -10,7 +10,8 @@ final class AppStateTests: XCTestCase {
         let appState = AppState(
             daemons: daemonManager,
             executor: executor,
-            computerUseProvider: FakeComputerUseProvider()
+            computerUseProvider: FakeComputerUseProvider(),
+            nativeExecutor: FakeNativeToolExecutor()
         )
         XCTAssertEqual(appState.computerUseProviderName, "fake-cu")
     }
@@ -22,6 +23,7 @@ final class AppStateTests: XCTestCase {
             daemons: daemonManager,
             executor: executor,
             computerUseProvider: FakeComputerUseProvider(),
+            nativeExecutor: FakeNativeToolExecutor(),
             llmProviders: [
                 FakeLLMProvider(name: "claude", response: LLMResponse(text: "", resolvedTool: nil)),
                 FakeLLMProvider(name: "openai", response: LLMResponse(text: "", resolvedTool: nil)),
@@ -41,6 +43,7 @@ final class AppStateTests: XCTestCase {
             daemons: daemonManager,
             executor: executor,
             computerUseProvider: FakeComputerUseProvider(),
+            nativeExecutor: FakeNativeToolExecutor(),
             llmProviders: llmProviders
         )
 
@@ -51,6 +54,67 @@ final class AppStateTests: XCTestCase {
             XCTAssertEqual(text, "fallback response")
         case .failure(let error):
             XCTFail("Expected fallback success, got \(error)")
+        }
+    }
+
+    func testExecuteRoutesShellNativeToolsToNativeExecutor() async {
+        let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
+        let executor = MCPToolExecutor(daemonManager: daemonManager)
+        let nativeExecutor = FakeNativeToolExecutor()
+        let appState = AppState(
+            daemons: daemonManager,
+            executor: executor,
+            computerUseProvider: FakeComputerUseProvider(),
+            nativeExecutor: nativeExecutor
+        )
+
+        let result = await appState.execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.shortcutsList.rawValue,
+                arguments: [:]
+            )
+        )
+
+        switch result {
+        case .success(let output):
+            XCTAssertEqual(output.text, "native result")
+        case .failure(let error):
+            XCTFail("Expected native execution success, got \(error)")
+        }
+    }
+
+    func testResolveWithLLMExecutesShellNativeResolvedTool() async {
+        let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
+        let executor = MCPToolExecutor(daemonManager: daemonManager)
+        let nativeExecutor = FakeNativeToolExecutor()
+        let appState = AppState(
+            daemons: daemonManager,
+            executor: executor,
+            computerUseProvider: FakeComputerUseProvider(),
+            nativeExecutor: nativeExecutor,
+            llmProviders: [
+                FakeLLMProvider(
+                    name: "claude",
+                    response: LLMResponse(
+                        text: "",
+                        resolvedTool: ResolvedTool(
+                            server: NativeToolExecutor.serverName,
+                            tool: NativeToolName.systemSettingsOpen.rawValue,
+                            arguments: ["pane": .string("accessibility")]
+                        )
+                    )
+                ),
+            ]
+        )
+
+        let result = await appState.resolveWithLLM(prompt: "open accessibility settings", availableTools: [])
+
+        switch result {
+        case .success(let text):
+            XCTAssertEqual(text, "native result")
+        case .failure(let error):
+            XCTFail("Expected native tool execution success, got \(error)")
         }
     }
 }
@@ -71,6 +135,12 @@ actor FakeComputerUseProvider: ComputerUseProvider {
     }
 
     func stopSession(sessionId _: String) async throws {}
+}
+
+actor FakeNativeToolExecutor: NativeToolExecuting {
+    func execute(tool: String, arguments _: [String: AnyCodable]) async throws -> MCPToolExecutionResult {
+        MCPToolExecutionResult(server: NativeToolExecutor.serverName, tool: tool, text: "native result")
+    }
 }
 
 struct FailingLLMProvider: LLMProvider {

--- a/shell/Tests/MojoShellTests/AppStateTests.swift
+++ b/shell/Tests/MojoShellTests/AppStateTests.swift
@@ -3,71 +3,31 @@ import XCTest
 
 @MainActor
 final class AppStateTests: XCTestCase {
-    func testRunAssemblyWorkflowIncludesJobNameAndProviderState() async {
+
+    func testDefaultProviderNameIsSetFromInjectedProvider() {
         let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
         let executor = MCPToolExecutor(daemonManager: daemonManager)
-        let provider = FakeComputerUseProvider()
         let appState = AppState(
             daemons: daemonManager,
             executor: executor,
-            computerUseProvider: provider,
-            assemblyClickTarget: "640,400"
+            computerUseProvider: FakeComputerUseProvider()
         )
-
-        let result = await appState.runAssemblyWorkflow(jobName: "Demo Job")
-
-        switch result {
-        case .success(let output):
-            XCTAssertTrue(output.contains("Demo Job"))
-            XCTAssertTrue(output.contains("fake-cu"))
-            XCTAssertTrue(output.contains("640,400"))
-            XCTAssertTrue(output.contains("executed"))
-        case .failure(let error):
-            XCTFail("Expected success, got \(error)")
-        }
+        XCTAssertEqual(appState.computerUseProviderName, "fake-cu")
     }
 
-    func testRunAssemblyWorkflowFailsWhenClickTargetIsMissing() async {
+    func testLLMStackDescriptionReflectsInjectedProviders() {
         let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
         let executor = MCPToolExecutor(daemonManager: daemonManager)
         let appState = AppState(
             daemons: daemonManager,
             executor: executor,
             computerUseProvider: FakeComputerUseProvider(),
-            assemblyClickTarget: nil
+            llmProviders: [
+                FakeLLMProvider(name: "claude", response: LLMResponse(text: "", resolvedTool: nil)),
+                FakeLLMProvider(name: "openai", response: LLMResponse(text: "", resolvedTool: nil)),
+            ]
         )
-
-        let result = await appState.runAssemblyWorkflow(jobName: "Demo Job")
-
-        switch result {
-        case .success(let output):
-            XCTFail("Expected missing target failure, got \(output)")
-        case .failure(let error as AssemblyWorkflowError):
-            XCTAssertEqual(error, .missingClickTarget)
-        case .failure(let error):
-            XCTFail("Unexpected error: \(error)")
-        }
-    }
-
-    func testRunAssemblyWorkflowStopsSessionAfterFailure() async {
-        let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
-        let executor = MCPToolExecutor(daemonManager: daemonManager)
-        let provider = RecordingFailingComputerUseProvider()
-        let appState = AppState(
-            daemons: daemonManager,
-            executor: executor,
-            computerUseProvider: provider,
-            assemblyClickTarget: "640,400"
-        )
-
-        let result = await appState.runAssemblyWorkflow(jobName: "Demo Job")
-
-        switch result {
-        case .success(let output):
-            XCTFail("Expected failure, got \(output)")
-        case .failure:
-            XCTAssertTrue(await provider.didStopSession)
-        }
+        XCTAssertEqual(appState.llmProviderStackDescription, "claude -> openai")
     }
 
     func testResolveWithLLMFallsBackToSecondProvider() async {
@@ -95,12 +55,12 @@ final class AppStateTests: XCTestCase {
     }
 }
 
+// MARK: - Test doubles
+
 actor FakeComputerUseProvider: ComputerUseProvider {
     let name = "fake-cu"
 
-    func startSession() async throws -> String {
-        "fake-session"
-    }
+    func startSession() async throws -> String { "fake-session" }
 
     func captureState(sessionId _: String) async throws -> ComputerUseState {
         ComputerUseState(appName: "fake-cu", screenshotData: nil, timestamp: Date())
@@ -111,28 +71,6 @@ actor FakeComputerUseProvider: ComputerUseProvider {
     }
 
     func stopSession(sessionId _: String) async throws {}
-}
-
-actor RecordingFailingComputerUseProvider: ComputerUseProvider {
-    let name = "recording-cu"
-
-    private(set) var didStopSession = false
-
-    func startSession() async throws -> String {
-        "recording-session"
-    }
-
-    func captureState(sessionId _: String) async throws -> ComputerUseState {
-        ComputerUseState(appName: "recording-cu", screenshotData: nil, timestamp: Date())
-    }
-
-    func execute(sessionId _: String, action _: ComputerUseAction) async throws -> ComputerUseResult {
-        throw TestComputerUseError.executionFailed
-    }
-
-    func stopSession(sessionId _: String) async throws {
-        didStopSession = true
-    }
 }
 
 struct FailingLLMProvider: LLMProvider {
@@ -165,19 +103,7 @@ enum TestLLMError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .failed(let name):
-            return "\(name) failed"
-        }
-    }
-}
-
-enum TestComputerUseError: LocalizedError {
-    case executionFailed
-
-    var errorDescription: String? {
-        switch self {
-        case .executionFailed:
-            return "execution failed"
+        case .failed(let name): return "\(name) failed"
         }
     }
 }

--- a/shell/Tests/MojoShellTests/AppStateTests.swift
+++ b/shell/Tests/MojoShellTests/AppStateTests.swift
@@ -24,6 +24,30 @@ final class AppStateTests: XCTestCase {
             XCTFail("Expected success, got \(error)")
         }
     }
+
+    func testResolveWithLLMFallsBackToSecondProvider() async {
+        let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
+        let executor = MCPToolExecutor(daemonManager: daemonManager)
+        let llmProviders: [any LLMProvider] = [
+            FailingLLMProvider(name: "claude"),
+            FakeLLMProvider(name: "openai", response: LLMResponse(text: "fallback response", resolvedTool: nil)),
+        ]
+        let appState = AppState(
+            daemons: daemonManager,
+            executor: executor,
+            computerUseProvider: FakeComputerUseProvider(),
+            llmProviders: llmProviders
+        )
+
+        let result = await appState.resolveWithLLM(prompt: "something ambiguous", availableTools: [])
+
+        switch result {
+        case .success(let text):
+            XCTAssertEqual(text, "fallback response")
+        case .failure(let error):
+            XCTFail("Expected fallback success, got \(error)")
+        }
+    }
 }
 
 actor FakeComputerUseProvider: ComputerUseProvider {
@@ -42,4 +66,40 @@ actor FakeComputerUseProvider: ComputerUseProvider {
     }
 
     func stopSession(sessionId _: String) async throws {}
+}
+
+struct FailingLLMProvider: LLMProvider {
+    let name: String
+
+    func resolve(prompt _: String, availableTools _: [LLMToolDefinition]) async throws -> LLMResponse {
+        throw TestLLMError.failed(name)
+    }
+
+    func buildURLRequest(prompt _: String, tools _: [LLMToolDefinition]) throws -> URLRequest {
+        URLRequest(url: URL(string: "https://example.com")!)
+    }
+}
+
+struct FakeLLMProvider: LLMProvider {
+    let name: String
+    let response: LLMResponse
+
+    func resolve(prompt _: String, availableTools _: [LLMToolDefinition]) async throws -> LLMResponse {
+        response
+    }
+
+    func buildURLRequest(prompt _: String, tools _: [LLMToolDefinition]) throws -> URLRequest {
+        URLRequest(url: URL(string: "https://example.com")!)
+    }
+}
+
+enum TestLLMError: LocalizedError {
+    case failed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .failed(let name):
+            return "\(name) failed"
+        }
+    }
 }

--- a/shell/Tests/MojoShellTests/AppStateTests.swift
+++ b/shell/Tests/MojoShellTests/AppStateTests.swift
@@ -117,6 +117,39 @@ final class AppStateTests: XCTestCase {
             XCTFail("Expected native tool execution success, got \(error)")
         }
     }
+
+    func testExecuteRecordsNativeAuditEvent() async {
+        let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
+        let executor = MCPToolExecutor(daemonManager: daemonManager)
+        let nativeExecutor = FakeNativeToolExecutor()
+        var recorded: [(AuditCategory, String, String, [String: String])] = []
+        let appState = AppState(
+            daemons: daemonManager,
+            executor: executor,
+            computerUseProvider: FakeComputerUseProvider(),
+            nativeExecutor: nativeExecutor,
+            auditRecorder: { category, title, detail, metadata in
+                recorded.append((category, title, detail, metadata))
+            }
+        )
+
+        let result = await appState.execute(
+            ResolvedTool(
+                server: NativeToolExecutor.serverName,
+                tool: NativeToolName.finderOpenRepoRoot.rawValue,
+                arguments: [:]
+            )
+        )
+
+        switch result {
+        case .success:
+            XCTAssertEqual(recorded.last?.0, .native)
+            XCTAssertEqual(recorded.last?.1, "Tool executed")
+            XCTAssertEqual(recorded.last?.2, "\(NativeToolExecutor.serverName)/\(NativeToolName.finderOpenRepoRoot.rawValue)")
+        case .failure(let error):
+            XCTFail("Expected native tool execution success, got \(error)")
+        }
+    }
 }
 
 // MARK: - Test doubles

--- a/shell/Tests/MojoShellTests/AppStateTests.swift
+++ b/shell/Tests/MojoShellTests/AppStateTests.swift
@@ -10,7 +10,8 @@ final class AppStateTests: XCTestCase {
         let appState = AppState(
             daemons: daemonManager,
             executor: executor,
-            computerUseProvider: provider
+            computerUseProvider: provider,
+            assemblyClickTarget: "640,400"
         )
 
         let result = await appState.runAssemblyWorkflow(jobName: "Demo Job")
@@ -19,9 +20,53 @@ final class AppStateTests: XCTestCase {
         case .success(let output):
             XCTAssertTrue(output.contains("Demo Job"))
             XCTAssertTrue(output.contains("fake-cu"))
+            XCTAssertTrue(output.contains("640,400"))
             XCTAssertTrue(output.contains("executed"))
         case .failure(let error):
             XCTFail("Expected success, got \(error)")
+        }
+    }
+
+    func testRunAssemblyWorkflowFailsWhenClickTargetIsMissing() async {
+        let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
+        let executor = MCPToolExecutor(daemonManager: daemonManager)
+        let appState = AppState(
+            daemons: daemonManager,
+            executor: executor,
+            computerUseProvider: FakeComputerUseProvider(),
+            assemblyClickTarget: nil
+        )
+
+        let result = await appState.runAssemblyWorkflow(jobName: "Demo Job")
+
+        switch result {
+        case .success(let output):
+            XCTFail("Expected missing target failure, got \(output)")
+        case .failure(let error as AssemblyWorkflowError):
+            XCTAssertEqual(error, .missingClickTarget)
+        case .failure(let error):
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testRunAssemblyWorkflowStopsSessionAfterFailure() async {
+        let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
+        let executor = MCPToolExecutor(daemonManager: daemonManager)
+        let provider = RecordingFailingComputerUseProvider()
+        let appState = AppState(
+            daemons: daemonManager,
+            executor: executor,
+            computerUseProvider: provider,
+            assemblyClickTarget: "640,400"
+        )
+
+        let result = await appState.runAssemblyWorkflow(jobName: "Demo Job")
+
+        switch result {
+        case .success(let output):
+            XCTFail("Expected failure, got \(output)")
+        case .failure:
+            XCTAssertTrue(await provider.didStopSession)
         }
     }
 
@@ -68,6 +113,28 @@ actor FakeComputerUseProvider: ComputerUseProvider {
     func stopSession(sessionId _: String) async throws {}
 }
 
+actor RecordingFailingComputerUseProvider: ComputerUseProvider {
+    let name = "recording-cu"
+
+    private(set) var didStopSession = false
+
+    func startSession() async throws -> String {
+        "recording-session"
+    }
+
+    func captureState(sessionId _: String) async throws -> ComputerUseState {
+        ComputerUseState(appName: "recording-cu", screenshotData: nil, timestamp: Date())
+    }
+
+    func execute(sessionId _: String, action _: ComputerUseAction) async throws -> ComputerUseResult {
+        throw TestComputerUseError.executionFailed
+    }
+
+    func stopSession(sessionId _: String) async throws {
+        didStopSession = true
+    }
+}
+
 struct FailingLLMProvider: LLMProvider {
     let name: String
 
@@ -100,6 +167,17 @@ enum TestLLMError: LocalizedError {
         switch self {
         case .failed(let name):
             return "\(name) failed"
+        }
+    }
+}
+
+enum TestComputerUseError: LocalizedError {
+    case executionFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .executionFailed:
+            return "execution failed"
         }
     }
 }

--- a/shell/Tests/MojoShellTests/AuditControllerTests.swift
+++ b/shell/Tests/MojoShellTests/AuditControllerTests.swift
@@ -21,4 +21,20 @@ final class AuditControllerTests: XCTestCase {
         XCTAssertEqual(loaded.first?.metadata["path"], "/tmp")
         XCTAssertEqual(controller.events.count, 2)
     }
+
+    func testClearRemovesPersistedAuditEvents() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-audit-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = AuditStore(fileURL: root.appendingPathComponent("audit.json"))
+        let controller = AuditController(store: store)
+
+        controller.record(category: .system, title: "Before clear", detail: "event")
+        controller.clear()
+
+        XCTAssertEqual(try store.load().count, 0)
+        XCTAssertEqual(controller.events.count, 0)
+    }
 }

--- a/shell/Tests/MojoShellTests/AuditControllerTests.swift
+++ b/shell/Tests/MojoShellTests/AuditControllerTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import MojoShell
+
+@MainActor
+final class AuditControllerTests: XCTestCase {
+    func testRecordPersistsAuditEvents() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-audit-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = AuditStore(fileURL: root.appendingPathComponent("audit.json"))
+        let controller = AuditController(store: store, now: { Date(timeIntervalSince1970: 10) })
+
+        controller.record(category: .native, title: "Tool executed", detail: "shell-native/finder_open_path", metadata: ["path": "/tmp"])
+        controller.record(category: .daemon, title: "Daemon state changed", detail: "apple-mail -> running")
+
+        let loaded = try store.load()
+        XCTAssertEqual(loaded.count, 2)
+        XCTAssertEqual(loaded.first?.category, .native)
+        XCTAssertEqual(loaded.first?.metadata["path"], "/tmp")
+        XCTAssertEqual(controller.events.count, 2)
+    }
+}

--- a/shell/Tests/MojoShellTests/BrainManagerTests.swift
+++ b/shell/Tests/MojoShellTests/BrainManagerTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import MojoShell
+
+@MainActor
+final class BrainManagerTests: XCTestCase {
+    func testUseLocalBrainSeedsCopyAndPersistsMode() throws {
+        let root = try makeBrainRepoRoot()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brain-config-\(UUID().uuidString).json")
+        let localBrainURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("local-brain-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: storeURL) }
+        defer { try? FileManager.default.removeItem(at: localBrainURL) }
+
+        let manager = BrainManager(
+            repoRoot: root,
+            localBrainPath: localBrainURL.path,
+            store: BrainConfigStore(fileURL: storeURL)
+        )
+
+        try manager.useLocalBrain()
+
+        XCTAssertEqual(manager.sourceMode, .localCopy)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: manager.localBrainPath))
+        XCTAssertEqual(try BrainConfigStore(fileURL: storeURL).load()?.mode, .localCopy)
+    }
+
+    func testUseCustomBrainRequiresExistingFile() throws {
+        let root = try makeBrainRepoRoot()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let manager = BrainManager(repoRoot: root)
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-brain-\(UUID().uuidString).json")
+
+        XCTAssertThrowsError(try manager.useCustomBrain(path: missing.path))
+    }
+
+    func testStoredConfigurationReloadsLocalBrain() throws {
+        let root = try makeBrainRepoRoot()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brain-config-\(UUID().uuidString).json")
+        let localBrainURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("local-brain-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: storeURL) }
+        defer { try? FileManager.default.removeItem(at: localBrainURL) }
+
+        let original = BrainManager(
+            repoRoot: root,
+            localBrainPath: localBrainURL.path,
+            store: BrainConfigStore(fileURL: storeURL)
+        )
+        try original.useLocalBrain()
+
+        let reloaded = BrainManager(
+            repoRoot: root,
+            localBrainPath: localBrainURL.path,
+            store: BrainConfigStore(fileURL: storeURL)
+        )
+
+        XCTAssertEqual(reloaded.sourceMode, .localCopy)
+        XCTAssertEqual(reloaded.activeBrainPath, original.localBrainPath)
+    }
+
+    private func makeBrainRepoRoot() throws -> String {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-brain-\(UUID().uuidString)")
+        let brainURL = root
+            .appendingPathComponent("knowledge-corpus")
+            .appendingPathComponent("data")
+        try FileManager.default.createDirectory(at: brainURL, withIntermediateDirectories: true)
+        try Data("{\"brain\":true}".utf8).write(to: brainURL.appendingPathComponent("mojosolo_operating_brain.json"))
+        return root.path
+    }
+}

--- a/shell/Tests/MojoShellTests/BrainManagerTests.swift
+++ b/shell/Tests/MojoShellTests/BrainManagerTests.swift
@@ -66,6 +66,35 @@ final class BrainManagerTests: XCTestCase {
         XCTAssertEqual(reloaded.activeBrainPath, original.localBrainPath)
     }
 
+    func testImportLocalBrainCopiesSelectedFile() throws {
+        let root = try makeBrainRepoRoot()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("brain-config-\(UUID().uuidString).json")
+        let localBrainURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("local-brain-\(UUID().uuidString).json")
+        let importURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("import-brain-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: storeURL) }
+        defer { try? FileManager.default.removeItem(at: localBrainURL) }
+        defer { try? FileManager.default.removeItem(at: importURL) }
+
+        try Data("{\"custom\":true}".utf8).write(to: importURL)
+
+        let manager = BrainManager(
+            repoRoot: root,
+            localBrainPath: localBrainURL.path,
+            store: BrainConfigStore(fileURL: storeURL)
+        )
+
+        try manager.importLocalBrain(from: importURL.path)
+
+        XCTAssertEqual(manager.sourceMode, .localCopy)
+        XCTAssertEqual(manager.activeBrainPath, localBrainURL.path)
+        XCTAssertEqual(try String(contentsOf: localBrainURL), "{\"custom\":true}")
+    }
+
     private func makeBrainRepoRoot() throws -> String {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("mojoshell-brain-\(UUID().uuidString)")

--- a/shell/Tests/MojoShellTests/CockpitPanelModelsTests.swift
+++ b/shell/Tests/MojoShellTests/CockpitPanelModelsTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import MojoShell
+
+final class CockpitPanelModelsTests: XCTestCase {
+    func testParseBrainOverviewBuildsStructuredPanel() {
+        let json = """
+        {
+          "corpus_name": "mojosolo_operating_brain",
+          "corpus_version": "2026.03.12",
+          "generated_on": "2026-03-12",
+          "target_company": "MojoSolo",
+          "target_domain": "mojosolo.com",
+          "section_count": 6,
+          "sections": ["company_profile", "personas", "signals", "laravel", "ops", "media"],
+          "source_count": 14,
+          "report_available": true,
+          "report_section_count": 9,
+          "machine_ingest_entities": ["persona", "signal_rule", "workflow"],
+          "corpus_path": "/tmp/brain.json",
+          "report_path": "/tmp/brain-report.md"
+        }
+        """
+
+        let panel = parseBrainOverview(from: json)
+
+        XCTAssertNotNil(panel)
+        XCTAssertEqual(panel?.headline, "mojosolo_operating_brain v2026.03.12")
+        XCTAssertEqual(panel?.subtitle, "MojoSolo • mojosolo.com")
+        XCTAssertEqual(panel?.cards.count, 3)
+        XCTAssertEqual(panel?.cards[0].value, "6")
+        XCTAssertEqual(panel?.cards[1].detail, "Machine entities: 3")
+        XCTAssertEqual(panel?.cards[2].value, "Ready")
+        XCTAssertEqual(panel?.sections.count, 6)
+        XCTAssertEqual(panel?.machineEntities, ["persona", "signal_rule", "workflow"])
+    }
+
+    func testParseNowPlayingBuildsTrackSummary() {
+        let json = """
+        {
+          "state": "playing",
+          "volume": 57,
+          "shuffle": true,
+          "repeat": "all",
+          "track": {
+            "name": "Iris",
+            "artist": "Goo Goo Dolls",
+            "album": "Dizzy Up the Girl",
+            "duration": 289.0,
+            "position": 64.0,
+            "loved": true,
+            "rating": 100
+          }
+        }
+        """
+
+        let panel = parseNowPlaying(from: json)
+
+        XCTAssertEqual(panel.title, "Iris")
+        XCTAssertEqual(panel.subtitle, "Goo Goo Dolls • Dizzy Up the Girl")
+        XCTAssertTrue(panel.detail.contains("Playing"))
+        XCTAssertTrue(panel.detail.contains("1:04 / 4:49"))
+        XCTAssertEqual(panel.status, .live)
+    }
+
+    func testParseNowPlayingHandlesErrors() {
+        let panel = parseNowPlaying(from: "Error: AppleScript error: No tracks found")
+
+        XCTAssertEqual(panel.title, "Music unavailable")
+        XCTAssertEqual(panel.status, .error)
+        XCTAssertTrue(panel.subtitle.contains("No tracks found"))
+    }
+}

--- a/shell/Tests/MojoShellTests/ComputerUseProviderTests.swift
+++ b/shell/Tests/MojoShellTests/ComputerUseProviderTests.swift
@@ -74,4 +74,35 @@ final class ComputerUseProviderTests: XCTestCase {
             // expected
         }
     }
+
+    func testCuaCaptureStateRequiresScreenRecordingPermission() async throws {
+        let provider = CuaComputerUseProvider(
+            permissionStatusProvider: { CuaPermissionStatus(accessibilityTrusted: true, screenRecordingGranted: false) }
+        )
+        let id = try await provider.startSession()
+
+        do {
+            _ = try await provider.captureState(sessionId: id)
+            XCTFail("Expected CuaError.screenRecordingPermissionDenied")
+        } catch CuaError.screenRecordingPermissionDenied {
+            // expected
+        }
+    }
+
+    func testCuaExecuteRequiresAccessibilityPermission() async throws {
+        let provider = CuaComputerUseProvider(
+            permissionStatusProvider: { CuaPermissionStatus(accessibilityTrusted: false, screenRecordingGranted: true) }
+        )
+        let id = try await provider.startSession()
+
+        do {
+            _ = try await provider.execute(
+                sessionId: id,
+                action: ComputerUseAction(type: .click, target: "640,400")
+            )
+            XCTFail("Expected CuaError.accessibilityPermissionDenied")
+        } catch CuaError.accessibilityPermissionDenied {
+            // expected
+        }
+    }
 }

--- a/shell/Tests/MojoShellTests/ComputerUseProviderTests.swift
+++ b/shell/Tests/MojoShellTests/ComputerUseProviderTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import MojoShell
+
+final class ComputerUseProviderTests: XCTestCase {
+    func testStubStartsSession() async throws {
+        let provider = StubComputerUseProvider()
+        let sessionID = try await provider.startSession()
+        XCTAssertFalse(sessionID.isEmpty)
+    }
+
+    func testStubCapturesState() async throws {
+        let provider = StubComputerUseProvider()
+        let sessionID = try await provider.startSession()
+        let state = try await provider.captureState(sessionId: sessionID)
+        XCTAssertEqual(state.appName, "stub")
+    }
+
+    func testStubExecutesAction() async throws {
+        let provider = StubComputerUseProvider()
+        let sessionID = try await provider.startSession()
+        let result = try await provider.execute(
+            sessionId: sessionID,
+            action: ComputerUseAction(type: .click, target: "Export Button")
+        )
+        XCTAssertTrue(result.success)
+    }
+}

--- a/shell/Tests/MojoShellTests/ComputerUseProviderTests.swift
+++ b/shell/Tests/MojoShellTests/ComputerUseProviderTests.swift
@@ -2,6 +2,9 @@ import XCTest
 @testable import MojoShell
 
 final class ComputerUseProviderTests: XCTestCase {
+
+    // MARK: - Stub
+
     func testStubStartsSession() async throws {
         let provider = StubComputerUseProvider()
         let sessionID = try await provider.startSession()
@@ -23,5 +26,52 @@ final class ComputerUseProviderTests: XCTestCase {
             action: ComputerUseAction(type: .click, target: "Export Button")
         )
         XCTAssertTrue(result.success)
+    }
+
+    // MARK: - CuaComputerUseProvider lifecycle (no display needed)
+
+    func testCuaStartAndStop() async throws {
+        let provider = CuaComputerUseProvider()
+        let id = try await provider.startSession()
+        XCTAssertFalse(id.isEmpty)
+        try await provider.stopSession(sessionId: id)
+    }
+
+    func testCuaUnknownSessionThrows() async throws {
+        let provider = CuaComputerUseProvider()
+        do {
+            _ = try await provider.captureState(sessionId: "nonexistent")
+            XCTFail("Expected CuaError.unknownSession")
+        } catch CuaError.unknownSession {
+            // expected
+        }
+    }
+
+    func testCuaInvalidCoordinatesThrows() async throws {
+        let provider = CuaComputerUseProvider()
+        let id = try await provider.startSession()
+        do {
+            _ = try await provider.execute(
+                sessionId: id,
+                action: ComputerUseAction(type: .click, target: "not-coordinates")
+            )
+            XCTFail("Expected CuaError.invalidCoordinates")
+        } catch CuaError.invalidCoordinates {
+            // expected
+        }
+    }
+
+    func testCuaUnknownKeyThrows() async throws {
+        let provider = CuaComputerUseProvider()
+        let id = try await provider.startSession()
+        do {
+            _ = try await provider.execute(
+                sessionId: id,
+                action: ComputerUseAction(type: .keypress, target: "superkey")
+            )
+            XCTFail("Expected CuaError.unknownKey")
+        } catch CuaError.unknownKey {
+            // expected
+        }
     }
 }

--- a/shell/Tests/MojoShellTests/DaemonManagerTests.swift
+++ b/shell/Tests/MojoShellTests/DaemonManagerTests.swift
@@ -13,6 +13,7 @@ final class DaemonManagerTests: XCTestCase {
         for server in manager.serverDefinitions {
             XCTAssertFalse(server.name.isEmpty)
             XCTAssertTrue(server.scriptPath.hasSuffix("index.js"), "\(server.name) path should end in index.js")
+            XCTAssertTrue(server.packagePath.hasSuffix("package.json"), "\(server.name) package should end in package.json")
         }
     }
 
@@ -33,9 +34,7 @@ final class DaemonManagerTests: XCTestCase {
     }
 
     func testRefreshRuntimeStatesMarksBuiltServerAsStopped() throws {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("mojoshell-daemon-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let root = try makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
 
         let manager = DaemonManager(repoRoot: root.path)
@@ -54,9 +53,7 @@ final class DaemonManagerTests: XCTestCase {
     }
 
     func testRuntimeStateCallbackCapturesDaemonFailure() async throws {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("mojoshell-daemon-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let root = try makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
 
         var transitions: [(DaemonRuntimeStatus?, DaemonRuntimeStatus)] = []
@@ -88,6 +85,78 @@ final class DaemonManagerTests: XCTestCase {
         XCTAssertTrue(transitions.contains(where: { $0.1 == .failed }))
     }
 
+    func testBuildSuccessUpdatesBuildStateAndCreatesStoppedRuntime() async throws {
+        let root = try makeRoot()
+        let logStore = DaemonLogStore(directoryURL: root.appendingPathComponent("logs"))
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let manager = DaemonManager(
+            repoRoot: root.path,
+            logStore: logStore,
+            buildOperation: { definition in
+                let scriptURL = URL(fileURLWithPath: definition.scriptPath)
+                try FileManager.default.createDirectory(at: scriptURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try Data("console.log('built')".utf8).write(to: scriptURL)
+                return DaemonBuildResult(output: "build ok", exitStatus: 0)
+            }
+        )
+
+        let first = try XCTUnwrap(manager.serverDefinitions.first)
+        await manager.build(serverName: first.name)
+
+        XCTAssertEqual(manager.buildState(for: first.name)?.status, .succeeded)
+        XCTAssertEqual(manager.runtimeState(for: first.name)?.status, .stopped)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: first.scriptPath))
+    }
+
+    func testBuildFailureUpdatesBuildState() async throws {
+        let root = try makeRoot()
+        let logStore = DaemonLogStore(directoryURL: root.appendingPathComponent("logs"))
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let manager = DaemonManager(
+            repoRoot: root.path,
+            logStore: logStore,
+            buildOperation: { _ in
+                DaemonBuildResult(output: "build failed", exitStatus: 1)
+            }
+        )
+
+        let first = try XCTUnwrap(manager.serverDefinitions.first)
+        await manager.build(serverName: first.name)
+
+        XCTAssertEqual(manager.buildState(for: first.name)?.status, .failed)
+        XCTAssertEqual(manager.runtimeState(for: first.name)?.status, .notBuilt)
+        XCTAssertTrue(manager.buildState(for: first.name)?.lastOutput.contains("build failed") ?? false)
+    }
+
+    func testDaemonReceivesBrainPathEnvironmentAndCapturesRuntimeLog() async throws {
+        let root = try makeRoot()
+        let logStore = DaemonLogStore(directoryURL: root.appendingPathComponent("logs"))
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let manager = DaemonManager(
+            repoRoot: root.path,
+            logStore: logStore,
+            brainPathProvider: { "/tmp/test-active-brain.json" }
+        )
+
+        let first = try XCTUnwrap(manager.serverDefinitions.first)
+        let scriptURL = URL(fileURLWithPath: first.scriptPath)
+        try FileManager.default.createDirectory(at: scriptURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("console.error(process.env.BRAIN_PATH || 'missing'); setTimeout(() => process.exit(1), 20)".utf8)
+            .write(to: scriptURL, options: .atomic)
+
+        _ = manager.ensureProcess(for: first.name)
+        try await waitUntil {
+            manager.runtimeState(for: first.name)?.status == .failed
+        }
+
+        XCTAssertTrue(manager.recentRuntimeLog(for: first.name).contains("/tmp/test-active-brain.json"))
+        let logContents = try logStore.load(serverName: first.name, kind: .runtime)
+        XCTAssertTrue(logContents.contains("/tmp/test-active-brain.json"))
+    }
+
     private func waitUntil(
         timeoutIterations: Int = 200,
         condition: @escaping () -> Bool
@@ -100,5 +169,12 @@ final class DaemonManagerTests: XCTestCase {
         }
 
         XCTFail("Timed out waiting for condition")
+    }
+
+    private func makeRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-daemon-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
     }
 }

--- a/shell/Tests/MojoShellTests/DaemonManagerTests.swift
+++ b/shell/Tests/MojoShellTests/DaemonManagerTests.swift
@@ -15,4 +15,9 @@ final class DaemonManagerTests: XCTestCase {
             XCTAssertTrue(server.scriptPath.hasSuffix("index.js"), "\(server.name) path should end in index.js")
         }
     }
+
+    func testRepoRootIsAccessible() {
+        let manager = DaemonManager(repoRoot: "/tmp/test-root")
+        XCTAssertEqual(manager.repoRoot, "/tmp/test-root")
+    }
 }

--- a/shell/Tests/MojoShellTests/DaemonManagerTests.swift
+++ b/shell/Tests/MojoShellTests/DaemonManagerTests.swift
@@ -20,4 +20,36 @@ final class DaemonManagerTests: XCTestCase {
         let manager = DaemonManager(repoRoot: "/tmp/test-root")
         XCTAssertEqual(manager.repoRoot, "/tmp/test-root")
     }
+
+    func testRuntimeStatesAreAvailableForAllServers() {
+        let manager = DaemonManager(repoRoot: "/tmp/nonexistent-\(UUID().uuidString)")
+        XCTAssertEqual(manager.allRuntimeStates.count, 10)
+    }
+
+    func testStartAllMarksMissingArtifactsAsNotBuilt() {
+        let manager = DaemonManager(repoRoot: "/tmp/nonexistent-\(UUID().uuidString)")
+        manager.startAll()
+        XCTAssertTrue(manager.allRuntimeStates.allSatisfy { $0.status == .notBuilt })
+    }
+
+    func testRefreshRuntimeStatesMarksBuiltServerAsStopped() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-daemon-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let manager = DaemonManager(repoRoot: root.path)
+        guard let first = manager.serverDefinitions.first else {
+            XCTFail("Expected at least one server definition")
+            return
+        }
+
+        let scriptURL = URL(fileURLWithPath: first.scriptPath)
+        try FileManager.default.createDirectory(at: scriptURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("console.log('ok')".utf8).write(to: scriptURL, options: .atomic)
+
+        manager.refreshRuntimeStates()
+        let state = manager.runtimeState(for: first.name)
+        XCTAssertEqual(state?.status, .stopped)
+    }
 }

--- a/shell/Tests/MojoShellTests/DaemonManagerTests.swift
+++ b/shell/Tests/MojoShellTests/DaemonManagerTests.swift
@@ -52,4 +52,53 @@ final class DaemonManagerTests: XCTestCase {
         let state = manager.runtimeState(for: first.name)
         XCTAssertEqual(state?.status, .stopped)
     }
+
+    func testRuntimeStateCallbackCapturesDaemonFailure() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-daemon-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var transitions: [(DaemonRuntimeStatus?, DaemonRuntimeStatus)] = []
+        let manager = DaemonManager(
+            repoRoot: root.path,
+            onRuntimeStateChanged: { previous, current in
+                transitions.append((previous?.status, current.status))
+            }
+        )
+        transitions.removeAll()
+
+        guard let first = manager.serverDefinitions.first else {
+            XCTFail("Expected at least one server definition")
+            return
+        }
+
+        let scriptURL = URL(fileURLWithPath: first.scriptPath)
+        try FileManager.default.createDirectory(at: scriptURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("setTimeout(() => process.exit(1), 20)".utf8).write(to: scriptURL, options: .atomic)
+
+        _ = manager.ensureProcess(for: first.name)
+        try await waitUntil {
+            manager.runtimeState(for: first.name)?.status == .failed
+        }
+
+        let state = manager.runtimeState(for: first.name)
+        XCTAssertEqual(state?.status, .failed)
+        XCTAssertNotNil(state?.lastError)
+        XCTAssertTrue(transitions.contains(where: { $0.1 == .failed }))
+    }
+
+    private func waitUntil(
+        timeoutIterations: Int = 200,
+        condition: @escaping () -> Bool
+    ) async throws {
+        for _ in 0..<timeoutIterations {
+            if condition() {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTFail("Timed out waiting for condition")
+    }
 }

--- a/shell/Tests/MojoShellTests/DaemonManagerTests.swift
+++ b/shell/Tests/MojoShellTests/DaemonManagerTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import MojoShell
+
+@MainActor
+final class DaemonManagerTests: XCTestCase {
+    func testKnownServersCount() {
+        let manager = DaemonManager(repoRoot: "/tmp/apple-mcp")
+        XCTAssertEqual(manager.serverDefinitions.count, 10)
+    }
+
+    func testServerDefinitionsHaveValidPaths() {
+        let manager = DaemonManager(repoRoot: "/tmp/apple-mcp")
+        for server in manager.serverDefinitions {
+            XCTAssertFalse(server.name.isEmpty)
+            XCTAssertTrue(server.scriptPath.hasSuffix("index.js"), "\(server.name) path should end in index.js")
+        }
+    }
+}

--- a/shell/Tests/MojoShellTests/DeterministicRouterTests.swift
+++ b/shell/Tests/MojoShellTests/DeterministicRouterTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import MojoShell
+
+final class DeterministicRouterTests: XCTestCase {
+    private let router = DeterministicRouter()
+
+    func testScanInboxesIntent() {
+        let result = router.route("scan today's inboxes")
+        XCTAssertEqual(result?.server, "mail-intelligence")
+        XCTAssertEqual(result?.tool, "scan_persona_inboxes")
+    }
+
+    func testPauseMusicIntent() {
+        let result = router.route("pause the music")
+        XCTAssertEqual(result?.server, "apple-music")
+        XCTAssertEqual(result?.tool, "pause")
+    }
+
+    func testFCPIntentFallsBack() {
+        let result = router.route("export the current FCP timeline")
+        XCTAssertNil(result)
+    }
+
+    func testUnknownReturnsNil() {
+        let result = router.route("zxqwerty something unknown")
+        XCTAssertNil(result)
+    }
+}

--- a/shell/Tests/MojoShellTests/DeterministicRouterTests.swift
+++ b/shell/Tests/MojoShellTests/DeterministicRouterTests.swift
@@ -38,6 +38,25 @@ final class DeterministicRouterTests: XCTestCase {
         XCTAssertEqual(result?.arguments["input"], .string("inbox summary"))
     }
 
+    func testOpenRepoInTerminalRoutesToNativeTool() {
+        let result = router.route("open repo in terminal")
+        XCTAssertEqual(result?.server, NativeToolExecutor.serverName)
+        XCTAssertEqual(result?.tool, NativeToolName.terminalOpenRepo.rawValue)
+    }
+
+    func testOpenFinderSelectionInPreviewRoutesToNativeTool() {
+        let result = router.route("open finder selection in preview")
+        XCTAssertEqual(result?.server, NativeToolExecutor.serverName)
+        XCTAssertEqual(result?.tool, NativeToolName.finderSelectionOpenInPreview.rawValue)
+    }
+
+    func testRunCommandInITermParsesDynamicRoute() {
+        let result = router.route("run git status in iterm")
+        XCTAssertEqual(result?.server, NativeToolExecutor.serverName)
+        XCTAssertEqual(result?.tool, NativeToolName.itermRunCommand.rawValue)
+        XCTAssertEqual(result?.arguments["command"], .string("git status"))
+    }
+
     func testFCPIntentFallsBack() {
         let result = router.route("export the current FCP timeline")
         XCTAssertNil(result)

--- a/shell/Tests/MojoShellTests/DeterministicRouterTests.swift
+++ b/shell/Tests/MojoShellTests/DeterministicRouterTests.swift
@@ -16,6 +16,28 @@ final class DeterministicRouterTests: XCTestCase {
         XCTAssertEqual(result?.tool, "pause")
     }
 
+    func testOpenDownloadsFolderRoutesToNativeFinderTool() {
+        let result = router.route("open downloads folder")
+        XCTAssertEqual(result?.server, NativeToolExecutor.serverName)
+        XCTAssertEqual(result?.tool, NativeToolName.finderOpenPath.rawValue)
+        XCTAssertEqual(result?.arguments["path"], .string("~/Downloads"))
+    }
+
+    func testOpenSafariURLBuildsNativeURLAction() {
+        let result = router.route("open openai.com in safari")
+        XCTAssertEqual(result?.server, NativeToolExecutor.serverName)
+        XCTAssertEqual(result?.tool, NativeToolName.safariOpenURL.rawValue)
+        XCTAssertEqual(result?.arguments["url"], .string("https://openai.com"))
+    }
+
+    func testRunShortcutParsesNameAndInput() {
+        let result = router.route("run shortcut Daily Brief with input inbox summary")
+        XCTAssertEqual(result?.server, NativeToolExecutor.serverName)
+        XCTAssertEqual(result?.tool, NativeToolName.shortcutsRun.rawValue)
+        XCTAssertEqual(result?.arguments["name"], .string("Daily Brief"))
+        XCTAssertEqual(result?.arguments["input"], .string("inbox summary"))
+    }
+
     func testFCPIntentFallsBack() {
         let result = router.route("export the current FCP timeline")
         XCTAssertNil(result)

--- a/shell/Tests/MojoShellTests/ExportTargetStoreTests.swift
+++ b/shell/Tests/MojoShellTests/ExportTargetStoreTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import MojoShell
+
+final class ExportTargetStoreTests: XCTestCase {
+    func testLoadReturnsDefaultTargetsWhenFileMissing() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-export-targets-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = ExportTargetStore(fileURL: root.appendingPathComponent("export-targets.json"))
+        let targets = try store.load()
+
+        XCTAssertFalse(targets.isEmpty)
+        XCTAssertTrue(targets.contains(where: { $0.isDefault }))
+    }
+
+    func testSaveRoundTripsTargets() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-export-targets-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = ExportTargetStore(fileURL: root.appendingPathComponent("export-targets.json"))
+        let targets = [
+            ExportTarget(name: "Exports", path: "/tmp/exports", isDefault: true),
+            ExportTarget(name: "Archive", path: "/tmp/archive", isDefault: false),
+        ]
+
+        try store.save(targets)
+        let loaded = try store.load()
+        XCTAssertEqual(loaded, targets)
+    }
+}

--- a/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
+++ b/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import MojoShell
+
+final class FcpWorkflowTests: XCTestCase {
+
+    // MARK: - WorkflowStep factories
+
+    func testClickStepHasAXQuery() {
+        let step = WorkflowStep.click("Test", app: "Final Cut Pro", buttonTitled: "Next")
+        XCTAssertNotNil(step.axQuery)
+        XCTAssertEqual(step.axQuery?.appName, "Final Cut Pro")
+        XCTAssertEqual(step.axQuery?.role, "AXButton")
+        XCTAssertEqual(step.axQuery?.titleContaining, "Next")
+        XCTAssertNil(step.keypress)
+        XCTAssertNil(step.typeText)
+    }
+
+    func testKeypressStepHasNoAXQuery() {
+        let step = WorkflowStep.keypress("Focus FCP", key: "cmd+tab")
+        XCTAssertNil(step.axQuery)
+        XCTAssertEqual(step.keypress, "cmd+tab")
+    }
+
+    func testTypeStepHasText() {
+        let step = WorkflowStep.type("Enter filename", text: "output.mp4")
+        XCTAssertEqual(step.typeText, "output.mp4")
+        XCTAssertNil(step.keypress)
+        XCTAssertNil(step.axQuery)
+    }
+
+    func testCoordinateStepHasNoAXQuery() {
+        let step = WorkflowStep.coordinate("Click export button", at: "640,400")
+        XCTAssertEqual(step.fallbackCoordinates, "640,400")
+        XCTAssertNil(step.axQuery)
+    }
+
+    // MARK: - FcpWorkflowDefinition
+
+    func testAssemblyWorkflowHasSteps() {
+        let steps = FcpWorkflowDefinition.assemblyWorkflow()
+        XCTAssertFalse(steps.isEmpty)
+        // First step focuses FCP
+        XCTAssertEqual(steps.first?.keypress, "cmd+tab")
+    }
+
+    func testMonitoringCheckHasSteps() {
+        let steps = FcpWorkflowDefinition.monitoringCheck()
+        XCTAssertEqual(steps.count, 2)
+        // Second step opens Background Tasks
+        XCTAssertEqual(steps.last?.keypress, "cmd+9")
+    }
+
+    // MARK: - WorkflowExecutor with stub provider
+
+    func testExecutorRunsAllKeyPressSteps() async throws {
+        let stub = CapturingComputerUseProvider()
+        let steps = [
+            WorkflowStep.keypress("Step 1", key: "cmd+tab"),
+            WorkflowStep.keypress("Step 2", key: "cmd+e"),
+        ]
+
+        let sessionId = try await stub.startSession()
+        let executor = WorkflowExecutor(provider: stub)
+        var log: [String] = []
+
+        try await executor.run(steps: steps, sessionId: sessionId) { message in
+            log.append(message)
+        }
+
+        let actions = await stub.executedActions
+        XCTAssertEqual(actions.count, 2)
+        XCTAssertEqual(actions[0].type, .keypress)
+        XCTAssertEqual(actions[0].target, "cmd+tab")
+        XCTAssertEqual(actions[1].target, "cmd+e")
+        XCTAssertTrue(log.contains("Workflow complete."))
+    }
+
+    func testExecutorFallsBackToCoordinatesWhenAXFails() async throws {
+        let stub = CapturingComputerUseProvider()
+        // AX query will fail (FCP not running), but there is a fallback coordinate
+        let steps = [
+            WorkflowStep.click(
+                "Click Export",
+                app: "Final Cut Pro",
+                buttonTitled: "Export",
+                fallback: "640,400"
+            ),
+        ]
+
+        let sessionId = try await stub.startSession()
+        let executor = WorkflowExecutor(provider: stub)
+        try await executor.run(steps: steps, sessionId: sessionId) { _ in }
+
+        let actions = await stub.executedActions
+        XCTAssertEqual(actions.count, 1)
+        XCTAssertEqual(actions[0].type, .click)
+        XCTAssertEqual(actions[0].target, "640,400")
+    }
+
+    func testExecutorThrowsWhenAXFailsAndNoFallback() async throws {
+        let stub = CapturingComputerUseProvider()
+        let steps = [
+            WorkflowStep.click("Click Export", app: "Final Cut Pro", buttonTitled: "Export"),
+        ]
+
+        let sessionId = try await stub.startSession()
+        let executor = WorkflowExecutor(provider: stub)
+
+        do {
+            try await executor.run(steps: steps, sessionId: sessionId) { _ in }
+            XCTFail("Expected WorkflowError.elementNotFound")
+        } catch is WorkflowError {
+            // expected
+        }
+    }
+}
+
+// MARK: - Test double
+
+actor CapturingComputerUseProvider: ComputerUseProvider {
+    let name = "capturing-stub"
+    private(set) var executedActions: [ComputerUseAction] = []
+    private var sessions: Set<String> = []
+
+    func startSession() async throws -> String {
+        let id = UUID().uuidString
+        sessions.insert(id)
+        return id
+    }
+
+    func captureState(sessionId: String) async throws -> ComputerUseState {
+        ComputerUseState(appName: "capturing-stub", screenshotData: nil, timestamp: Date())
+    }
+
+    func execute(sessionId: String, action: ComputerUseAction) async throws -> ComputerUseResult {
+        executedActions.append(action)
+        return ComputerUseResult(success: true, message: "captured", screenshotAfter: nil)
+    }
+
+    func stopSession(sessionId: String) async throws {
+        sessions.remove(sessionId)
+    }
+}

--- a/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
+++ b/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
@@ -66,6 +66,14 @@ final class FcpWorkflowTests: XCTestCase {
             steps.dropFirst(3).first?.axQuery?.titleContaining,
             "Next…"
         )
+        XCTAssertEqual(
+            steps.dropFirst(2).first?.approvalPrompt,
+            "Confirm the export destination in Final Cut Pro before MojoShell clicks it."
+        )
+        XCTAssertEqual(
+            steps.dropFirst(3).first?.approvalPrompt,
+            "Confirm the export sheet is configured correctly before advancing."
+        )
     }
 
     func testMonitoringCheckFirstStepActivatesFCP() {
@@ -157,6 +165,31 @@ final class FcpWorkflowTests: XCTestCase {
         } catch is WorkflowError {
             // expected
         }
+    }
+
+    func testExecutorThrowsWhenApprovalIsRejected() async throws {
+        let stub = CapturingComputerUseProvider()
+        let steps = [
+            WorkflowStep.keypress("Approve Export", key: "cmd+e", approvalPrompt: "Confirm export settings"),
+        ]
+
+        let sessionId = try await stub.startSession()
+        let executor = WorkflowExecutor(provider: stub)
+
+        do {
+            try await executor.run(
+                steps: steps,
+                sessionId: sessionId,
+                onProgress: { _ in },
+                onApprovalRequested: { _, _ in false }
+            )
+            XCTFail("Expected WorkflowError.approvalRejected")
+        } catch WorkflowError.approvalRejected(let description) {
+            XCTAssertEqual(description, "Approve Export")
+        }
+
+        let actions = await stub.executedActions
+        XCTAssertTrue(actions.isEmpty)
     }
 }
 

--- a/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
+++ b/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
@@ -76,6 +76,13 @@ final class FcpWorkflowTests: XCTestCase {
         )
     }
 
+    func testAssemblyWorkflowIncludesExportTargetInApprovalPrompt() {
+        let steps = FcpWorkflowDefinition.assemblyWorkflow(exportTargetPath: "/tmp/exports")
+
+        XCTAssertTrue(steps.dropFirst(2).first?.approvalPrompt?.contains("/tmp/exports") ?? false)
+        XCTAssertTrue(steps.dropFirst(3).first?.approvalPrompt?.contains("/tmp/exports") ?? false)
+    }
+
     func testMonitoringCheckFirstStepActivatesFCP() {
         let steps = FcpWorkflowDefinition.monitoringCheck()
         XCTAssertEqual(steps.first?.appActivationName, "Final Cut Pro")

--- a/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
+++ b/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
@@ -60,6 +60,11 @@ final class FcpWorkflowTests: XCTestCase {
             steps.dropFirst(2).first?.axQuery?.titleContaining,
             "Export File (default)…"
         )
+        // Step 4: advance button confirmed live — "Next…" (with ellipsis)
+        XCTAssertEqual(
+            steps.dropFirst(3).first?.axQuery?.titleContaining,
+            "Next…"
+        )
     }
 
     func testMonitoringCheckFirstStepActivatesFCP() {

--- a/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
+++ b/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
@@ -50,6 +50,10 @@ final class FcpWorkflowTests: XCTestCase {
         // First step activates FCP deterministically — not cmd+tab
         XCTAssertEqual(steps.first?.appActivationName, "Final Cut Pro")
         XCTAssertNil(steps.first?.keypress)
+        XCTAssertEqual(
+            steps.dropFirst().first?.axQuery?.titleContaining,
+            "Share the project, event clip, or Timeline range"
+        )
     }
 
     func testMonitoringCheckFirstStepActivatesFCP() {

--- a/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
+++ b/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import MojoShell
 
+@MainActor
 final class FcpWorkflowTests: XCTestCase {
 
     // MARK: - WorkflowStep factories

--- a/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
+++ b/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
@@ -137,11 +137,11 @@ final class FcpWorkflowTests: XCTestCase {
 
     func testExecutorFallsBackToCoordinatesWhenAXFails() async throws {
         let stub = CapturingComputerUseProvider()
-        // AX query will fail (FCP not running), but there is a fallback coordinate
+        // AX query will fail because the app name is fake, but there is a fallback coordinate.
         let steps = [
             WorkflowStep.click(
                 "Click Export",
-                app: "Final Cut Pro",
+                app: "__NonExistentApp__",
                 buttonTitled: "Export",
                 fallback: "640,400"
             ),
@@ -160,7 +160,7 @@ final class FcpWorkflowTests: XCTestCase {
     func testExecutorThrowsWhenAXFailsAndNoFallback() async throws {
         let stub = CapturingComputerUseProvider()
         let steps = [
-            WorkflowStep.click("Click Export", app: "Final Cut Pro", buttonTitled: "Export"),
+            WorkflowStep.click("Click Export", app: "__NonExistentApp__", buttonTitled: "Export"),
         ]
 
         let sessionId = try await stub.startSession()

--- a/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
+++ b/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
@@ -50,9 +50,15 @@ final class FcpWorkflowTests: XCTestCase {
         // First step activates FCP deterministically — not cmd+tab
         XCTAssertEqual(steps.first?.appActivationName, "Final Cut Pro")
         XCTAssertNil(steps.first?.keypress)
+        // Second step: toolbar Share button (verified live AX title)
         XCTAssertEqual(
             steps.dropFirst().first?.axQuery?.titleContaining,
             "Share the project, event clip, or Timeline range"
+        )
+        // Default share destination is the verified File > Share submenu name
+        XCTAssertEqual(
+            steps.dropFirst(2).first?.axQuery?.titleContaining,
+            "Export File (default)…"
         )
     }
 

--- a/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
+++ b/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
@@ -105,7 +105,7 @@ final class FcpWorkflowTests: XCTestCase {
 
         let sessionId = try await stub.startSession()
         let executor = WorkflowExecutor(provider: stub)
-        var log: [String] = []
+        let log = MessageLog()
 
         try await executor.run(steps: steps, sessionId: sessionId) { message in
             log.append(message)
@@ -116,7 +116,7 @@ final class FcpWorkflowTests: XCTestCase {
         XCTAssertEqual(actions[0].type, .keypress)
         XCTAssertEqual(actions[0].target, "cmd+tab")
         XCTAssertEqual(actions[1].target, "cmd+e")
-        XCTAssertTrue(log.contains("Workflow complete."))
+        XCTAssertTrue(log.messages.contains("Workflow complete."))
     }
 
     func testExecutorFallsBackToCoordinatesWhenAXFails() async throws {
@@ -159,7 +159,13 @@ final class FcpWorkflowTests: XCTestCase {
     }
 }
 
-// MARK: - Test double
+// MARK: - Test doubles
+
+/// Thread-safe string log for capturing @Sendable progress callbacks.
+final class MessageLog: @unchecked Sendable {
+    private(set) var messages: [String] = []
+    func append(_ message: String) { messages.append(message) }
+}
 
 actor CapturingComputerUseProvider: ComputerUseProvider {
     let name = "capturing-stub"

--- a/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
+++ b/shell/Tests/MojoShellTests/FcpWorkflowTests.swift
@@ -36,11 +36,25 @@ final class FcpWorkflowTests: XCTestCase {
 
     // MARK: - FcpWorkflowDefinition
 
+    func testActivateAppStepHasAppActivationName() {
+        let step = WorkflowStep.activateApp("Final Cut Pro")
+        XCTAssertEqual(step.appActivationName, "Final Cut Pro")
+        XCTAssertNil(step.keypress)
+        XCTAssertNil(step.axQuery)
+        XCTAssertNil(step.typeText)
+    }
+
     func testAssemblyWorkflowHasSteps() {
         let steps = FcpWorkflowDefinition.assemblyWorkflow()
         XCTAssertFalse(steps.isEmpty)
-        // First step focuses FCP
-        XCTAssertEqual(steps.first?.keypress, "cmd+tab")
+        // First step activates FCP deterministically — not cmd+tab
+        XCTAssertEqual(steps.first?.appActivationName, "Final Cut Pro")
+        XCTAssertNil(steps.first?.keypress)
+    }
+
+    func testMonitoringCheckFirstStepActivatesFCP() {
+        let steps = FcpWorkflowDefinition.monitoringCheck()
+        XCTAssertEqual(steps.first?.appActivationName, "Final Cut Pro")
     }
 
     func testMonitoringCheckHasSteps() {
@@ -51,6 +65,21 @@ final class FcpWorkflowTests: XCTestCase {
     }
 
     // MARK: - WorkflowExecutor with stub provider
+
+    func testExecutorThrowsAppNotRunningWhenActivationFails() async throws {
+        let stub = CapturingComputerUseProvider()
+        // Use a deliberately fake app name that will never be running
+        let steps = [WorkflowStep.activateApp("__NonExistentApp__")]
+        let sessionId = try await stub.startSession()
+        let executor = WorkflowExecutor(provider: stub)
+
+        do {
+            try await executor.run(steps: steps, sessionId: sessionId) { _ in }
+            XCTFail("Expected WorkflowError.appNotRunning")
+        } catch WorkflowError.appNotRunning(let name) {
+            XCTAssertEqual(name, "__NonExistentApp__")
+        }
+    }
 
     func testExecutorRunsAllKeyPressSteps() async throws {
         let stub = CapturingComputerUseProvider()

--- a/shell/Tests/MojoShellTests/JobStoreTests.swift
+++ b/shell/Tests/MojoShellTests/JobStoreTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import MojoShell
+
+final class JobStoreTests: XCTestCase {
+    func testJobStoreRoundTripsJobs() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-jobstore-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = JobStore(fileURL: root.appendingPathComponent("jobs.json"))
+        let jobs = [
+            MediaJob(
+                name: "Test Job",
+                client: "Client",
+                status: .queued,
+                progress: 0.0,
+                createdAt: Date(timeIntervalSince1970: 100),
+                completedAt: nil,
+                errorMessage: nil
+            ),
+        ]
+
+        try store.save(jobs)
+        let loaded = try store.load()
+        XCTAssertEqual(loaded, jobs)
+    }
+
+    func testEventStoreAppendAndLoadRecent() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-eventstore-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = JobEventStore(fileURL: root.appendingPathComponent("events.json"))
+        let jobID = UUID()
+        try store.append(JobEvent(jobID: jobID, timestamp: Date(timeIntervalSince1970: 1), type: .queued, message: "q1"))
+        try store.append(JobEvent(jobID: jobID, timestamp: Date(timeIntervalSince1970: 2), type: .started, message: "s1"))
+        try store.append(JobEvent(jobID: jobID, timestamp: Date(timeIntervalSince1970: 3), type: .completed, message: "c1"))
+
+        let recent = try store.loadRecent(limit: 2)
+        XCTAssertEqual(recent.count, 2)
+        XCTAssertEqual(recent[0].message, "s1")
+        XCTAssertEqual(recent[1].message, "c1")
+    }
+
+    func testScreenshotStoreWritesPNGData() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-screens-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = ScreenshotStore(directoryURL: root)
+        let data = Data([0x89, 0x50, 0x4E, 0x47]) // PNG signature prefix
+        let url = try store.save(data, jobID: UUID(), stepIndex: 0)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        let onDisk = try Data(contentsOf: url)
+        XCTAssertEqual(onDisk, data)
+    }
+}

--- a/shell/Tests/MojoShellTests/JobStoreTests.swift
+++ b/shell/Tests/MojoShellTests/JobStoreTests.swift
@@ -17,7 +17,18 @@ final class JobStoreTests: XCTestCase {
                 progress: 0.0,
                 createdAt: Date(timeIntervalSince1970: 100),
                 completedAt: nil,
-                errorMessage: nil
+                errorMessage: nil,
+                sourceAssets: [
+                    SourceAsset(
+                        path: "/tmp/input.mov",
+                        name: "input.mov",
+                        kind: .video,
+                        byteSize: 1024
+                    ),
+                ],
+                notes: "operator note",
+                workflowVersion: "test-v2",
+                approvalMode: .alwaysAsk
             ),
         ]
 

--- a/shell/Tests/MojoShellTests/LLMProviderTests.swift
+++ b/shell/Tests/MojoShellTests/LLMProviderTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import MojoShell
+
+final class LLMProviderTests: XCTestCase {
+    func testClaudeProviderName() {
+        let provider = ClaudeProvider(apiKey: "test-key")
+        XCTAssertEqual(provider.name, "claude")
+    }
+
+    func testRequestBuildsCorrectURL() throws {
+        let provider = ClaudeProvider(apiKey: "test-key")
+        let request = try provider.buildURLRequest(prompt: "scan my inbox", tools: [])
+        XCTAssertEqual(request.url?.host, "api.anthropic.com")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertNotNil(request.value(forHTTPHeaderField: "x-api-key"))
+    }
+}

--- a/shell/Tests/MojoShellTests/LLMProviderTests.swift
+++ b/shell/Tests/MojoShellTests/LLMProviderTests.swift
@@ -14,4 +14,12 @@ final class LLMProviderTests: XCTestCase {
         XCTAssertEqual(request.httpMethod, "POST")
         XCTAssertNotNil(request.value(forHTTPHeaderField: "x-api-key"))
     }
+
+    func testOpenAIRequestBuildsCorrectURL() throws {
+        let provider = OpenAIProvider(apiKey: "test-key", model: "gpt-test")
+        let request = try provider.buildURLRequest(prompt: "scan my inbox", tools: [])
+        XCTAssertEqual(request.url?.host, "api.openai.com")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-key")
+    }
 }

--- a/shell/Tests/MojoShellTests/MCPClientTests.swift
+++ b/shell/Tests/MojoShellTests/MCPClientTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import MojoShell
+
+final class MCPClientTests: XCTestCase {
+    func testRequestSerialization() throws {
+        let request = MCPRequest(id: 1, method: "tools/list", params: [:])
+        let data = try JSONEncoder().encode(request)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(json["jsonrpc"] as? String, "2.0")
+        XCTAssertEqual(json["method"] as? String, "tools/list")
+    }
+
+    func testResponseParsing() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"list_notes","description":"List notes"}]}}
+        """.data(using: .utf8)!
+        let response = try JSONDecoder().decode(MCPResponse.self, from: json)
+        XCTAssertNil(response.error)
+        XCTAssertNotNil(response.result)
+    }
+}

--- a/shell/Tests/MojoShellTests/MCPToolExecutorTests.swift
+++ b/shell/Tests/MojoShellTests/MCPToolExecutorTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import MojoShell
+
+@MainActor
+final class MCPToolExecutorTests: XCTestCase {
+    func testExecutorReturnsToolTextFromOverrideClient() async throws {
+        let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
+        let executor = MCPToolExecutor(
+            daemonManager: daemonManager,
+            clientOverrides: [
+                "mail-intelligence": FakeMCPToolClient(
+                    response: MCPResponse(
+                        jsonrpc: "2.0",
+                        id: 1,
+                        result: MCPResult(
+                            tools: nil,
+                            content: [MCPContent(type: "text", text: "{\"ok\":true}")]
+                        ),
+                        error: nil
+                    )
+                )
+            ]
+        )
+
+        let result = try await executor.execute(
+            server: "mail-intelligence",
+            tool: "scan_persona_inboxes"
+        )
+
+        XCTAssertEqual(result.server, "mail-intelligence")
+        XCTAssertEqual(result.tool, "scan_persona_inboxes")
+        XCTAssertEqual(result.text, "{\"ok\":true}")
+    }
+
+    func testExecutorThrowsForUnknownServer() async {
+        let daemonManager = DaemonManager(repoRoot: "/tmp/apple-mcp")
+        let executor = MCPToolExecutor(daemonManager: daemonManager)
+
+        do {
+            _ = try await executor.execute(server: "does-not-exist", tool: "noop")
+            XCTFail("Expected unknown server error")
+        } catch let error as MCPToolExecutionError {
+            XCTAssertEqual(error, .unknownServer("does-not-exist"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}
+
+actor FakeMCPToolClient: MCPToolCalling {
+    let response: MCPResponse
+
+    init(response: MCPResponse) {
+        self.response = response
+    }
+
+    func callTool(name _: String, arguments _: [String: AnyCodable]) async throws -> MCPResponse {
+        response
+    }
+}

--- a/shell/Tests/MojoShellTests/MediaSupportTests.swift
+++ b/shell/Tests/MojoShellTests/MediaSupportTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import MojoShell
+
+final class MediaSupportTests: XCTestCase {
+    func testSourceAssetFromTextFileClassifiesDocument() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).txt")
+        try "hello".write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let asset = try XCTUnwrap(SourceAsset.from(path: url.path))
+        XCTAssertEqual(asset.name, url.lastPathComponent)
+        XCTAssertEqual(asset.kind, .document)
+        XCTAssertEqual(asset.byteSize, 5)
+    }
+
+    func testDocumentInspectorReturnsMetadataForFile() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).txt")
+        try "hello".write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let metadata = try XCTUnwrap(DocumentInspector.inspect(path: url.path))
+        XCTAssertEqual(metadata.name, url.lastPathComponent)
+        XCTAssertEqual(metadata.kind, .document)
+        XCTAssertEqual(metadata.byteSize, 5)
+        XCTAssertNotNil(metadata.modifiedAt)
+    }
+}

--- a/shell/Tests/MojoShellTests/MojoShellTests.swift
+++ b/shell/Tests/MojoShellTests/MojoShellTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+final class MojoShellTests: XCTestCase {
+    func testPlaceholder() {
+        XCTAssertTrue(true)
+    }
+}

--- a/shell/Tests/MojoShellTests/NativeToolExecutorTests.swift
+++ b/shell/Tests/MojoShellTests/NativeToolExecutorTests.swift
@@ -60,6 +60,14 @@ final class NativeToolExecutorTests: XCTestCase {
         XCTAssertEqual(invocation?.arguments, ["run", "Daily Brief", "--output-path", "-", "--input-path", "-"])
         XCTAssertEqual(invocation?.stdin, "hello world")
         XCTAssertEqual(result.text, "shortcut output")
+        XCTAssertEqual(
+            result.payload,
+            .object([
+                "name": .string("Daily Brief"),
+                "input_provided": .bool(true),
+                "stdout": .string("shortcut output"),
+            ])
+        )
     }
 
     func testSystemSettingsOpenUsesDeepLink() async throws {
@@ -82,6 +90,26 @@ final class NativeToolExecutorTests: XCTestCase {
         let opened = await capture.urls.first
         XCTAssertEqual(opened?.absoluteString, "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
         XCTAssertEqual(result.text, "Opened System Settings: accessibility")
+    }
+
+    func testShortcutsListReturnsStructuredPayload() async throws {
+        let executor = NativeToolExecutor(
+            repoRoot: "/tmp/apple-mcp",
+            appleScriptRunner: { _ in "" },
+            commandRunner: { _, _, _ in "Daily Brief\nExport Deliverable\n" },
+            urlOpener: { _ in true }
+        )
+
+        let result = try await executor.execute(
+            tool: NativeToolName.shortcutsList.rawValue,
+            arguments: [:]
+        )
+
+        XCTAssertEqual(result.text, "Daily Brief\nExport Deliverable")
+        XCTAssertEqual(
+            result.payload,
+            .array([.string("Daily Brief"), .string("Export Deliverable")])
+        )
     }
 }
 

--- a/shell/Tests/MojoShellTests/NativeToolExecutorTests.swift
+++ b/shell/Tests/MojoShellTests/NativeToolExecutorTests.swift
@@ -196,6 +196,33 @@ final class NativeToolExecutorTests: XCTestCase {
             .object(["path": .string(fileURL.path), "application": .string("Preview")])
         )
     }
+
+    func testRevealBrainFileUsesInjectedActiveBrainPath() async throws {
+        let capture = ScriptCapture()
+        let brainURL = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).json")
+        try Data("{}".utf8).write(to: brainURL)
+        defer { try? FileManager.default.removeItem(at: brainURL) }
+
+        let executor = NativeToolExecutor(
+            repoRoot: "/tmp/apple-mcp",
+            brainPathProvider: { brainURL.path },
+            appleScriptRunner: { script in
+                await capture.record(script)
+                return ""
+            },
+            commandRunner: { _, _, _ in "" },
+            urlOpener: { _ in true }
+        )
+
+        let result = try await executor.execute(
+            tool: NativeToolName.finderRevealBrainFile.rawValue,
+            arguments: [:]
+        )
+
+        let script = await capture.scripts.first
+        XCTAssertTrue(script?.contains(brainURL.path) ?? false)
+        XCTAssertEqual(result.text, "Revealed brain file in Finder: \(brainURL.path)")
+    }
 }
 
 private actor ScriptCapture {

--- a/shell/Tests/MojoShellTests/NativeToolExecutorTests.swift
+++ b/shell/Tests/MojoShellTests/NativeToolExecutorTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import MojoShell
+
+final class NativeToolExecutorTests: XCTestCase {
+    func testFinderOpenPathExpandsTildeAndRunsAppleScript() async throws {
+        let capture = ScriptCapture()
+        let executor = NativeToolExecutor(
+            repoRoot: "/tmp/apple-mcp",
+            appleScriptRunner: { script in
+                await capture.record(script)
+                return ""
+            },
+            commandRunner: { _, _, _ in "" },
+            urlOpener: { _ in true }
+        )
+
+        let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let currentDir = FileManager.default.currentDirectoryPath
+        FileManager.default.changeCurrentDirectoryPath(tempRoot.path)
+        defer { FileManager.default.changeCurrentDirectoryPath(currentDir) }
+
+        let downloads = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Downloads")
+        try? FileManager.default.createDirectory(at: downloads, withIntermediateDirectories: true)
+
+        let result = try await executor.execute(
+            tool: NativeToolName.finderOpenPath.rawValue,
+            arguments: ["path": .string("~/Downloads")]
+        )
+
+        let scripts = await capture.scripts
+        XCTAssertEqual(result.text, "Opened in Finder: \((downloads.path as NSString).standardizingPath)")
+        XCTAssertTrue(scripts.first?.contains(downloads.path) ?? false)
+    }
+
+    func testShortcutsRunUsesCLIAndInput() async throws {
+        let capture = CommandCapture()
+        let executor = NativeToolExecutor(
+            repoRoot: "/tmp/apple-mcp",
+            appleScriptRunner: { _ in "" },
+            commandRunner: { executable, arguments, stdin in
+                await capture.record(executable: executable, arguments: arguments, stdin: stdin)
+                return "shortcut output"
+            },
+            urlOpener: { _ in true }
+        )
+
+        let result = try await executor.execute(
+            tool: NativeToolName.shortcutsRun.rawValue,
+            arguments: [
+                "name": .string("Daily Brief"),
+                "input": .string("hello world"),
+            ]
+        )
+
+        let invocation = await capture.invocations.first
+        XCTAssertEqual(invocation?.executable, "/usr/bin/shortcuts")
+        XCTAssertEqual(invocation?.arguments, ["run", "Daily Brief", "--output-path", "-", "--input-path", "-"])
+        XCTAssertEqual(invocation?.stdin, "hello world")
+        XCTAssertEqual(result.text, "shortcut output")
+    }
+
+    func testSystemSettingsOpenUsesDeepLink() async throws {
+        let capture = URLCapture()
+        let executor = NativeToolExecutor(
+            repoRoot: "/tmp/apple-mcp",
+            appleScriptRunner: { _ in "" },
+            commandRunner: { _, _, _ in "" },
+            urlOpener: { url in
+                await capture.record(url)
+                return true
+            }
+        )
+
+        let result = try await executor.execute(
+            tool: NativeToolName.systemSettingsOpen.rawValue,
+            arguments: ["pane": .string("accessibility")]
+        )
+
+        let opened = await capture.urls.first
+        XCTAssertEqual(opened?.absoluteString, "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+        XCTAssertEqual(result.text, "Opened System Settings: accessibility")
+    }
+}
+
+private actor ScriptCapture {
+    private(set) var scripts: [String] = []
+
+    func record(_ script: String) {
+        scripts.append(script)
+    }
+}
+
+private actor URLCapture {
+    private(set) var urls: [URL] = []
+
+    func record(_ url: URL) {
+        urls.append(url)
+    }
+}
+
+private actor CommandCapture {
+    struct Invocation: Equatable {
+        let executable: String
+        let arguments: [String]
+        let stdin: String?
+    }
+
+    private(set) var invocations: [Invocation] = []
+
+    func record(executable: String, arguments: [String], stdin: String?) {
+        invocations.append(Invocation(executable: executable, arguments: arguments, stdin: stdin))
+    }
+}

--- a/shell/Tests/MojoShellTests/NativeToolExecutorTests.swift
+++ b/shell/Tests/MojoShellTests/NativeToolExecutorTests.swift
@@ -111,6 +111,91 @@ final class NativeToolExecutorTests: XCTestCase {
             .array([.string("Daily Brief"), .string("Export Deliverable")])
         )
     }
+
+    func testTerminalOpenRepoUsesOpenApplication() async throws {
+        let capture = CommandCapture()
+        let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let executor = NativeToolExecutor(
+            repoRoot: tempRoot.path,
+            appleScriptRunner: { _ in "" },
+            commandRunner: { executable, arguments, stdin in
+                await capture.record(executable: executable, arguments: arguments, stdin: stdin)
+                return ""
+            },
+            urlOpener: { _ in true }
+        )
+
+        let result = try await executor.execute(
+            tool: NativeToolName.terminalOpenRepo.rawValue,
+            arguments: [:]
+        )
+
+        let invocation = await capture.invocations.first
+        XCTAssertEqual(invocation?.executable, "/usr/bin/open")
+        XCTAssertEqual(invocation?.arguments, ["-a", "Terminal", tempRoot.path])
+        XCTAssertEqual(result.text, "Opened repo root in Terminal: \(tempRoot.path)")
+    }
+
+    func testTerminalRunCommandUsesAppleScriptAdapter() async throws {
+        let capture = ScriptCapture()
+        let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let executor = NativeToolExecutor(
+            repoRoot: tempRoot.path,
+            appleScriptRunner: { script in
+                await capture.record(script)
+                return ""
+            },
+            commandRunner: { _, _, _ in "" },
+            urlOpener: { _ in true }
+        )
+
+        let result = try await executor.execute(
+            tool: NativeToolName.terminalRunCommand.rawValue,
+            arguments: ["command": .string("pwd"), "path": .string(tempRoot.path)]
+        )
+
+        let script = await capture.scripts.last
+        XCTAssertTrue(script?.contains("tell application \"Terminal\"") ?? false)
+        XCTAssertTrue(script?.contains("pwd") ?? false)
+        XCTAssertTrue(script?.contains(tempRoot.path) ?? false)
+        XCTAssertEqual(result.text, "Ran command in Terminal: pwd")
+    }
+
+    func testPreviewOpenPathUsesOpenApplication() async throws {
+        let capture = CommandCapture()
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).txt")
+        try XCTUnwrap("hello".data(using: .utf8)).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let executor = NativeToolExecutor(
+            repoRoot: "/tmp/apple-mcp",
+            appleScriptRunner: { _ in "" },
+            commandRunner: { executable, arguments, stdin in
+                await capture.record(executable: executable, arguments: arguments, stdin: stdin)
+                return ""
+            },
+            urlOpener: { _ in true }
+        )
+
+        let result = try await executor.execute(
+            tool: NativeToolName.previewOpenPath.rawValue,
+            arguments: ["path": .string(fileURL.path)]
+        )
+
+        let invocation = await capture.invocations.first
+        XCTAssertEqual(invocation?.executable, "/usr/bin/open")
+        XCTAssertEqual(invocation?.arguments, ["-a", "Preview", fileURL.path])
+        XCTAssertEqual(
+            result.payload,
+            .object(["path": .string(fileURL.path), "application": .string("Preview")])
+        )
+    }
 }
 
 private actor ScriptCapture {

--- a/shell/Tests/MojoShellTests/ProductionControllerTests.swift
+++ b/shell/Tests/MojoShellTests/ProductionControllerTests.swift
@@ -325,6 +325,56 @@ final class ProductionControllerTests: XCTestCase {
         XCTAssertNil(controller.jobs.first?.errorMessage)
     }
 
+    func testEventsForJobReturnsOnlyMatchingHistory() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let jobOne = MediaJob(
+            id: UUID(),
+            name: "Job One",
+            client: "QA",
+            status: .completed,
+            progress: 1.0,
+            createdAt: Date(),
+            completedAt: Date(),
+            errorMessage: nil
+        )
+        let jobTwo = MediaJob(
+            id: UUID(),
+            name: "Job Two",
+            client: "QA",
+            status: .queued,
+            progress: 0.0,
+            createdAt: Date().addingTimeInterval(-60),
+            completedAt: nil,
+            errorMessage: nil
+        )
+
+        let jobStore = JobStore(fileURL: root.appendingPathComponent("jobs.json"))
+        try jobStore.save([jobOne, jobTwo])
+
+        let eventStore = JobEventStore(fileURL: root.appendingPathComponent("events.json"))
+        try eventStore.save([
+            JobEvent(jobID: jobOne.id, timestamp: Date(), type: .completed, message: "one"),
+            JobEvent(jobID: jobTwo.id, timestamp: Date().addingTimeInterval(-10), type: .queued, message: "two"),
+        ])
+
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            jobStore: jobStore,
+            eventStore: eventStore,
+            screenshotStore: ScreenshotStore(directoryURL: root.appendingPathComponent("screens")),
+            preflightCheck: {},
+            stepsProvider: { [] }
+        )
+
+        let events = controller.events(for: jobOne.id)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.message, "one")
+    }
+
     private func waitUntil(
         timeoutIterations: Int = 100,
         condition: @escaping () -> Bool

--- a/shell/Tests/MojoShellTests/ProductionControllerTests.swift
+++ b/shell/Tests/MojoShellTests/ProductionControllerTests.swift
@@ -173,11 +173,27 @@ final class ProductionControllerTests: XCTestCase {
             stepsProvider: { [] }
         )
 
-        controller.queueWorkflowJob(client: "QA", preset: .fcpExportCurrentTimeline)
+        controller.queueWorkflowJob(
+            client: "QA",
+            preset: .fcpExportCurrentTimeline,
+            sourceAssets: [
+                SourceAsset(
+                    path: "/tmp/input.mov",
+                    name: "input.mov",
+                    kind: .video,
+                    byteSize: 1024
+                ),
+            ],
+            notes: "operator note",
+            approvalMode: .alwaysAsk
+        )
 
         XCTAssertEqual(controller.jobs.last?.workflowPreset, .fcpExportCurrentTimeline)
         XCTAssertEqual(controller.jobs.last?.exportTargetPath, targetPath)
         XCTAssertEqual(controller.jobs.last?.appTarget, .finalCutPro)
+        XCTAssertEqual(controller.jobs.last?.sourceAssets.count, 1)
+        XCTAssertEqual(controller.jobs.last?.notes, "operator note")
+        XCTAssertEqual(controller.jobs.last?.approvalMode, .alwaysAsk)
     }
 
     func testMotionPlaceholderCompletesWithoutStartingComputerUseSession() async throws {
@@ -323,6 +339,80 @@ final class ProductionControllerTests: XCTestCase {
         controller.retryFailedJob(id: jobID)
         XCTAssertEqual(controller.jobs.first?.status, .queued)
         XCTAssertNil(controller.jobs.first?.errorMessage)
+    }
+
+    func testNeverAskApprovalModeRunsWithoutPendingApproval() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            jobStore: JobStore(fileURL: root.appendingPathComponent("jobs.json")),
+            eventStore: JobEventStore(fileURL: root.appendingPathComponent("events.json")),
+            screenshotStore: ScreenshotStore(directoryURL: root.appendingPathComponent("screens")),
+            preflightCheck: {},
+            workflowPlanProvider: { job in
+                WorkflowPlan(
+                    preset: job.workflowPreset ?? .fcpExportCurrentTimeline,
+                    steps: [
+                        WorkflowStep.keypress(
+                            "Approve Export",
+                            key: "cmd+e",
+                            approvalPrompt: "Confirm export settings",
+                            delay: 0
+                        ),
+                    ],
+                    requiresExportPreflight: false,
+                    completionMessage: "Approval workflow complete.",
+                    placeholderMessage: nil
+                )
+            }
+        )
+
+        controller.queueWorkflowJob(client: "QA", preset: .fcpExportCurrentTimeline, approvalMode: .neverAsk)
+        await controller.runNextWorkflow()
+
+        XCTAssertNil(controller.pendingApproval)
+        XCTAssertEqual(controller.jobs.first?.status, .completed)
+    }
+
+    func testAlwaysAskApprovalModePausesEvenWithoutStepPrompt() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            jobStore: JobStore(fileURL: root.appendingPathComponent("jobs.json")),
+            eventStore: JobEventStore(fileURL: root.appendingPathComponent("events.json")),
+            screenshotStore: ScreenshotStore(directoryURL: root.appendingPathComponent("screens")),
+            preflightCheck: {},
+            workflowPlanProvider: { job in
+                WorkflowPlan(
+                    preset: job.workflowPreset ?? .fcpExportCurrentTimeline,
+                    steps: [
+                        WorkflowStep.keypress("Background Step", key: "cmd+9", delay: 0),
+                    ],
+                    requiresExportPreflight: false,
+                    completionMessage: "Approval workflow complete.",
+                    placeholderMessage: nil
+                )
+            }
+        )
+
+        controller.queueWorkflowJob(client: "QA", preset: .fcpMonitorBackgroundTasks, approvalMode: .alwaysAsk)
+        let runTask = Task { await controller.runNextWorkflow() }
+
+        try await waitUntil { controller.pendingApproval != nil }
+        XCTAssertEqual(controller.pendingApproval?.stepDescription, "Background Step")
+
+        controller.approvePendingStep()
+        await runTask.value
+
+        XCTAssertEqual(controller.jobs.first?.status, .completed)
     }
 
     func testEventsForJobReturnsOnlyMatchingHistory() throws {

--- a/shell/Tests/MojoShellTests/ProductionControllerTests.swift
+++ b/shell/Tests/MojoShellTests/ProductionControllerTests.swift
@@ -47,7 +47,15 @@ final class ProductionControllerTests: XCTestCase {
             eventStore: eventStore,
             screenshotStore: screenshotStore,
             preflightCheck: {},
-            stepsProvider: { [WorkflowStep.keypress("Test Step", key: "cmd+e", delay: 0)] }
+            workflowPlanProvider: { job in
+                WorkflowPlan(
+                    preset: job.workflowPreset ?? .fcpExportCurrentTimeline,
+                    steps: [WorkflowStep.keypress("Test Step", key: "cmd+e", delay: 0)],
+                    requiresExportPreflight: false,
+                    completionMessage: "Test workflow complete.",
+                    placeholderMessage: nil
+                )
+            }
         )
 
         controller.queueAssemblyJob(name: "Run Job", client: "QA")
@@ -140,6 +148,61 @@ final class ProductionControllerTests: XCTestCase {
         XCTAssertTrue(events.contains(where: { $0.message == "Job requeued for retry" }))
     }
 
+    func testQueueWorkflowJobStoresPresetAndExportTarget() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let exportTargetStore = ExportTargetStore(fileURL: root.appendingPathComponent("export-targets.json"))
+        let jobStore = JobStore(fileURL: root.appendingPathComponent("jobs.json"))
+        let eventStore = JobEventStore(fileURL: root.appendingPathComponent("events.json"))
+        let screenshotStore = ScreenshotStore(directoryURL: root.appendingPathComponent("screens"))
+        let targetPath = root.appendingPathComponent("exports").path
+        try exportTargetStore.save([
+            ExportTarget(name: "Exports", path: targetPath, isDefault: true),
+        ])
+
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            jobStore: jobStore,
+            eventStore: eventStore,
+            screenshotStore: screenshotStore,
+            exportTargetStore: exportTargetStore,
+            preflightCheck: {},
+            stepsProvider: { [] }
+        )
+
+        controller.queueWorkflowJob(client: "QA", preset: .fcpExportCurrentTimeline)
+
+        XCTAssertEqual(controller.jobs.last?.workflowPreset, .fcpExportCurrentTimeline)
+        XCTAssertEqual(controller.jobs.last?.exportTargetPath, targetPath)
+        XCTAssertEqual(controller.jobs.last?.appTarget, .finalCutPro)
+    }
+
+    func testMotionPlaceholderCompletesWithoutStartingComputerUseSession() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let provider = ControllerTestComputerUseProvider()
+        let controller = ProductionController(
+            computerUseProvider: provider,
+            jobStore: JobStore(fileURL: root.appendingPathComponent("jobs.json")),
+            eventStore: JobEventStore(fileURL: root.appendingPathComponent("events.json")),
+            screenshotStore: ScreenshotStore(directoryURL: root.appendingPathComponent("screens"))
+        )
+
+        controller.queueWorkflowJob(client: "QA", preset: .motionPlaceholderReview)
+        await controller.runNextWorkflow()
+
+        let startedSessionCount = await provider.startedSessionCount()
+        XCTAssertEqual(controller.jobs.first?.status, .completed)
+        XCTAssertEqual(startedSessionCount, 0)
+        XCTAssertTrue(controller.workflowLog.contains("placeholder"))
+    }
+
     func testRunWorkflowWaitsForApprovalAndCompletesWhenApproved() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
@@ -158,15 +221,21 @@ final class ProductionControllerTests: XCTestCase {
             eventStore: eventStore,
             screenshotStore: screenshotStore,
             preflightCheck: {},
-            stepsProvider: {
-                [
-                    WorkflowStep.keypress(
-                        "Approve Export",
-                        key: "cmd+e",
-                        approvalPrompt: "Confirm export settings",
-                        delay: 0
-                    ),
-                ]
+            workflowPlanProvider: { job in
+                WorkflowPlan(
+                    preset: job.workflowPreset ?? .fcpExportCurrentTimeline,
+                    steps: [
+                        WorkflowStep.keypress(
+                            "Approve Export",
+                            key: "cmd+e",
+                            approvalPrompt: "Confirm export settings",
+                            delay: 0
+                        ),
+                    ],
+                    requiresExportPreflight: false,
+                    completionMessage: "Approval workflow complete.",
+                    placeholderMessage: nil
+                )
             }
         )
 
@@ -210,15 +279,21 @@ final class ProductionControllerTests: XCTestCase {
             eventStore: eventStore,
             screenshotStore: screenshotStore,
             preflightCheck: {},
-            stepsProvider: {
-                [
-                    WorkflowStep.keypress(
-                        "Approve Export",
-                        key: "cmd+e",
-                        approvalPrompt: "Confirm export settings",
-                        delay: 0
-                    ),
-                ]
+            workflowPlanProvider: { job in
+                WorkflowPlan(
+                    preset: job.workflowPreset ?? .fcpExportCurrentTimeline,
+                    steps: [
+                        WorkflowStep.keypress(
+                            "Approve Export",
+                            key: "cmd+e",
+                            approvalPrompt: "Confirm export settings",
+                            delay: 0
+                        ),
+                    ],
+                    requiresExportPreflight: false,
+                    completionMessage: "Approval workflow complete.",
+                    placeholderMessage: nil
+                )
             }
         )
 
@@ -286,6 +361,7 @@ private actor ControllerTestComputerUseProvider: ComputerUseProvider {
     let name = "controller-test-provider"
     private var sessions: Set<String> = []
     private let screenshotAfter: Data?
+    private var startCount = 0
 
     init(screenshotAfter: Data? = nil) {
         self.screenshotAfter = screenshotAfter
@@ -293,6 +369,7 @@ private actor ControllerTestComputerUseProvider: ComputerUseProvider {
 
     func startSession() async throws -> String {
         let id = UUID().uuidString
+        startCount += 1
         sessions.insert(id)
         return id
     }
@@ -309,6 +386,10 @@ private actor ControllerTestComputerUseProvider: ComputerUseProvider {
 
     func stopSession(sessionId: String) async throws {
         sessions.remove(sessionId)
+    }
+
+    func startedSessionCount() -> Int {
+        startCount
     }
 }
 

--- a/shell/Tests/MojoShellTests/ProductionControllerTests.swift
+++ b/shell/Tests/MojoShellTests/ProductionControllerTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import MojoShell
+
+@MainActor
+final class ProductionControllerTests: XCTestCase {
+    func testQueueAssemblyJobPersistsToDisk() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let jobStore = JobStore(fileURL: root.appendingPathComponent("jobs.json"))
+        let eventStore = JobEventStore(fileURL: root.appendingPathComponent("events.json"))
+        let screenshotStore = ScreenshotStore(directoryURL: root.appendingPathComponent("screens"))
+
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            jobStore: jobStore,
+            eventStore: eventStore,
+            screenshotStore: screenshotStore,
+            preflightCheck: {},
+            stepsProvider: { [] }
+        )
+
+        controller.queueAssemblyJob(name: "Queued Job", client: "QA")
+        XCTAssertEqual(controller.jobs.count, 1)
+
+        let onDisk = try jobStore.load()
+        XCTAssertEqual(onDisk.count, 1)
+        XCTAssertEqual(onDisk[0].name, "Queued Job")
+    }
+
+    func testRunNextAssemblyWorkflowCompletesAndPersistsEvents() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let jobStore = JobStore(fileURL: root.appendingPathComponent("jobs.json"))
+        let eventStore = JobEventStore(fileURL: root.appendingPathComponent("events.json"))
+        let screenshotStore = ScreenshotStore(directoryURL: root.appendingPathComponent("screens"))
+        let provider = ControllerTestComputerUseProvider(screenshotAfter: Data([1, 2, 3]))
+
+        let controller = ProductionController(
+            computerUseProvider: provider,
+            jobStore: jobStore,
+            eventStore: eventStore,
+            screenshotStore: screenshotStore,
+            preflightCheck: {},
+            stepsProvider: { [WorkflowStep.keypress("Test Step", key: "cmd+e", delay: 0)] }
+        )
+
+        controller.queueAssemblyJob(name: "Run Job", client: "QA")
+        await controller.runNextAssemblyWorkflow()
+
+        XCTAssertEqual(controller.jobs.first?.status, .completed)
+        XCTAssertEqual(controller.jobs.first?.progress, 1.0)
+
+        let events = try eventStore.load()
+        XCTAssertTrue(events.contains(where: { $0.type == .queued }))
+        XCTAssertTrue(events.contains(where: { $0.type == .started }))
+        XCTAssertTrue(events.contains(where: { $0.type == .completed }))
+
+        let screenshotEvent = events.first(where: { $0.screenshotPath != nil })
+        XCTAssertNotNil(screenshotEvent)
+        if let screenshotPath = screenshotEvent?.screenshotPath {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: screenshotPath))
+        }
+    }
+
+    func testPreflightFailureMarksJobAsFailed() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let jobStore = JobStore(fileURL: root.appendingPathComponent("jobs.json"))
+        let eventStore = JobEventStore(fileURL: root.appendingPathComponent("events.json"))
+        let screenshotStore = ScreenshotStore(directoryURL: root.appendingPathComponent("screens"))
+
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            jobStore: jobStore,
+            eventStore: eventStore,
+            screenshotStore: screenshotStore,
+            preflightCheck: { throw ProductionControllerError.noExportSelection },
+            stepsProvider: { [] }
+        )
+
+        controller.queueAssemblyJob(name: "Run Job", client: "QA")
+        await controller.runNextAssemblyWorkflow()
+
+        XCTAssertEqual(controller.jobs.first?.status, .failed)
+        XCTAssertTrue(controller.jobs.first?.errorMessage?.contains("No exportable clip selected") ?? false)
+
+        let events = try eventStore.load()
+        XCTAssertTrue(events.contains(where: { $0.type == .failed }))
+    }
+}
+
+private actor ControllerTestComputerUseProvider: ComputerUseProvider {
+    let name = "controller-test-provider"
+    private var sessions: Set<String> = []
+    private let screenshotAfter: Data?
+
+    init(screenshotAfter: Data? = nil) {
+        self.screenshotAfter = screenshotAfter
+    }
+
+    func startSession() async throws -> String {
+        let id = UUID().uuidString
+        sessions.insert(id)
+        return id
+    }
+
+    func captureState(sessionId: String) async throws -> ComputerUseState {
+        guard sessions.contains(sessionId) else { throw ControllerProviderError.unknownSession }
+        return ComputerUseState(appName: "test", screenshotData: nil, timestamp: Date())
+    }
+
+    func execute(sessionId: String, action: ComputerUseAction) async throws -> ComputerUseResult {
+        guard sessions.contains(sessionId) else { throw ControllerProviderError.unknownSession }
+        return ComputerUseResult(success: true, message: "ok \(action.type.rawValue)", screenshotAfter: screenshotAfter)
+    }
+
+    func stopSession(sessionId: String) async throws {
+        sessions.remove(sessionId)
+    }
+}
+
+private enum ControllerProviderError: Error {
+    case unknownSession
+}

--- a/shell/Tests/MojoShellTests/ProductionControllerTests.swift
+++ b/shell/Tests/MojoShellTests/ProductionControllerTests.swift
@@ -575,6 +575,40 @@ final class ProductionControllerTests: XCTestCase {
         XCTAssertEqual(try eventStore.load().filter { $0.type == .canceled }.count, 1)
     }
 
+    func testInterruptedRunningJobsAreRecoveredOnLoad() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let runningJob = MediaJob(
+            name: "Recovered Job",
+            client: "QA",
+            status: .running,
+            progress: 0.6,
+            createdAt: Date(),
+            completedAt: nil,
+            errorMessage: nil
+        )
+
+        let jobStore = JobStore(fileURL: root.appendingPathComponent("jobs.json"))
+        let eventStore = JobEventStore(fileURL: root.appendingPathComponent("events.json"))
+        try jobStore.save([runningJob])
+
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            jobStore: jobStore,
+            eventStore: eventStore,
+            screenshotStore: ScreenshotStore(directoryURL: root.appendingPathComponent("screens")),
+            preflightCheck: {},
+            stepsProvider: { [] }
+        )
+
+        XCTAssertEqual(controller.jobs.first?.status, .failed)
+        XCTAssertEqual(controller.jobs.first?.errorMessage, "Recovered after unexpected app exit.")
+        XCTAssertTrue(try eventStore.load().contains(where: { $0.message.contains("Recovered interrupted running job") }))
+    }
+
     private func waitUntil(
         timeoutIterations: Int = 100,
         condition: @escaping () -> Bool

--- a/shell/Tests/MojoShellTests/ProductionControllerTests.swift
+++ b/shell/Tests/MojoShellTests/ProductionControllerTests.swift
@@ -96,6 +96,43 @@ final class ProductionControllerTests: XCTestCase {
         let events = try eventStore.load()
         XCTAssertTrue(events.contains(where: { $0.type == .failed }))
     }
+
+    func testRetryFailedJobRequeuesIt() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let jobStore = JobStore(fileURL: root.appendingPathComponent("jobs.json"))
+        let eventStore = JobEventStore(fileURL: root.appendingPathComponent("events.json"))
+        let screenshotStore = ScreenshotStore(directoryURL: root.appendingPathComponent("screens"))
+
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            jobStore: jobStore,
+            eventStore: eventStore,
+            screenshotStore: screenshotStore,
+            preflightCheck: { throw ProductionControllerError.noExportSelection },
+            stepsProvider: { [] }
+        )
+
+        controller.queueAssemblyJob(name: "Run Job", client: "QA")
+        await controller.runNextAssemblyWorkflow()
+
+        guard let failedID = controller.jobs.first?.id else {
+            XCTFail("Expected failed job to exist")
+            return
+        }
+
+        controller.retryFailedJob(id: failedID)
+
+        XCTAssertEqual(controller.jobs.first?.status, .queued)
+        XCTAssertNil(controller.jobs.first?.errorMessage)
+        XCTAssertEqual(controller.jobs.first?.progress, 0.0)
+
+        let events = try eventStore.load()
+        XCTAssertTrue(events.contains(where: { $0.message == "Job requeued for retry" }))
+    }
 }
 
 private actor ControllerTestComputerUseProvider: ComputerUseProvider {

--- a/shell/Tests/MojoShellTests/ProductionControllerTests.swift
+++ b/shell/Tests/MojoShellTests/ProductionControllerTests.swift
@@ -77,9 +77,11 @@ final class ProductionControllerTests: XCTestCase {
         let jobStore = JobStore(fileURL: root.appendingPathComponent("jobs.json"))
         let eventStore = JobEventStore(fileURL: root.appendingPathComponent("events.json"))
         let screenshotStore = ScreenshotStore(directoryURL: root.appendingPathComponent("screens"))
+        let notifications = TestNotificationManager()
 
         let controller = ProductionController(
             computerUseProvider: ControllerTestComputerUseProvider(),
+            notifications: notifications,
             jobStore: jobStore,
             eventStore: eventStore,
             screenshotStore: screenshotStore,
@@ -95,6 +97,10 @@ final class ProductionControllerTests: XCTestCase {
 
         let events = try eventStore.load()
         XCTAssertTrue(events.contains(where: { $0.type == .failed }))
+
+        let delivered = await notifications.delivered()
+        XCTAssertEqual(delivered.last?.title, "MojoShell Job Failed")
+        XCTAssertEqual(delivered.last?.body, "Run Job")
     }
 
     func testRetryFailedJobRequeuesIt() async throws {
@@ -132,6 +138,147 @@ final class ProductionControllerTests: XCTestCase {
 
         let events = try eventStore.load()
         XCTAssertTrue(events.contains(where: { $0.message == "Job requeued for retry" }))
+    }
+
+    func testRunWorkflowWaitsForApprovalAndCompletesWhenApproved() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let jobStore = JobStore(fileURL: root.appendingPathComponent("jobs.json"))
+        let eventStore = JobEventStore(fileURL: root.appendingPathComponent("events.json"))
+        let screenshotStore = ScreenshotStore(directoryURL: root.appendingPathComponent("screens"))
+        let notifications = TestNotificationManager()
+
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            notifications: notifications,
+            jobStore: jobStore,
+            eventStore: eventStore,
+            screenshotStore: screenshotStore,
+            preflightCheck: {},
+            stepsProvider: {
+                [
+                    WorkflowStep.keypress(
+                        "Approve Export",
+                        key: "cmd+e",
+                        approvalPrompt: "Confirm export settings",
+                        delay: 0
+                    ),
+                ]
+            }
+        )
+
+        controller.queueAssemblyJob(name: "Approval Job", client: "QA")
+        let runTask = Task { await controller.runNextAssemblyWorkflow() }
+
+        try await waitUntil { controller.pendingApproval != nil }
+        XCTAssertEqual(controller.pendingApproval?.stepDescription, "Approve Export")
+        XCTAssertEqual(controller.pendingApproval?.prompt, "Confirm export settings")
+
+        controller.approvePendingStep()
+        await runTask.value
+
+        XCTAssertNil(controller.pendingApproval)
+        XCTAssertEqual(controller.jobs.first?.status, .completed)
+
+        let events = try eventStore.load()
+        XCTAssertTrue(events.contains(where: { $0.message.contains("Approval required for step 1") }))
+        XCTAssertTrue(events.contains(where: { $0.message.contains("Approval granted for step 1") }))
+
+        let delivered = await notifications.delivered()
+        XCTAssertEqual(delivered.last?.title, "MojoShell Job Complete")
+        XCTAssertEqual(delivered.last?.body, "Approval Job")
+    }
+
+    func testApprovalRejectionCancelsJobAndAllowsRetry() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let jobStore = JobStore(fileURL: root.appendingPathComponent("jobs.json"))
+        let eventStore = JobEventStore(fileURL: root.appendingPathComponent("events.json"))
+        let screenshotStore = ScreenshotStore(directoryURL: root.appendingPathComponent("screens"))
+        let notifications = TestNotificationManager()
+
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            notifications: notifications,
+            jobStore: jobStore,
+            eventStore: eventStore,
+            screenshotStore: screenshotStore,
+            preflightCheck: {},
+            stepsProvider: {
+                [
+                    WorkflowStep.keypress(
+                        "Approve Export",
+                        key: "cmd+e",
+                        approvalPrompt: "Confirm export settings",
+                        delay: 0
+                    ),
+                ]
+            }
+        )
+
+        controller.queueAssemblyJob(name: "Canceled Job", client: "QA")
+        let runTask = Task { await controller.runNextAssemblyWorkflow() }
+
+        try await waitUntil { controller.pendingApproval != nil }
+        controller.rejectPendingStep()
+        await runTask.value
+
+        XCTAssertEqual(controller.jobs.first?.status, .canceled)
+        XCTAssertTrue(controller.jobs.first?.errorMessage?.contains("Approval rejected") ?? false)
+
+        let events = try eventStore.load()
+        XCTAssertTrue(events.contains(where: { $0.type == .canceled }))
+        XCTAssertTrue(events.contains(where: { $0.message.contains("Approval rejected for step 1") }))
+
+        let delivered = await notifications.delivered()
+        XCTAssertEqual(delivered.last?.title, "MojoShell Job Canceled")
+        XCTAssertEqual(delivered.last?.body, "Canceled Job")
+
+        guard let jobID = controller.jobs.first?.id else {
+            XCTFail("Expected canceled job")
+            return
+        }
+
+        controller.retryFailedJob(id: jobID)
+        XCTAssertEqual(controller.jobs.first?.status, .queued)
+        XCTAssertNil(controller.jobs.first?.errorMessage)
+    }
+
+    private func waitUntil(
+        timeoutIterations: Int = 100,
+        condition: @escaping () -> Bool
+    ) async throws {
+        for _ in 0..<timeoutIterations {
+            if condition() {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTFail("Timed out waiting for condition")
+    }
+}
+
+private struct DeliveredNotification: Equatable {
+    let title: String
+    let body: String
+}
+
+private actor TestNotificationManager: AppNotifying {
+    private var notifications: [DeliveredNotification] = []
+
+    func deliver(title: String, body: String) async {
+        notifications.append(DeliveredNotification(title: title, body: body))
+    }
+
+    func delivered() -> [DeliveredNotification] {
+        notifications
     }
 }
 

--- a/shell/Tests/MojoShellTests/ProductionControllerTests.swift
+++ b/shell/Tests/MojoShellTests/ProductionControllerTests.swift
@@ -465,6 +465,116 @@ final class ProductionControllerTests: XCTestCase {
         XCTAssertEqual(events.first?.message, "one")
     }
 
+    func testDuplicateJobQueuesNewCopy() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            jobStore: JobStore(fileURL: root.appendingPathComponent("jobs.json")),
+            eventStore: JobEventStore(fileURL: root.appendingPathComponent("events.json")),
+            screenshotStore: ScreenshotStore(directoryURL: root.appendingPathComponent("screens")),
+            preflightCheck: {},
+            stepsProvider: { [] }
+        )
+
+        controller.queueAssemblyJob(name: "Original", client: "QA")
+        let originalID = try XCTUnwrap(controller.jobs.first?.id)
+
+        controller.duplicateJob(id: originalID)
+
+        XCTAssertEqual(controller.jobs.count, 2)
+        XCTAssertEqual(controller.jobs.first?.status, .queued)
+        XCTAssertNotEqual(controller.jobs.first?.id, originalID)
+        XCTAssertTrue(controller.jobs.first?.name.contains("Copy") ?? false)
+    }
+
+    func testCancelQueuedJobMarksItCanceled() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            jobStore: JobStore(fileURL: root.appendingPathComponent("jobs.json")),
+            eventStore: JobEventStore(fileURL: root.appendingPathComponent("events.json")),
+            screenshotStore: ScreenshotStore(directoryURL: root.appendingPathComponent("screens")),
+            preflightCheck: {},
+            stepsProvider: { [] }
+        )
+
+        controller.queueAssemblyJob(name: "Cancelable", client: "QA")
+        let jobID = try XCTUnwrap(controller.jobs.first?.id)
+
+        controller.cancelQueuedJob(id: jobID)
+
+        XCTAssertEqual(controller.jobs.first?.status, .canceled)
+        XCTAssertEqual(controller.jobs.first?.errorMessage, "Canceled before run.")
+    }
+
+    func testPrioritizeQueuedJobMovesItToFront() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            jobStore: JobStore(fileURL: root.appendingPathComponent("jobs.json")),
+            eventStore: JobEventStore(fileURL: root.appendingPathComponent("events.json")),
+            screenshotStore: ScreenshotStore(directoryURL: root.appendingPathComponent("screens")),
+            preflightCheck: {},
+            stepsProvider: { [] }
+        )
+
+        controller.queueAssemblyJob(name: "First", client: "QA")
+        controller.queueAssemblyJob(name: "Second", client: "QA")
+
+        let secondID = try XCTUnwrap(controller.jobs.last?.id)
+        controller.prioritizeQueuedJob(id: secondID)
+
+        XCTAssertEqual(controller.jobs.first?.id, secondID)
+    }
+
+    func testRemoveAndClearFinishedJobsPruneQueue() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-production-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let jobStore = JobStore(fileURL: root.appendingPathComponent("jobs.json"))
+        let eventStore = JobEventStore(fileURL: root.appendingPathComponent("events.json"))
+        let controller = ProductionController(
+            computerUseProvider: ControllerTestComputerUseProvider(),
+            jobStore: jobStore,
+            eventStore: eventStore,
+            screenshotStore: ScreenshotStore(directoryURL: root.appendingPathComponent("screens")),
+            preflightCheck: {},
+            stepsProvider: { [] }
+        )
+
+        controller.queueAssemblyJob(name: "Keep", client: "QA")
+        controller.queueAssemblyJob(name: "Remove", client: "QA")
+        let removeID = try XCTUnwrap(controller.jobs.last?.id)
+        controller.removeJob(id: removeID)
+
+        XCTAssertEqual(controller.jobs.count, 1)
+
+        guard let keepID = controller.jobs.first?.id else {
+            XCTFail("Expected remaining job")
+            return
+        }
+        controller.cancelQueuedJob(id: keepID)
+        controller.clearFinishedJobs()
+
+        XCTAssertEqual(controller.jobs.count, 0)
+        XCTAssertEqual(try jobStore.load().count, 0)
+        XCTAssertEqual(try eventStore.load().filter { $0.type == .canceled }.count, 1)
+    }
+
     private func waitUntil(
         timeoutIterations: Int = 100,
         condition: @escaping () -> Bool

--- a/shell/Tests/MojoShellTests/ReadinessModelsTests.swift
+++ b/shell/Tests/MojoShellTests/ReadinessModelsTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import MojoShell
+
+final class ReadinessModelsTests: XCTestCase {
+    func testSeverityCasesExist() {
+        let severities: [ReadinessSeverity] = [.info, .warning, .blocking]
+        XCTAssertEqual(severities.count, 3)
+    }
+
+    func testSeverityIsEquatable() {
+        XCTAssertEqual(ReadinessSeverity.blocking, .blocking)
+        XCTAssertNotEqual(ReadinessSeverity.blocking, .warning)
+    }
+
+    func testIssueStoresValues() {
+        let issue = ReadinessIssue(
+            id: "test_id",
+            title: "Test Title",
+            fixInstruction: "Do something",
+            actionURL: nil,
+            severity: .blocking
+        )
+        XCTAssertEqual(issue.id, "test_id")
+        XCTAssertEqual(issue.title, "Test Title")
+        XCTAssertEqual(issue.fixInstruction, "Do something")
+        XCTAssertEqual(issue.severity, .blocking)
+        XCTAssertNil(issue.actionURL)
+    }
+
+    func testIssueIsEquatable() {
+        let first = ReadinessIssue(id: "a", title: "A", fixInstruction: "fix", actionURL: nil, severity: .warning)
+        let second = ReadinessIssue(id: "a", title: "A", fixInstruction: "fix", actionURL: nil, severity: .warning)
+        XCTAssertEqual(first, second)
+    }
+
+    func testFeatureCasesExist() {
+        let features: Set<ReadinessFeature> = [.computerUse, .llm]
+        XCTAssertEqual(features.count, 2)
+    }
+}

--- a/shell/Tests/MojoShellTests/ReadinessStateTests.swift
+++ b/shell/Tests/MojoShellTests/ReadinessStateTests.swift
@@ -1,0 +1,283 @@
+import XCTest
+@testable import MojoShell
+
+private func makeTestDefaults() -> UserDefaults {
+    let suite = "ReadinessTests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suite)!
+    defaults.removePersistentDomain(forName: suite)
+    return defaults
+}
+
+@MainActor
+private func makeRepoRoot(
+    createBrainFile: Bool = true,
+    createArtifacts: Bool = true
+) -> String {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("mojoshell-readiness-\(UUID().uuidString)")
+    try! FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+    if createBrainFile {
+        let brainURL = root
+            .appendingPathComponent("knowledge-corpus")
+            .appendingPathComponent("data")
+        try! FileManager.default.createDirectory(at: brainURL, withIntermediateDirectories: true)
+        let fileURL = brainURL.appendingPathComponent("mojosolo_operating_brain.json")
+        try! "{}".data(using: .utf8)!.write(to: fileURL)
+    }
+
+    if createArtifacts {
+        let manager = DaemonManager(repoRoot: root.path)
+        for server in manager.serverDefinitions {
+            let fileURL = URL(fileURLWithPath: server.scriptPath)
+            try! FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try! Data().write(to: fileURL)
+        }
+    }
+
+    return root.path
+}
+
+@MainActor
+private func makeState(
+    repoRoot: String,
+    defaults: UserDefaults = makeTestDefaults(),
+    environment: [String: String] = [:],
+    axGranted: Bool = true,
+    screenRecordingGranted: Bool = true
+) -> ReadinessState {
+    ReadinessState(
+        daemonManager: DaemonManager(repoRoot: repoRoot),
+        defaults: defaults,
+        environment: environment,
+        axCheck: { axGranted },
+        screenRecordingCheck: { screenRecordingGranted }
+    )
+}
+
+@MainActor
+final class ReadinessStateCoreTests: XCTestCase {
+    func testMissingRepoRootProducesBlockingCoreIssue() async {
+        let repoRoot = "/tmp/nonexistent-readiness-\(UUID().uuidString)"
+        let state = makeState(repoRoot: repoRoot)
+
+        await state.refresh()
+
+        let issue = state.coreIssues.first(where: { $0.id == "repo_root" })
+        XCTAssertNotNil(issue)
+        XCTAssertEqual(issue?.severity, .blocking)
+    }
+
+    func testValidRepoRootProducesNoRepoRootIssue() async {
+        let repoRoot = makeRepoRoot()
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let state = makeState(repoRoot: repoRoot)
+
+        await state.refresh()
+
+        XCTAssertFalse(state.coreIssues.map(\.id).contains("repo_root"))
+    }
+
+    func testMissingBrainFileProducesBlockingCoreIssue() async {
+        let repoRoot = makeRepoRoot(createBrainFile: false)
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let state = makeState(repoRoot: repoRoot)
+
+        await state.refresh()
+
+        let issue = state.coreIssues.first(where: { $0.id == "brain_file" })
+        XCTAssertNotNil(issue)
+        XCTAssertEqual(issue?.severity, .blocking)
+    }
+
+    func testBrainPathEnvVarOverridesDefault() async {
+        let repoRoot = makeRepoRoot(createBrainFile: false, createArtifacts: true)
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+
+        let brainURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-brain-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: brainURL) }
+        try! "{\"brain\":true}".data(using: .utf8)!.write(to: brainURL)
+
+        let state = makeState(
+            repoRoot: repoRoot,
+            environment: ["BRAIN_PATH": brainURL.path]
+        )
+
+        await state.refresh()
+
+        XCTAssertFalse(state.coreIssues.map(\.id).contains("brain_file"))
+    }
+
+    func testMissingDaemonArtifactsProducesWarningCoreIssue() async {
+        let repoRoot = makeRepoRoot(createBrainFile: true, createArtifacts: false)
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let state = makeState(repoRoot: repoRoot)
+
+        await state.refresh()
+
+        let issue = state.coreIssues.first(where: { $0.id == "daemon_artifacts" })
+        XCTAssertNotNil(issue)
+        XCTAssertEqual(issue?.severity, .warning)
+    }
+
+    func testIssuesAreSortedBySeverityThenId() async {
+        let repoRoot = "/tmp/nonexistent-readiness-\(UUID().uuidString)"
+        let state = makeState(repoRoot: repoRoot)
+
+        await state.refresh()
+
+        XCTAssertEqual(state.coreIssues.map(\.id), ["brain_file", "repo_root", "daemon_artifacts"])
+    }
+
+    func testRefreshDoesNotDuplicateIssues() async {
+        let repoRoot = makeRepoRoot(createBrainFile: false, createArtifacts: false)
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let state = makeState(repoRoot: repoRoot)
+
+        await state.refresh()
+        let firstIDs = state.coreIssues.map(\.id)
+
+        await state.refresh()
+        let secondIDs = state.coreIssues.map(\.id)
+
+        XCTAssertEqual(firstIDs, secondIDs)
+        XCTAssertEqual(Set(secondIDs).count, secondIDs.count)
+    }
+}
+
+@MainActor
+final class ReadinessStateFeatureTests: XCTestCase {
+    func testComputerUseIsNotReadyWhenAccessibilityMissing() async {
+        let repoRoot = makeRepoRoot()
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let state = makeState(repoRoot: repoRoot, axGranted: false, screenRecordingGranted: true)
+
+        await state.refresh()
+
+        XCTAssertFalse(state.isReady(for: .computerUse))
+        XCTAssertEqual(state.blockingIssue(for: .computerUse)?.id, "accessibility")
+    }
+
+    func testComputerUseIsReadyWhenOnlyScreenRecordingMissing() async {
+        let repoRoot = makeRepoRoot()
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let state = makeState(repoRoot: repoRoot, axGranted: true, screenRecordingGranted: false)
+
+        await state.refresh()
+
+        XCTAssertTrue(state.isReady(for: .computerUse))
+        XCTAssertEqual(state.featureIssues[.computerUse]?.map(\.id), ["screen_recording"])
+    }
+
+    func testLLMIsNotReadyWhenNoKeysPresent() async {
+        let repoRoot = makeRepoRoot()
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let state = makeState(repoRoot: repoRoot)
+
+        await state.refresh()
+
+        XCTAssertFalse(state.isReady(for: .llm))
+        XCTAssertEqual(state.blockingIssue(for: .llm)?.id, "llm_no_keys")
+    }
+
+    func testLLMShowsInfoWhenOnlyOneKeyPresent() async {
+        let repoRoot = makeRepoRoot()
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let state = makeState(repoRoot: repoRoot, environment: ["ANTHROPIC_API_KEY": "sk-ant"])
+
+        await state.refresh()
+
+        XCTAssertTrue(state.isReady(for: .llm))
+        XCTAssertEqual(state.featureIssues[.llm]?.map(\.id), ["llm_single_provider"])
+        XCTAssertEqual(state.featureIssues[.llm]?.first?.severity, .info)
+    }
+
+    func testLLMHasNoIssuesWhenBothKeysPresent() async {
+        let repoRoot = makeRepoRoot()
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let state = makeState(
+            repoRoot: repoRoot,
+            environment: [
+                "ANTHROPIC_API_KEY": "sk-ant",
+                "OPENAI_API_KEY": "sk-oai",
+            ]
+        )
+
+        await state.refresh()
+
+        XCTAssertEqual(state.featureIssues[.llm] ?? [], [])
+        XCTAssertTrue(state.isReady(for: .llm))
+    }
+
+    func testAXPermissionGrantedUsesInjectedClosure() {
+        let repoRoot = makeRepoRoot()
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let state = makeState(repoRoot: repoRoot, axGranted: false)
+        XCTAssertFalse(state.axPermissionGranted())
+    }
+}
+
+@MainActor
+final class ReadinessStateFirstRunTests: XCTestCase {
+    func testShowFirstRunSheetWhenIssuesPresentAndKeyAbsent() async {
+        let repoRoot = makeRepoRoot(createBrainFile: false, createArtifacts: false)
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let defaults = makeTestDefaults()
+        let state = makeState(repoRoot: repoRoot, defaults: defaults)
+
+        await state.refresh()
+
+        XCTAssertTrue(state.showFirstRunSheet)
+    }
+
+    func testDoNotShowFirstRunSheetWhenKeyAlreadySet() async {
+        let repoRoot = makeRepoRoot(createBrainFile: false, createArtifacts: false)
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let defaults = makeTestDefaults()
+        defaults.set(true, forKey: "readiness.firstRunShown")
+        let state = makeState(repoRoot: repoRoot, defaults: defaults)
+
+        await state.refresh()
+
+        XCTAssertFalse(state.showFirstRunSheet)
+    }
+
+    func testNoFirstRunSheetWhenNoIssues() async {
+        let repoRoot = makeRepoRoot()
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let defaults = makeTestDefaults()
+        let state = makeState(
+            repoRoot: repoRoot,
+            defaults: defaults,
+            environment: [
+                "ANTHROPIC_API_KEY": "sk-ant",
+                "OPENAI_API_KEY": "sk-oai",
+            ],
+            axGranted: true,
+            screenRecordingGranted: true
+        )
+
+        await state.refresh()
+
+        XCTAssertFalse(state.showFirstRunSheet)
+    }
+
+    func testMarkFirstRunShownPersistsAndDismissesSheet() async {
+        let repoRoot = makeRepoRoot(createBrainFile: false, createArtifacts: false)
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+        let defaults = makeTestDefaults()
+        let state = makeState(repoRoot: repoRoot, defaults: defaults)
+
+        await state.refresh()
+        XCTAssertTrue(state.showFirstRunSheet)
+
+        state.markFirstRunShown()
+
+        XCTAssertTrue(defaults.bool(forKey: "readiness.firstRunShown"))
+        XCTAssertFalse(state.showFirstRunSheet)
+    }
+}

--- a/shell/Tests/MojoShellTests/ReadinessStateTests.swift
+++ b/shell/Tests/MojoShellTests/ReadinessStateTests.swift
@@ -46,6 +46,7 @@ private func makeState(
     repoRoot: String,
     defaults: UserDefaults = makeTestDefaults(),
     environment: [String: String] = [:],
+    brainPathProvider: @escaping @MainActor () -> String? = { nil },
     axGranted: Bool = true,
     screenRecordingGranted: Bool = true
 ) -> ReadinessState {
@@ -53,6 +54,7 @@ private func makeState(
         daemonManager: DaemonManager(repoRoot: repoRoot),
         defaults: defaults,
         environment: environment,
+        brainPathProvider: brainPathProvider,
         axCheck: { axGranted },
         screenRecordingCheck: { screenRecordingGranted }
     )
@@ -105,6 +107,25 @@ final class ReadinessStateCoreTests: XCTestCase {
         let state = makeState(
             repoRoot: repoRoot,
             environment: ["BRAIN_PATH": brainURL.path]
+        )
+
+        await state.refresh()
+
+        XCTAssertFalse(state.coreIssues.map(\.id).contains("brain_file"))
+    }
+
+    func testBrainPathProviderOverridesDefault() async {
+        let repoRoot = makeRepoRoot(createBrainFile: false, createArtifacts: true)
+        defer { try? FileManager.default.removeItem(atPath: repoRoot) }
+
+        let brainURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("provider-brain-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: brainURL) }
+        try! "{\"brain\":true}".data(using: .utf8)!.write(to: brainURL)
+
+        let state = makeState(
+            repoRoot: repoRoot,
+            brainPathProvider: { brainURL.path }
         )
 
         await state.refresh()

--- a/shell/Tests/MojoShellTests/ShellPreferencesControllerTests.swift
+++ b/shell/Tests/MojoShellTests/ShellPreferencesControllerTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import MojoShell
+
+@MainActor
+final class ShellPreferencesControllerTests: XCTestCase {
+    func testPreferencesPersistAndReload() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-preferences-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = ShellPreferencesStore(fileURL: root.appendingPathComponent("preferences.json"))
+        let controller = ShellPreferencesController(store: store)
+
+        controller.autoStartDaemonsOnLaunch = false
+        controller.autoRefreshNowPlaying = false
+        controller.morningOpsOnLaunch = true
+        controller.recordMorningOpsRun(at: Date(timeIntervalSince1970: 42))
+
+        let reloaded = ShellPreferencesController(store: store)
+        XCTAssertFalse(reloaded.autoStartDaemonsOnLaunch)
+        XCTAssertFalse(reloaded.autoRefreshNowPlaying)
+        XCTAssertTrue(reloaded.morningOpsOnLaunch)
+        XCTAssertEqual(reloaded.lastMorningOpsRunAt, Date(timeIntervalSince1970: 42))
+    }
+}

--- a/shell/Tests/MojoShellTests/ShellSessionControllerTests.swift
+++ b/shell/Tests/MojoShellTests/ShellSessionControllerTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import MojoShell
+
+@MainActor
+final class ShellSessionControllerTests: XCTestCase {
+    func testShellSessionControllerPersistsAndReloadsState() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-session-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = ShellSessionStore(fileURL: root.appendingPathComponent("session.json"))
+        let controller = ShellSessionController(store: store)
+
+        controller.selectedView = .production
+        controller.preferredPreset = .motionPlaceholderExport
+        controller.preferredApprovalMode = .alwaysAsk
+        controller.appendTerminalEntry(TerminalEntry(role: .user, text: "scan inboxes"))
+
+        let reloaded = ShellSessionController(store: store)
+        XCTAssertEqual(reloaded.selectedView, .production)
+        XCTAssertEqual(reloaded.preferredPreset, .motionPlaceholderExport)
+        XCTAssertEqual(reloaded.preferredApprovalMode, .alwaysAsk)
+        XCTAssertEqual(reloaded.terminalHistory.last?.text, "scan inboxes")
+    }
+
+    func testClearTerminalHistoryResetsToSystemEntry() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-session-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let controller = ShellSessionController(
+            store: ShellSessionStore(fileURL: root.appendingPathComponent("session.json"))
+        )
+        controller.appendTerminalEntry(TerminalEntry(role: .user, text: "hello"))
+        controller.clearTerminalHistory()
+
+        XCTAssertEqual(controller.terminalHistory.count, 1)
+        XCTAssertEqual(controller.terminalHistory.first?.role, .system)
+    }
+}

--- a/shell/Tests/MojoShellTests/ShellSessionControllerTests.swift
+++ b/shell/Tests/MojoShellTests/ShellSessionControllerTests.swift
@@ -39,4 +39,19 @@ final class ShellSessionControllerTests: XCTestCase {
         XCTAssertEqual(controller.terminalHistory.count, 1)
         XCTAssertEqual(controller.terminalHistory.first?.role, .system)
     }
+
+    func testMorningOpsRequestIsTransient() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mojoshell-session-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = ShellSessionStore(fileURL: root.appendingPathComponent("session.json"))
+        let controller = ShellSessionController(store: store)
+        controller.requestMorningOpsRun()
+
+        XCTAssertNotNil(controller.morningOpsRequestID)
+        let reloaded = ShellSessionController(store: store)
+        XCTAssertNil(reloaded.morningOpsRequestID)
+    }
 }


### PR DESCRIPTION
## Summary
- add a governed roadmap for apple-mcp covering MCP foundation, hydration pipeline, canonical brain, shell, and packaging sequencing
- lock the main architectural boundary that deterministic harvest and skill compilation come before the shell
- add a CLAUDE memory pointer to the new roadmap packet

## Notes
- roadmap grounded in current repo docs and committed branch head e3b2539
- preserves active local feat/macos-shell work by using a clean docs worktree
