### PR TITLE
Add get_message_source tool for raw RFC822 email access

### DIFF
--- a/mail/src/applescript.ts
+++ b/mail/src/applescript.ts
@@ -163,6 +163,42 @@ end tell`;
   };
 }
 
+export async function getMessageSource(
+  mailboxName: string,
+  accountName: string,
+  messageId: number
+): Promise<{
+  id: number;
+  subject: string;
+  sender: string;
+  source: string;
+}> {
+  const safeMb = sanitize(mailboxName);
+  const safeAcct = sanitize(accountName);
+  const script = `
+tell application "Mail"
+  set mb to mailbox "${safeMb}" of account "${safeAcct}"
+  set matchedMsgs to (every message of mb whose id is ${messageId})
+  if (count of matchedMsgs) is 0 then
+    error "Message not found with id: ${messageId}"
+  end if
+  set m to item 1 of matchedMsgs
+  set mId to id of m
+  set mSubject to subject of m
+  set mSender to sender of m
+  set mSource to source of m
+  return (mId as text) & "${RECORD_DELIM}" & mSubject & "${RECORD_DELIM}" & mSender & "${RECORD_DELIM}" & mSource
+end tell`;
+  const raw = await runAppleScript(script);
+  const parts = raw.split(RECORD_DELIM);
+  return {
+    id: parseInt(parts[0]?.trim() || "0", 10),
+    subject: parts[1]?.trim() || "",
+    sender: parts[2]?.trim() || "",
+    source: parts[3] || "",
+  };
+}
+
 export async function searchMessages(
   query: string,
   mailboxName?: string,

--- a/mail/src/index.ts
+++ b/mail/src/index.ts
@@ -69,6 +69,27 @@ server.registerTool(
   }
 );
 
+// ---- get_message_source ----
+server.registerTool(
+  "get_message_source",
+  {
+    description: "Get the raw RFC822 source of an email (includes all headers like List-Unsubscribe and the full HTML body). Use this when you need to find unsubscribe links or inspect email headers.",
+    inputSchema: z.object({
+      mailbox: z.string().describe("Name of the mailbox"),
+      account: z.string().describe("Name of the email account"),
+      message_id: z.number().describe("ID of the message to retrieve"),
+    }),
+  },
+  async ({ mailbox, account, message_id }) => {
+    try {
+      const message = await applescript.getMessageSource(mailbox, account, message_id);
+      return { content: [{ type: "text", text: JSON.stringify(message, null, 2) }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+    }
+  }
+);
+
 // ---- search_messages ----
 server.registerTool(
   "search_messages",


### PR DESCRIPTION
## Summary

- Adds a new `get_message_source` MCP tool that returns the full raw RFC822 source of an email message
- Uses AppleScript's `source of m` property (vs the existing `content of m` which strips HTML/headers)
- Returns: message ID, subject, sender, and the complete raw source (all headers + MIME body)

## Motivation

The existing `get_message` tool returns only plain-text content, which makes it impossible to:
- Extract unsubscribe URLs from HTML anchor tags (`<a href="https://...">Unsubscribe</a>`)
- Read standard email headers like `List-Unsubscribe` (RFC 2369)
- Access the full HTML body for any kind of parsing

This came up while building an email unsubscribe automation that needed to find and navigate HTTP unsubscribe links using a browser.

## Changes

- **`mail/src/applescript.ts`** — Added `getMessageSource()` function that fetches `source of m` from Apple Mail
- **`mail/src/index.ts`** — Registered the `get_message_source` tool with schema and description

## Test plan

- [ ] `get_message_source` returns raw RFC822 source with full headers
- [ ] `List-Unsubscribe` header is accessible in the returned source
- [ ] HTML body content is preserved (not stripped to plain text)
- [ ] Existing `get_message` tool continues to work unchanged