### PR TITLE
Align MCP safety flags across servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,14 @@ All servers (except Apple Maps, which is UI-only) support two optional safety fl
 | Mode | Flag | Behaviour |
 |------|------|-----------|
 | **Normal** (default) | _(none)_ | All tools available, no restrictions |
-| **Read-only** | `--read-only` | Destructive/write tools are not registered at all |
-| **Confirm** | `--confirm-destructive` | Destructive tools require a `confirm: true` parameter; without it they return a warning asking the AI to check with the user first |
+| **Read-only** | `--read-only` | Only read tools are registered. All mutating tools, including non-destructive writes like `send_email` or `send_message`, are removed. |
+| **Confirm** | `--confirm-destructive` | Destructive tools require a `confirm: true` parameter; without it they return a warning asking the AI to check with the user first. Non-destructive write tools remain available. |
+
+In other words:
+
+- `--read-only` removes all write and destructive tools from the server entirely.
+- `--confirm-destructive` only adds confirmation to destructive tools.
+- If both flags are provided, `--read-only` wins because destructive tools are not registered in that mode.
 
 ### Claude Desktop
 
@@ -63,6 +69,7 @@ claude mcp add apple-messages -- npx @griches/apple-messages-mcp --confirm-destr
 | Contacts | `delete_contact`, `delete_group` |
 | Reminders | `delete_reminder`, `delete_list` |
 | Calendar | `delete_event` |
+| Mail | `delete_message` |
 
 ## Installation
 

--- a/calendar/src/index.ts
+++ b/calendar/src/index.ts
@@ -5,216 +5,261 @@ import { z } from "zod";
 import * as applescript from "./applescript.js";
 import * as eventkit from "./eventkit.js";
 
-const readOnly = process.argv.includes("--read-only");
-const confirmDestructive = process.argv.includes("--confirm-destructive");
+export interface SafetyFlags {
+  readOnly: boolean;
+  confirmDestructive: boolean;
+}
 
-const server = new McpServer({
-  name: "apple-calendar",
-  version: "1.0.0",
-});
-
-// ---- list_calendars ----
-server.registerTool(
+const READ_TOOL_NAMES = [
   "list_calendars",
-  {
-    description: "List all calendars in Apple Calendar",
-    inputSchema: z.object({}),
-  },
-  async () => {
-    try {
-      const calendars = await eventkit.listCalendars();
-      return { content: [{ type: "text", text: JSON.stringify(calendars, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- list_all_events ----
-server.registerTool(
   "list_all_events",
-  {
-    description: "List events across ALL calendars within a date range. Use this instead of list_events when you need events from all calendars.",
-    inputSchema: z.object({
-      from_date: z.string().describe("Start date (e.g. '1 January 2025')"),
-      to_date: z.string().describe("End date (e.g. '31 January 2025')"),
-    }),
-  },
-  async ({ from_date, to_date }) => {
-    try {
-      const events = await eventkit.listAllEvents(from_date, to_date);
-      return { content: [{ type: "text", text: JSON.stringify(events, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- list_events ----
-server.registerTool(
   "list_events",
-  {
-    description: "List events in a calendar within a date range",
-    inputSchema: z.object({
-      calendar: z.string().describe("Name of the calendar"),
-      from_date: z.string().describe("Start date (e.g. '1 January 2025')"),
-      to_date: z.string().describe("End date (e.g. '31 January 2025')"),
-    }),
-  },
-  async ({ calendar, from_date, to_date }) => {
-    try {
-      const events = await eventkit.listEvents(calendar, from_date, to_date);
-      return { content: [{ type: "text", text: JSON.stringify(events, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- get_event ----
-server.registerTool(
   "get_event",
-  {
-    description: "Get full details of an event by its summary/title",
-    inputSchema: z.object({
-      summary: z.string().describe("Summary/title of the event"),
-      calendar: z.string().optional().describe("Calendar to search in (searches all calendars if omitted)"),
-    }),
-  },
-  async ({ summary, calendar }) => {
-    try {
-      const event = await eventkit.getEvent(summary, calendar);
-      return { content: [{ type: "text", text: JSON.stringify(event, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
+  "search_events",
+] as const;
 
-// ---- create_event ----
-server.registerTool(
+const WRITE_TOOL_NAMES = [
   "create_event",
-  {
-    description: "Create a new event in a calendar",
-    inputSchema: z.object({
-      calendar: z.string().describe("Name of the calendar to add the event to"),
-      summary: z.string().describe("Title/summary of the event"),
-      start_date: z.string().describe("Start date and time (e.g. '15 March 2025 at 2:00 PM')"),
-      end_date: z.string().describe("End date and time (e.g. '15 March 2025 at 3:00 PM')"),
-      location: z.string().optional().describe("Location of the event"),
-      description: z.string().optional().describe("Description or notes for the event"),
-      all_day: z.boolean().optional().describe("Whether this is an all-day event"),
-      alert_minutes: z.union([z.number(), z.array(z.number())]).optional().describe("Minutes before event to send an alert, e.g. 30 for 30 min before, or [30, 120] for multiple alerts"),
-    }),
-  },
-  async ({ calendar, summary, start_date, end_date, location, description, all_day, alert_minutes }) => {
-    try {
-      const alertMinutes = alert_minutes === undefined ? undefined
-        : Array.isArray(alert_minutes) ? alert_minutes : [alert_minutes];
-      const result = await applescript.createEvent(calendar, summary, start_date, end_date, {
-        location,
-        description,
-        allDay: all_day,
-        alertMinutes,
-      });
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- update_event ----
-server.registerTool(
   "update_event",
-  {
-    description: "Update an existing calendar event's details",
-    inputSchema: z.object({
-      summary: z.string().describe("Current summary/title of the event to update"),
-      calendar: z.string().optional().describe("Calendar the event is in (searches all calendars if omitted)"),
-      new_summary: z.string().optional().describe("New title/summary for the event"),
-      start_date: z.string().optional().describe("New start date and time (e.g. '15 March 2025 at 2:00 PM')"),
-      end_date: z.string().optional().describe("New end date and time (e.g. '15 March 2025 at 3:00 PM')"),
-      location: z.string().optional().describe("New location"),
-      description: z.string().optional().describe("New description or notes"),
-      all_day: z.boolean().optional().describe("Whether this is an all-day event"),
-      alert_minutes: z.union([z.number(), z.array(z.number())]).optional().describe("Replace all alerts with these minutes-before values, e.g. 30 or [30, 120]. Pass an empty array [] to remove all alerts. Omit to leave alerts unchanged."),
-    }),
-  },
-  async ({ summary, calendar, new_summary, start_date, end_date, location, description, all_day, alert_minutes }) => {
-    try {
-      const alertMinutes = alert_minutes === undefined ? undefined
-        : Array.isArray(alert_minutes) ? alert_minutes : [alert_minutes];
-      const result = await applescript.updateEvent(summary, calendar, {
-        newSummary: new_summary,
-        startDate: start_date,
-        endDate: end_date,
-        location,
-        description,
-        allDay: all_day,
-        alertMinutes,
-      });
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
+] as const;
 
-if (!readOnly) {
-  // ---- delete_event ----
+const DESTRUCTIVE_TOOL_NAMES = ["delete_event"] as const;
+
+export function parseSafetyFlags(argv: string[] = process.argv): SafetyFlags {
+  return {
+    readOnly: argv.includes("--read-only"),
+    confirmDestructive: argv.includes("--confirm-destructive"),
+  };
+}
+
+export function getRegisteredToolNames(flags: SafetyFlags = parseSafetyFlags()): string[] {
+  return [
+    ...READ_TOOL_NAMES,
+    ...(flags.readOnly ? [] : WRITE_TOOL_NAMES),
+    ...(flags.readOnly ? [] : DESTRUCTIVE_TOOL_NAMES),
+  ];
+}
+
+export function requiresDestructiveConfirmation(flags: SafetyFlags = parseSafetyFlags()): boolean {
+  return !flags.readOnly && flags.confirmDestructive;
+}
+
+export function createServer(flags: SafetyFlags = parseSafetyFlags()): McpServer {
+  const { readOnly, confirmDestructive } = flags;
+  const server = new McpServer({
+    name: "apple-calendar",
+    version: "1.0.0",
+  });
+
+  // ---- list_calendars ----
   server.registerTool(
-    "delete_event",
+    "list_calendars",
     {
-      description: "Delete an event by its summary/title",
-      inputSchema: z.object({
-        summary: z.string().describe("Summary/title of the event to delete"),
-        calendar: z.string().optional().describe("Calendar the event is in (searches all calendars if omitted)"),
-        ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
-      }),
+      description: "List all calendars in Apple Calendar",
+      inputSchema: z.object({}),
     },
-    async ({ summary, calendar, confirm }: { summary: string; calendar?: string; confirm?: unknown }) => {
-      if (confirmDestructive && !confirm) {
-        return { content: [{ type: "text", text: "This will permanently delete the calendar event. Please confirm with the user, then call again with confirm: true." }] };
-      }
+    async () => {
       try {
-        const result = await applescript.deleteEvent(summary, calendar);
-        return { content: [{ type: "text", text: result }] };
+        const calendars = await eventkit.listCalendars();
+        return { content: [{ type: "text", text: JSON.stringify(calendars, null, 2) }] };
       } catch (err) {
         return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
       }
     }
   );
-}
 
-// ---- search_events ----
-server.registerTool(
-  "search_events",
-  {
-    description: "Search events by summary/title across calendars",
-    inputSchema: z.object({
-      query: z.string().describe("Text to search for in event summaries"),
-      calendar: z.string().optional().describe("Calendar to search in (searches all calendars if omitted)"),
-    }),
-  },
-  async ({ query, calendar }) => {
-    try {
-      const results = await eventkit.searchEvents(query, calendar);
-      return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+  // ---- list_all_events ----
+  server.registerTool(
+    "list_all_events",
+    {
+      description: "List events across ALL calendars within a date range. Use this instead of list_events when you need events from all calendars.",
+      inputSchema: z.object({
+        from_date: z.string().describe("Start date (e.g. '1 January 2025')"),
+        to_date: z.string().describe("End date (e.g. '31 January 2025')"),
+      }),
+    },
+    async ({ from_date, to_date }) => {
+      try {
+        const events = await eventkit.listAllEvents(from_date, to_date);
+        return { content: [{ type: "text", text: JSON.stringify(events, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
     }
+  );
+
+  // ---- list_events ----
+  server.registerTool(
+    "list_events",
+    {
+      description: "List events in a calendar within a date range",
+      inputSchema: z.object({
+        calendar: z.string().describe("Name of the calendar"),
+        from_date: z.string().describe("Start date (e.g. '1 January 2025')"),
+        to_date: z.string().describe("End date (e.g. '31 January 2025')"),
+      }),
+    },
+    async ({ calendar, from_date, to_date }) => {
+      try {
+        const events = await eventkit.listEvents(calendar, from_date, to_date);
+        return { content: [{ type: "text", text: JSON.stringify(events, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  // ---- get_event ----
+  server.registerTool(
+    "get_event",
+    {
+      description: "Get full details of an event by its summary/title",
+      inputSchema: z.object({
+        summary: z.string().describe("Summary/title of the event"),
+        calendar: z.string().optional().describe("Calendar to search in (searches all calendars if omitted)"),
+      }),
+    },
+    async ({ summary, calendar }) => {
+      try {
+        const event = await eventkit.getEvent(summary, calendar);
+        return { content: [{ type: "text", text: JSON.stringify(event, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  if (!readOnly) {
+    // ---- create_event ----
+    server.registerTool(
+      "create_event",
+      {
+        description: "Create a new event in a calendar",
+        inputSchema: z.object({
+          calendar: z.string().describe("Name of the calendar to add the event to"),
+          summary: z.string().describe("Title/summary of the event"),
+          start_date: z.string().describe("Start date and time (e.g. '15 March 2025 at 2:00 PM')"),
+          end_date: z.string().describe("End date and time (e.g. '15 March 2025 at 3:00 PM')"),
+          location: z.string().optional().describe("Location of the event"),
+          description: z.string().optional().describe("Description or notes for the event"),
+          all_day: z.boolean().optional().describe("Whether this is an all-day event"),
+          alert_minutes: z.union([z.number(), z.array(z.number())]).optional().describe("Minutes before event to send an alert, e.g. 30 for 30 min before, or [30, 120] for multiple alerts"),
+        }),
+      },
+      async ({ calendar, summary, start_date, end_date, location, description, all_day, alert_minutes }) => {
+        try {
+          const alertMinutes = alert_minutes === undefined
+            ? undefined
+            : Array.isArray(alert_minutes) ? alert_minutes : [alert_minutes];
+          const result = await applescript.createEvent(calendar, summary, start_date, end_date, {
+            location,
+            description,
+            allDay: all_day,
+            alertMinutes,
+          });
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- update_event ----
+    server.registerTool(
+      "update_event",
+      {
+        description: "Update an existing calendar event's details",
+        inputSchema: z.object({
+          summary: z.string().describe("Current summary/title of the event to update"),
+          calendar: z.string().optional().describe("Calendar the event is in (searches all calendars if omitted)"),
+          new_summary: z.string().optional().describe("New title/summary for the event"),
+          start_date: z.string().optional().describe("New start date and time (e.g. '15 March 2025 at 2:00 PM')"),
+          end_date: z.string().optional().describe("New end date and time (e.g. '15 March 2025 at 3:00 PM')"),
+          location: z.string().optional().describe("New location"),
+          description: z.string().optional().describe("New description or notes"),
+          all_day: z.boolean().optional().describe("Whether this is an all-day event"),
+          alert_minutes: z.union([z.number(), z.array(z.number())]).optional().describe("Replace all alerts with these minutes-before values, e.g. 30 or [30, 120]. Pass an empty array [] to remove all alerts. Omit to leave alerts unchanged."),
+        }),
+      },
+      async ({ summary, calendar, new_summary, start_date, end_date, location, description, all_day, alert_minutes }) => {
+        try {
+          const alertMinutes = alert_minutes === undefined
+            ? undefined
+            : Array.isArray(alert_minutes) ? alert_minutes : [alert_minutes];
+          const result = await applescript.updateEvent(summary, calendar, {
+            newSummary: new_summary,
+            startDate: start_date,
+            endDate: end_date,
+            location,
+            description,
+            allDay: all_day,
+            alertMinutes,
+          });
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- delete_event ----
+    server.registerTool(
+      "delete_event",
+      {
+        description: "Delete an event by its summary/title",
+        inputSchema: z.object({
+          summary: z.string().describe("Summary/title of the event to delete"),
+          calendar: z.string().optional().describe("Calendar the event is in (searches all calendars if omitted)"),
+          ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
+        }),
+      },
+      async ({ summary, calendar, confirm }: { summary: string; calendar?: string; confirm?: unknown }) => {
+        if (confirmDestructive && !confirm) {
+          return { content: [{ type: "text", text: "This will permanently delete the calendar event. Please confirm with the user, then call again with confirm: true." }] };
+        }
+        try {
+          const result = await applescript.deleteEvent(summary, calendar);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
   }
-);
+
+  // ---- search_events ----
+  server.registerTool(
+    "search_events",
+    {
+      description: "Search events by summary/title across calendars",
+      inputSchema: z.object({
+        query: z.string().describe("Text to search for in event summaries"),
+        calendar: z.string().optional().describe("Calendar to search in (searches all calendars if omitted)"),
+      }),
+    },
+    async ({ query, calendar }) => {
+      try {
+        const results = await eventkit.searchEvents(query, calendar);
+        return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  return server;
+}
 
 // ---- Start server ----
 async function main() {
   const transport = new StdioServerTransport();
-  await server.connect(transport);
+  await createServer().connect(transport);
   console.error("Apple Calendar MCP server running on stdio");
 }
 
-main().catch((err) => {
-  console.error("Fatal error:", err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/calendar/tests/safety.test.ts
+++ b/calendar/tests/safety.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { getRegisteredToolNames, requiresDestructiveConfirmation } from "../src/index.js";
+
+describe("safety flags", () => {
+  test("default mode registers all tools", () => {
+    expect(getRegisteredToolNames({ readOnly: false, confirmDestructive: false })).toEqual([
+      "list_calendars",
+      "list_all_events",
+      "list_events",
+      "get_event",
+      "search_events",
+      "create_event",
+      "update_event",
+      "delete_event",
+    ]);
+  });
+
+  test("read-only mode removes mutating tools", () => {
+    expect(getRegisteredToolNames({ readOnly: true, confirmDestructive: false })).toEqual([
+      "list_calendars",
+      "list_all_events",
+      "list_events",
+      "get_event",
+      "search_events",
+    ]);
+  });
+
+  test("confirm-destructive only gates delete_event", () => {
+    expect(requiresDestructiveConfirmation({ readOnly: false, confirmDestructive: true })).toBe(true);
+  });
+});

--- a/contacts/src/index.ts
+++ b/contacts/src/index.ts
@@ -4,270 +4,316 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import * as applescript from "./applescript.js";
 
-const readOnly = process.argv.includes("--read-only");
-const confirmDestructive = process.argv.includes("--confirm-destructive");
-
-const server = new McpServer({
-  name: "apple-contacts",
-  version: "1.0.0",
-});
-
-// ---- list_groups ----
-server.registerTool(
-  "list_groups",
-  {
-    description: "List all groups in Apple Contacts",
-    inputSchema: z.object({}),
-  },
-  async () => {
-    try {
-      const groups = await applescript.listGroups();
-      return { content: [{ type: "text", text: JSON.stringify(groups, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- list_contacts ----
-server.registerTool(
-  "list_contacts",
-  {
-    description: "List all contacts, optionally filtered by group",
-    inputSchema: z.object({
-      group: z.string().optional().describe("Group name to filter contacts (lists all if omitted)"),
-    }),
-  },
-  async ({ group }) => {
-    try {
-      const contacts = await applescript.listContacts(group);
-      return { content: [{ type: "text", text: JSON.stringify(contacts, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- get_contact ----
-server.registerTool(
-  "get_contact",
-  {
-    description: "Get full details of a contact by name including emails, phones, organization, and addresses",
-    inputSchema: z.object({
-      name: z.string().describe("Full name of the contact to retrieve"),
-    }),
-  },
-  async ({ name }) => {
-    try {
-      const contact = await applescript.getContact(name);
-      return { content: [{ type: "text", text: JSON.stringify(contact, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- search_contacts ----
-server.registerTool(
-  "search_contacts",
-  {
-    description: "Search contacts by name",
-    inputSchema: z.object({
-      query: z.string().describe("Text to search for in contact names"),
-    }),
-  },
-  async ({ query }) => {
-    try {
-      const results = await applescript.searchContacts(query);
-      return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- update_contact ----
-server.registerTool(
-  "update_contact",
-  {
-    description: "Update an existing contact's details. For email and phone, new entries are added (existing ones are not removed).",
-    inputSchema: z.object({
-      name: z.string().describe("Full name of the contact to update"),
-      first_name: z.string().optional().describe("New first name"),
-      last_name: z.string().optional().describe("New last name"),
-      email: z.string().optional().describe("Email address to add"),
-      phone: z.string().optional().describe("Phone number to add"),
-      organization: z.string().optional().describe("New company or organization"),
-      job_title: z.string().optional().describe("New job title"),
-      note: z.string().optional().describe("New note"),
-    }),
-  },
-  async ({ name, first_name, last_name, email, phone, organization, job_title, note }) => {
-    try {
-      const result = await applescript.updateContact(name, {
-        firstName: first_name,
-        lastName: last_name,
-        email,
-        phone,
-        organization,
-        jobTitle: job_title,
-        note,
-      });
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- create_contact ----
-server.registerTool(
-  "create_contact",
-  {
-    description: "Create a new contact in Apple Contacts",
-    inputSchema: z.object({
-      first_name: z.string().describe("First name of the contact"),
-      last_name: z.string().describe("Last name of the contact"),
-      email: z.string().optional().describe("Email address"),
-      phone: z.string().optional().describe("Phone number"),
-      organization: z.string().optional().describe("Company or organization"),
-      job_title: z.string().optional().describe("Job title"),
-      note: z.string().optional().describe("Note about the contact"),
-    }),
-  },
-  async ({ first_name, last_name, email, phone, organization, job_title, note }) => {
-    try {
-      const result = await applescript.createContact(first_name, last_name, {
-        email,
-        phone,
-        organization,
-        jobTitle: job_title,
-        note,
-      });
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-if (!readOnly) {
-  // ---- delete_contact ----
-  server.registerTool(
-    "delete_contact",
-    {
-      description: "Delete a contact by name",
-      inputSchema: z.object({
-        name: z.string().describe("Full name of the contact to delete"),
-        ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
-      }),
-    },
-    async ({ name, confirm }: { name: string; confirm?: unknown }) => {
-      if (confirmDestructive && !confirm) {
-        return { content: [{ type: "text", text: "This will permanently delete the contact. Please confirm with the user, then call again with confirm: true." }] };
-      }
-      try {
-        const result = await applescript.deleteContact(name);
-        return { content: [{ type: "text", text: result }] };
-      } catch (err) {
-        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-      }
-    }
-  );
+export interface SafetyFlags {
+  readOnly: boolean;
+  confirmDestructive: boolean;
 }
 
-// ---- create_group ----
-server.registerTool(
+const READ_TOOL_NAMES = [
+  "list_groups",
+  "list_contacts",
+  "get_contact",
+  "search_contacts",
+] as const;
+
+const WRITE_TOOL_NAMES = [
+  "update_contact",
+  "create_contact",
   "create_group",
-  {
-    description: "Create a new group in Apple Contacts",
-    inputSchema: z.object({
-      name: z.string().describe("Name of the group to create"),
-    }),
-  },
-  async ({ name }) => {
-    try {
-      const result = await applescript.createGroup(name);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- add_contact_to_group ----
-server.registerTool(
   "add_contact_to_group",
-  {
-    description: "Add an existing contact to a group",
-    inputSchema: z.object({
-      contact_name: z.string().describe("Full name of the contact"),
-      group_name: z.string().describe("Name of the group to add the contact to"),
-    }),
-  },
-  async ({ contact_name, group_name }) => {
-    try {
-      const result = await applescript.addContactToGroup(contact_name, group_name);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- remove_contact_from_group ----
-server.registerTool(
   "remove_contact_from_group",
-  {
-    description: "Remove a contact from a group",
-    inputSchema: z.object({
-      contact_name: z.string().describe("Full name of the contact"),
-      group_name: z.string().describe("Name of the group to remove the contact from"),
-    }),
-  },
-  async ({ contact_name, group_name }) => {
-    try {
-      const result = await applescript.removeContactFromGroup(contact_name, group_name);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
+] as const;
 
-if (!readOnly) {
-  // ---- delete_group ----
+const DESTRUCTIVE_TOOL_NAMES = [
+  "delete_contact",
+  "delete_group",
+] as const;
+
+export function parseSafetyFlags(argv: string[] = process.argv): SafetyFlags {
+  return {
+    readOnly: argv.includes("--read-only"),
+    confirmDestructive: argv.includes("--confirm-destructive"),
+  };
+}
+
+export function getRegisteredToolNames(flags: SafetyFlags = parseSafetyFlags()): string[] {
+  return [
+    ...READ_TOOL_NAMES,
+    ...(flags.readOnly ? [] : WRITE_TOOL_NAMES),
+    ...(flags.readOnly ? [] : DESTRUCTIVE_TOOL_NAMES),
+  ];
+}
+
+export function requiresDestructiveConfirmation(flags: SafetyFlags = parseSafetyFlags()): boolean {
+  return !flags.readOnly && flags.confirmDestructive;
+}
+
+export function createServer(flags: SafetyFlags = parseSafetyFlags()): McpServer {
+  const { readOnly, confirmDestructive } = flags;
+  const server = new McpServer({
+    name: "apple-contacts",
+    version: "1.0.0",
+  });
+
+  // ---- list_groups ----
   server.registerTool(
-    "delete_group",
+    "list_groups",
     {
-      description: "Delete a contact group",
-      inputSchema: z.object({
-        name: z.string().describe("Name of the group to delete"),
-        ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
-      }),
+      description: "List all groups in Apple Contacts",
+      inputSchema: z.object({}),
     },
-    async ({ name, confirm }: { name: string; confirm?: unknown }) => {
-      if (confirmDestructive && !confirm) {
-        return { content: [{ type: "text", text: "This will permanently delete the contact group. Please confirm with the user, then call again with confirm: true." }] };
-      }
+    async () => {
       try {
-        const result = await applescript.deleteGroup(name);
-        return { content: [{ type: "text", text: result }] };
+        const groups = await applescript.listGroups();
+        return { content: [{ type: "text", text: JSON.stringify(groups, null, 2) }] };
       } catch (err) {
         return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
       }
     }
   );
+
+  // ---- list_contacts ----
+  server.registerTool(
+    "list_contacts",
+    {
+      description: "List all contacts, optionally filtered by group",
+      inputSchema: z.object({
+        group: z.string().optional().describe("Group name to filter contacts (lists all if omitted)"),
+      }),
+    },
+    async ({ group }) => {
+      try {
+        const contacts = await applescript.listContacts(group);
+        return { content: [{ type: "text", text: JSON.stringify(contacts, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  // ---- get_contact ----
+  server.registerTool(
+    "get_contact",
+    {
+      description: "Get full details of a contact by name including emails, phones, organization, and addresses",
+      inputSchema: z.object({
+        name: z.string().describe("Full name of the contact to retrieve"),
+      }),
+    },
+    async ({ name }) => {
+      try {
+        const contact = await applescript.getContact(name);
+        return { content: [{ type: "text", text: JSON.stringify(contact, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  // ---- search_contacts ----
+  server.registerTool(
+    "search_contacts",
+    {
+      description: "Search contacts by name",
+      inputSchema: z.object({
+        query: z.string().describe("Text to search for in contact names"),
+      }),
+    },
+    async ({ query }) => {
+      try {
+        const results = await applescript.searchContacts(query);
+        return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  if (!readOnly) {
+    // ---- update_contact ----
+    server.registerTool(
+      "update_contact",
+      {
+        description: "Update an existing contact's details. For email and phone, new entries are added (existing ones are not removed).",
+        inputSchema: z.object({
+          name: z.string().describe("Full name of the contact to update"),
+          first_name: z.string().optional().describe("New first name"),
+          last_name: z.string().optional().describe("New last name"),
+          email: z.string().optional().describe("Email address to add"),
+          phone: z.string().optional().describe("Phone number to add"),
+          organization: z.string().optional().describe("New company or organization"),
+          job_title: z.string().optional().describe("New job title"),
+          note: z.string().optional().describe("New note"),
+        }),
+      },
+      async ({ name, first_name, last_name, email, phone, organization, job_title, note }) => {
+        try {
+          const result = await applescript.updateContact(name, {
+            firstName: first_name,
+            lastName: last_name,
+            email,
+            phone,
+            organization,
+            jobTitle: job_title,
+            note,
+          });
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- create_contact ----
+    server.registerTool(
+      "create_contact",
+      {
+        description: "Create a new contact in Apple Contacts",
+        inputSchema: z.object({
+          first_name: z.string().describe("First name of the contact"),
+          last_name: z.string().describe("Last name of the contact"),
+          email: z.string().optional().describe("Email address"),
+          phone: z.string().optional().describe("Phone number"),
+          organization: z.string().optional().describe("Company or organization"),
+          job_title: z.string().optional().describe("Job title"),
+          note: z.string().optional().describe("Note about the contact"),
+        }),
+      },
+      async ({ first_name, last_name, email, phone, organization, job_title, note }) => {
+        try {
+          const result = await applescript.createContact(first_name, last_name, {
+            email,
+            phone,
+            organization,
+            jobTitle: job_title,
+            note,
+          });
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- delete_contact ----
+    server.registerTool(
+      "delete_contact",
+      {
+        description: "Delete a contact by name",
+        inputSchema: z.object({
+          name: z.string().describe("Full name of the contact to delete"),
+          ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
+        }),
+      },
+      async ({ name, confirm }: { name: string; confirm?: unknown }) => {
+        if (confirmDestructive && !confirm) {
+          return { content: [{ type: "text", text: "This will permanently delete the contact. Please confirm with the user, then call again with confirm: true." }] };
+        }
+        try {
+          const result = await applescript.deleteContact(name);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- create_group ----
+    server.registerTool(
+      "create_group",
+      {
+        description: "Create a new group in Apple Contacts",
+        inputSchema: z.object({
+          name: z.string().describe("Name of the group to create"),
+        }),
+      },
+      async ({ name }) => {
+        try {
+          const result = await applescript.createGroup(name);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- add_contact_to_group ----
+    server.registerTool(
+      "add_contact_to_group",
+      {
+        description: "Add an existing contact to a group",
+        inputSchema: z.object({
+          contact_name: z.string().describe("Full name of the contact"),
+          group_name: z.string().describe("Name of the group to add the contact to"),
+        }),
+      },
+      async ({ contact_name, group_name }) => {
+        try {
+          const result = await applescript.addContactToGroup(contact_name, group_name);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- remove_contact_from_group ----
+    server.registerTool(
+      "remove_contact_from_group",
+      {
+        description: "Remove a contact from a group",
+        inputSchema: z.object({
+          contact_name: z.string().describe("Full name of the contact"),
+          group_name: z.string().describe("Name of the group to remove the contact from"),
+        }),
+      },
+      async ({ contact_name, group_name }) => {
+        try {
+          const result = await applescript.removeContactFromGroup(contact_name, group_name);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- delete_group ----
+    server.registerTool(
+      "delete_group",
+      {
+        description: "Delete a contact group",
+        inputSchema: z.object({
+          name: z.string().describe("Name of the group to delete"),
+          ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
+        }),
+      },
+      async ({ name, confirm }: { name: string; confirm?: unknown }) => {
+        if (confirmDestructive && !confirm) {
+          return { content: [{ type: "text", text: "This will permanently delete the contact group. Please confirm with the user, then call again with confirm: true." }] };
+        }
+        try {
+          const result = await applescript.deleteGroup(name);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+  }
+
+  return server;
 }
 
 // ---- Start server ----
 async function main() {
   const transport = new StdioServerTransport();
-  await server.connect(transport);
+  await createServer().connect(transport);
   console.error("Apple Contacts MCP server running on stdio");
 }
 
-main().catch((err) => {
-  console.error("Fatal error:", err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/contacts/tests/safety.test.ts
+++ b/contacts/tests/safety.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { getRegisteredToolNames, requiresDestructiveConfirmation } from "../src/index.js";
+
+describe("safety flags", () => {
+  test("default mode registers all tools", () => {
+    expect(getRegisteredToolNames({ readOnly: false, confirmDestructive: false })).toEqual([
+      "list_groups",
+      "list_contacts",
+      "get_contact",
+      "search_contacts",
+      "update_contact",
+      "create_contact",
+      "create_group",
+      "add_contact_to_group",
+      "remove_contact_from_group",
+      "delete_contact",
+      "delete_group",
+    ]);
+  });
+
+  test("read-only mode removes all mutating tools", () => {
+    expect(getRegisteredToolNames({ readOnly: true, confirmDestructive: false })).toEqual([
+      "list_groups",
+      "list_contacts",
+      "get_contact",
+      "search_contacts",
+    ]);
+  });
+
+  test("confirm-destructive only applies to deletes", () => {
+    expect(requiresDestructiveConfirmation({ readOnly: false, confirmDestructive: true })).toBe(true);
+  });
+});

--- a/mail/src/index.ts
+++ b/mail/src/index.ts
@@ -4,238 +4,292 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import * as applescript from "./applescript.js";
 
-const server = new McpServer({
-  name: "apple-mail",
-  version: "1.0.0",
-});
+export interface SafetyFlags {
+  readOnly: boolean;
+  confirmDestructive: boolean;
+}
 
-// ---- list_mailboxes ----
-server.registerTool(
+const READ_TOOL_NAMES = [
   "list_mailboxes",
-  {
-    description: "List all mailboxes across all accounts with unread counts",
-    inputSchema: z.object({}),
-  },
-  async () => {
-    try {
-      const mailboxes = await applescript.listMailboxes();
-      return { content: [{ type: "text", text: JSON.stringify(mailboxes, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- list_messages ----
-server.registerTool(
   "list_messages",
-  {
-    description: "List recent messages in a mailbox, optionally filtered to unread only",
-    inputSchema: z.object({
-      mailbox: z.string().describe("Name of the mailbox (e.g. 'INBOX')"),
-      account: z.string().describe("Name of the email account"),
-      limit: z.number().optional().describe("Maximum number of messages to return (default 25)"),
-      unread_only: z.boolean().optional().describe("When true, only return unread messages"),
-    }),
-  },
-  async ({ mailbox, account, limit, unread_only }) => {
-    try {
-      const messages = await applescript.listMessages(mailbox, account, limit, unread_only);
-      return { content: [{ type: "text", text: JSON.stringify(messages, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- get_message ----
-server.registerTool(
   "get_message",
-  {
-    description: "Get the full content of an email message by ID",
-    inputSchema: z.object({
-      mailbox: z.string().describe("Name of the mailbox"),
-      account: z.string().describe("Name of the email account"),
-      message_id: z.number().describe("ID of the message to retrieve"),
-    }),
-  },
-  async ({ mailbox, account, message_id }) => {
-    try {
-      const message = await applescript.getMessage(mailbox, account, message_id);
-      return { content: [{ type: "text", text: JSON.stringify(message, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- search_messages ----
-server.registerTool(
   "search_messages",
-  {
-    description: "Search emails by subject or sender across mailboxes",
-    inputSchema: z.object({
-      query: z.string().describe("Text to search for in email subjects or sender"),
-      mailbox: z.string().optional().describe("Mailbox to search in (searches all if omitted)"),
-      account: z.string().optional().describe("Account to search in (required if mailbox is specified)"),
-      limit: z.number().optional().describe("Maximum number of results (default 25)"),
-      search_field: z.enum(["subject", "sender"]).optional().describe("Field to search: 'subject' (default) or 'sender'"),
-    }),
-  },
-  async ({ query, mailbox, account, limit, search_field }) => {
-    try {
-      const results = await applescript.searchMessages(query, mailbox, account, limit, search_field);
-      return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- send_email ----
-server.registerTool(
-  "send_email",
-  {
-    description: "Send an email via Apple Mail",
-    inputSchema: z.object({
-      to: z.string().describe("Recipient email address (comma-separated for multiple recipients)"),
-      subject: z.string().describe("Email subject"),
-      body: z.string().describe("Email body text"),
-      cc: z.string().optional().describe("CC recipient email address (comma-separated for multiple)"),
-      bcc: z.string().optional().describe("BCC recipient email address (comma-separated for multiple)"),
-      from_account: z.string().optional().describe("Account to send from (uses default if omitted)"),
-    }),
-  },
-  async ({ to, subject, body, cc, bcc, from_account }) => {
-    try {
-      const result = await applescript.sendEmail(to, subject, body, {
-        cc,
-        bcc,
-        from: from_account,
-      });
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- get_unread_count ----
-server.registerTool(
   "get_unread_count",
-  {
-    description: "Get the unread email count for a mailbox or across all mailboxes",
-    inputSchema: z.object({
-      mailbox: z.string().optional().describe("Mailbox name (returns total across all if omitted)"),
-      account: z.string().optional().describe("Account name (required if mailbox is specified)"),
-    }),
-  },
-  async ({ mailbox, account }) => {
-    try {
-      const count = await applescript.getUnreadCount(mailbox, account);
-      return { content: [{ type: "text", text: JSON.stringify({ unread_count: count }, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
+] as const;
 
-// ---- move_message ----
-server.registerTool(
+const WRITE_TOOL_NAMES = [
+  "send_email",
   "move_message",
-  {
-    description: "Move an email message to a different mailbox",
-    inputSchema: z.object({
-      message_id: z.number().describe("ID of the message to move"),
-      from_mailbox: z.string().describe("Source mailbox name"),
-      from_account: z.string().describe("Source account name"),
-      to_mailbox: z.string().describe("Destination mailbox name"),
-      to_account: z.string().optional().describe("Destination account (same as source if omitted)"),
-    }),
-  },
-  async ({ message_id, from_mailbox, from_account, to_mailbox, to_account }) => {
-    try {
-      const result = await applescript.moveMessage(message_id, from_mailbox, from_account, to_mailbox, to_account);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- mark_read ----
-server.registerTool(
   "mark_read",
-  {
-    description: "Mark an email message as read or unread",
-    inputSchema: z.object({
-      message_id: z.number().describe("ID of the message"),
-      mailbox: z.string().describe("Mailbox the message is in"),
-      account: z.string().describe("Account the mailbox belongs to"),
-      read: z.boolean().describe("True to mark as read, false to mark as unread"),
-    }),
-  },
-  async ({ message_id, mailbox, account, read }) => {
-    try {
-      const result = await applescript.markRead(message_id, mailbox, account, read);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- delete_message ----
-server.registerTool(
-  "delete_message",
-  {
-    description: "Delete an email message (moves to trash)",
-    inputSchema: z.object({
-      message_id: z.number().describe("ID of the message to delete"),
-      mailbox: z.string().describe("Mailbox the message is in"),
-      account: z.string().describe("Account the mailbox belongs to"),
-    }),
-  },
-  async ({ message_id, mailbox, account }) => {
-    try {
-      const result = await applescript.deleteMessage(message_id, mailbox, account);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- flag_message ----
-server.registerTool(
   "flag_message",
-  {
-    description: "Flag or unflag an email message",
-    inputSchema: z.object({
-      message_id: z.number().describe("ID of the message to flag/unflag"),
-      mailbox: z.string().describe("Mailbox the message is in"),
-      account: z.string().describe("Account the mailbox belongs to"),
-      flagged: z.boolean().describe("True to flag, false to unflag"),
-    }),
-  },
-  async ({ message_id, mailbox, account, flagged }) => {
-    try {
-      const result = await applescript.flagMessage(message_id, mailbox, account, flagged);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+] as const;
+
+const DESTRUCTIVE_TOOL_NAMES = ["delete_message"] as const;
+
+export function parseSafetyFlags(argv: string[] = process.argv): SafetyFlags {
+  return {
+    readOnly: argv.includes("--read-only"),
+    confirmDestructive: argv.includes("--confirm-destructive"),
+  };
+}
+
+export function getRegisteredToolNames(flags: SafetyFlags = parseSafetyFlags()): string[] {
+  return [
+    ...READ_TOOL_NAMES,
+    ...(flags.readOnly ? [] : WRITE_TOOL_NAMES),
+    ...(flags.readOnly ? [] : DESTRUCTIVE_TOOL_NAMES),
+  ];
+}
+
+export function requiresDestructiveConfirmation(flags: SafetyFlags = parseSafetyFlags()): boolean {
+  return !flags.readOnly && flags.confirmDestructive;
+}
+
+export function createServer(flags: SafetyFlags = parseSafetyFlags()): McpServer {
+  const { readOnly, confirmDestructive } = flags;
+  const server = new McpServer({
+    name: "apple-mail",
+    version: "1.0.0",
+  });
+
+  // ---- list_mailboxes ----
+  server.registerTool(
+    "list_mailboxes",
+    {
+      description: "List all mailboxes across all accounts with unread counts",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      try {
+        const mailboxes = await applescript.listMailboxes();
+        return { content: [{ type: "text", text: JSON.stringify(mailboxes, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
     }
+  );
+
+  // ---- list_messages ----
+  server.registerTool(
+    "list_messages",
+    {
+      description: "List recent messages in a mailbox, optionally filtered to unread only",
+      inputSchema: z.object({
+        mailbox: z.string().describe("Name of the mailbox (e.g. 'INBOX')"),
+        account: z.string().describe("Name of the email account"),
+        limit: z.number().optional().describe("Maximum number of messages to return (default 25)"),
+        unread_only: z.boolean().optional().describe("When true, only return unread messages"),
+      }),
+    },
+    async ({ mailbox, account, limit, unread_only }) => {
+      try {
+        const messages = await applescript.listMessages(mailbox, account, limit, unread_only);
+        return { content: [{ type: "text", text: JSON.stringify(messages, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  // ---- get_message ----
+  server.registerTool(
+    "get_message",
+    {
+      description: "Get the full content of an email message by ID",
+      inputSchema: z.object({
+        mailbox: z.string().describe("Name of the mailbox"),
+        account: z.string().describe("Name of the email account"),
+        message_id: z.number().describe("ID of the message to retrieve"),
+      }),
+    },
+    async ({ mailbox, account, message_id }) => {
+      try {
+        const message = await applescript.getMessage(mailbox, account, message_id);
+        return { content: [{ type: "text", text: JSON.stringify(message, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  // ---- search_messages ----
+  server.registerTool(
+    "search_messages",
+    {
+      description: "Search emails by subject or sender across mailboxes",
+      inputSchema: z.object({
+        query: z.string().describe("Text to search for in email subjects or sender"),
+        mailbox: z.string().optional().describe("Mailbox to search in (searches all if omitted)"),
+        account: z.string().optional().describe("Account to search in (required if mailbox is specified)"),
+        limit: z.number().optional().describe("Maximum number of results (default 25)"),
+        search_field: z.enum(["subject", "sender"]).optional().describe("Field to search: 'subject' (default) or 'sender'"),
+      }),
+    },
+    async ({ query, mailbox, account, limit, search_field }) => {
+      try {
+        const results = await applescript.searchMessages(query, mailbox, account, limit, search_field);
+        return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  // ---- get_unread_count ----
+  server.registerTool(
+    "get_unread_count",
+    {
+      description: "Get the unread email count for a mailbox or across all mailboxes",
+      inputSchema: z.object({
+        mailbox: z.string().optional().describe("Mailbox name (returns total across all if omitted)"),
+        account: z.string().optional().describe("Account name (required if mailbox is specified)"),
+      }),
+    },
+    async ({ mailbox, account }) => {
+      try {
+        const count = await applescript.getUnreadCount(mailbox, account);
+        return { content: [{ type: "text", text: JSON.stringify({ unread_count: count }, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  if (!readOnly) {
+    // ---- send_email ----
+    server.registerTool(
+      "send_email",
+      {
+        description: "Send an email via Apple Mail",
+        inputSchema: z.object({
+          to: z.string().describe("Recipient email address (comma-separated for multiple recipients)"),
+          subject: z.string().describe("Email subject"),
+          body: z.string().describe("Email body text"),
+          cc: z.string().optional().describe("CC recipient email address (comma-separated for multiple)"),
+          bcc: z.string().optional().describe("BCC recipient email address (comma-separated for multiple)"),
+          from_account: z.string().optional().describe("Account to send from (uses default if omitted)"),
+        }),
+      },
+      async ({ to, subject, body, cc, bcc, from_account }) => {
+        try {
+          const result = await applescript.sendEmail(to, subject, body, {
+            cc,
+            bcc,
+            from: from_account,
+          });
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- move_message ----
+    server.registerTool(
+      "move_message",
+      {
+        description: "Move an email message to a different mailbox",
+        inputSchema: z.object({
+          message_id: z.number().describe("ID of the message to move"),
+          from_mailbox: z.string().describe("Source mailbox name"),
+          from_account: z.string().describe("Source account name"),
+          to_mailbox: z.string().describe("Destination mailbox name"),
+          to_account: z.string().optional().describe("Destination account (same as source if omitted)"),
+        }),
+      },
+      async ({ message_id, from_mailbox, from_account, to_mailbox, to_account }) => {
+        try {
+          const result = await applescript.moveMessage(message_id, from_mailbox, from_account, to_mailbox, to_account);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- mark_read ----
+    server.registerTool(
+      "mark_read",
+      {
+        description: "Mark an email message as read or unread",
+        inputSchema: z.object({
+          message_id: z.number().describe("ID of the message"),
+          mailbox: z.string().describe("Mailbox the message is in"),
+          account: z.string().describe("Account the mailbox belongs to"),
+          read: z.boolean().describe("True to mark as read, false to mark as unread"),
+        }),
+      },
+      async ({ message_id, mailbox, account, read }) => {
+        try {
+          const result = await applescript.markRead(message_id, mailbox, account, read);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- delete_message ----
+    server.registerTool(
+      "delete_message",
+      {
+        description: "Delete an email message (moves to trash)",
+        inputSchema: z.object({
+          message_id: z.number().describe("ID of the message to delete"),
+          mailbox: z.string().describe("Mailbox the message is in"),
+          account: z.string().describe("Account the mailbox belongs to"),
+          ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
+        }),
+      },
+      async ({ message_id, mailbox, account, confirm }: { message_id: number; mailbox: string; account: string; confirm?: unknown }) => {
+        if (confirmDestructive && !confirm) {
+          return { content: [{ type: "text", text: "This will move the email to trash. Please confirm with the user, then call again with confirm: true." }] };
+        }
+        try {
+          const result = await applescript.deleteMessage(message_id, mailbox, account);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- flag_message ----
+    server.registerTool(
+      "flag_message",
+      {
+        description: "Flag or unflag an email message",
+        inputSchema: z.object({
+          message_id: z.number().describe("ID of the message to flag/unflag"),
+          mailbox: z.string().describe("Mailbox the message is in"),
+          account: z.string().describe("Account the mailbox belongs to"),
+          flagged: z.boolean().describe("True to flag, false to unflag"),
+        }),
+      },
+      async ({ message_id, mailbox, account, flagged }) => {
+        try {
+          const result = await applescript.flagMessage(message_id, mailbox, account, flagged);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
   }
-);
+
+  return server;
+}
 
 // ---- Start server ----
 async function main() {
   const transport = new StdioServerTransport();
-  await server.connect(transport);
+  await createServer().connect(transport);
   console.error("Apple Mail MCP server running on stdio");
 }
 
-main().catch((err) => {
-  console.error("Fatal error:", err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/mail/tests/safety.test.ts
+++ b/mail/tests/safety.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { getRegisteredToolNames, requiresDestructiveConfirmation } from "../src/index.js";
+
+describe("safety flags", () => {
+  test("default mode registers all tools", () => {
+    expect(getRegisteredToolNames({ readOnly: false, confirmDestructive: false })).toEqual([
+      "list_mailboxes",
+      "list_messages",
+      "get_message",
+      "search_messages",
+      "get_unread_count",
+      "send_email",
+      "move_message",
+      "mark_read",
+      "flag_message",
+      "delete_message",
+    ]);
+  });
+
+  test("read-only mode removes write and destructive tools", () => {
+    expect(getRegisteredToolNames({ readOnly: true, confirmDestructive: false })).toEqual([
+      "list_mailboxes",
+      "list_messages",
+      "get_message",
+      "search_messages",
+      "get_unread_count",
+    ]);
+  });
+
+  test("confirm-destructive keeps delete_message registered and enables confirmation", () => {
+    expect(getRegisteredToolNames({ readOnly: false, confirmDestructive: true })).toEqual([
+      "list_mailboxes",
+      "list_messages",
+      "get_message",
+      "search_messages",
+      "get_unread_count",
+      "send_email",
+      "move_message",
+      "mark_read",
+      "flag_message",
+      "delete_message",
+    ]);
+    expect(requiresDestructiveConfirmation({ readOnly: false, confirmDestructive: true })).toBe(true);
+  });
+
+  test("read-only wins when both flags are set", () => {
+    expect(getRegisteredToolNames({ readOnly: true, confirmDestructive: true })).toEqual([
+      "list_mailboxes",
+      "list_messages",
+      "get_message",
+      "search_messages",
+      "get_unread_count",
+    ]);
+    expect(requiresDestructiveConfirmation({ readOnly: true, confirmDestructive: true })).toBe(false);
+  });
+});

--- a/messages/package.json
+++ b/messages/package.json
@@ -14,8 +14,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node build/index.js",
-    "test": "bun test tests/applescript.test.ts && node --experimental-strip-types --no-warnings --test tests/database.test.ts",
-    "test:clean": "bun test --bail tests/applescript.test.ts && node --experimental-strip-types --no-warnings --test tests/database.test.ts",
+    "test": "bun test tests/applescript.test.ts tests/safety.test.ts && node --experimental-strip-types --no-warnings --test tests/database.test.ts",
+    "test:clean": "bun test --bail tests/applescript.test.ts tests/safety.test.ts && node --experimental-strip-types --no-warnings --test tests/database.test.ts",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/messages/src/index.ts
+++ b/messages/src/index.ts
@@ -5,121 +5,158 @@ import { z } from "zod";
 import * as applescript from "./applescript.js";
 import * as database from "./database.js";
 
-const server = new McpServer({
-  name: "apple-messages",
-  version: "1.0.0",
-});
+export interface SafetyFlags {
+  readOnly: boolean;
+  confirmDestructive: boolean;
+}
 
-// ---- list_chats ----
-server.registerTool(
+const READ_TOOL_NAMES = [
   "list_chats",
-  {
-    description: "List recent chats with last message preview and participant info",
-    inputSchema: z.object({
-      limit: z.number().optional().describe("Maximum number of chats to return (default 50)"),
-    }),
-  },
-  async ({ limit }) => {
-    try {
-      const chats = database.listChats(limit);
-      return { content: [{ type: "text", text: JSON.stringify(chats, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- get_chat_messages ----
-server.registerTool(
   "get_chat_messages",
-  {
-    description: "Get message history for a specific chat",
-    inputSchema: z.object({
-      chat_id: z.string().describe("Chat identifier (e.g. iMessage;-;+1234567890)"),
-      limit: z.number().optional().describe("Maximum number of messages to return (default 100)"),
-      from_date: z.string().optional().describe("Filter messages from this date (e.g. '2025-01-01' or '2025-03-15T14:00:00')"),
-      to_date: z.string().optional().describe("Filter messages up to this date (e.g. '2025-12-31')"),
-    }),
-  },
-  async ({ chat_id, limit, from_date, to_date }) => {
-    try {
-      const messages = database.getChatMessages(chat_id, limit, from_date, to_date);
-      return { content: [{ type: "text", text: JSON.stringify(messages, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- search_messages ----
-server.registerTool(
   "search_messages",
-  {
-    description: "Search messages by text content",
-    inputSchema: z.object({
-      query: z.string().describe("Text to search for in messages"),
-      chat_id: z.string().optional().describe("Limit search to a specific chat"),
-      limit: z.number().optional().describe("Maximum number of results (default 50)"),
-    }),
-  },
-  async ({ query, chat_id, limit }) => {
-    try {
-      const results = database.searchMessages(query, chat_id, limit);
-      return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- send_message ----
-server.registerTool(
-  "send_message",
-  {
-    description: "Send an iMessage or SMS to a phone number or email address",
-    inputSchema: z.object({
-      to: z.string().describe("Phone number or email address of the recipient"),
-      text: z.string().describe("Message text to send"),
-      service: z.enum(["iMessage", "SMS"]).optional().describe("Service to use (default iMessage)"),
-    }),
-  },
-  async ({ to, text, service }) => {
-    try {
-      const result = await applescript.sendMessage(to, text, service);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- get_chat_participants ----
-server.registerTool(
   "get_chat_participants",
-  {
-    description: "Get participants of a chat",
-    inputSchema: z.object({
-      chat_id: z.string().describe("Chat identifier (e.g. iMessage;-;+1234567890)"),
-    }),
-  },
-  async ({ chat_id }) => {
-    try {
-      const participants = database.getChatParticipants(chat_id);
-      return { content: [{ type: "text", text: JSON.stringify(participants, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+] as const;
+
+const WRITE_TOOL_NAMES = ["send_message"] as const;
+
+export function parseSafetyFlags(argv: string[] = process.argv): SafetyFlags {
+  return {
+    readOnly: argv.includes("--read-only"),
+    confirmDestructive: argv.includes("--confirm-destructive"),
+  };
+}
+
+export function getRegisteredToolNames(flags: SafetyFlags = parseSafetyFlags()): string[] {
+  return [
+    ...READ_TOOL_NAMES,
+    ...(flags.readOnly ? [] : WRITE_TOOL_NAMES),
+  ];
+}
+
+export function createServer(flags: SafetyFlags = parseSafetyFlags()): McpServer {
+  const { readOnly } = flags;
+  const server = new McpServer({
+    name: "apple-messages",
+    version: "1.0.0",
+  });
+
+  // ---- list_chats ----
+  server.registerTool(
+    "list_chats",
+    {
+      description: "List recent chats with last message preview and participant info",
+      inputSchema: z.object({
+        limit: z.number().optional().describe("Maximum number of chats to return (default 50)"),
+      }),
+    },
+    async ({ limit }) => {
+      try {
+        const chats = database.listChats(limit);
+        return { content: [{ type: "text", text: JSON.stringify(chats, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
     }
+  );
+
+  // ---- get_chat_messages ----
+  server.registerTool(
+    "get_chat_messages",
+    {
+      description: "Get message history for a specific chat",
+      inputSchema: z.object({
+        chat_id: z.string().describe("Chat identifier (e.g. iMessage;-;+1234567890)"),
+        limit: z.number().optional().describe("Maximum number of messages to return (default 100)"),
+        from_date: z.string().optional().describe("Filter messages from this date (e.g. '2025-01-01' or '2025-03-15T14:00:00')"),
+        to_date: z.string().optional().describe("Filter messages up to this date (e.g. '2025-12-31')"),
+      }),
+    },
+    async ({ chat_id, limit, from_date, to_date }) => {
+      try {
+        const messages = database.getChatMessages(chat_id, limit, from_date, to_date);
+        return { content: [{ type: "text", text: JSON.stringify(messages, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  // ---- search_messages ----
+  server.registerTool(
+    "search_messages",
+    {
+      description: "Search messages by text content",
+      inputSchema: z.object({
+        query: z.string().describe("Text to search for in messages"),
+        chat_id: z.string().optional().describe("Limit search to a specific chat"),
+        limit: z.number().optional().describe("Maximum number of results (default 50)"),
+      }),
+    },
+    async ({ query, chat_id, limit }) => {
+      try {
+        const results = database.searchMessages(query, chat_id, limit);
+        return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  if (!readOnly) {
+    // ---- send_message ----
+    server.registerTool(
+      "send_message",
+      {
+        description: "Send an iMessage or SMS to a phone number or email address",
+        inputSchema: z.object({
+          to: z.string().describe("Phone number or email address of the recipient"),
+          text: z.string().describe("Message text to send"),
+          service: z.enum(["iMessage", "SMS"]).optional().describe("Service to use (default iMessage)"),
+        }),
+      },
+      async ({ to, text, service }) => {
+        try {
+          const result = await applescript.sendMessage(to, text, service);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
   }
-);
+
+  // ---- get_chat_participants ----
+  server.registerTool(
+    "get_chat_participants",
+    {
+      description: "Get participants of a chat",
+      inputSchema: z.object({
+        chat_id: z.string().describe("Chat identifier (e.g. iMessage;-;+1234567890)"),
+      }),
+    },
+    async ({ chat_id }) => {
+      try {
+        const participants = database.getChatParticipants(chat_id);
+        return { content: [{ type: "text", text: JSON.stringify(participants, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  return server;
+}
 
 // ---- Start server ----
 async function main() {
   const transport = new StdioServerTransport();
-  await server.connect(transport);
+  await createServer().connect(transport);
   console.error("Apple Messages MCP server running on stdio");
 }
 
-main().catch((err) => {
-  console.error("Fatal error:", err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/messages/tests/safety.test.ts
+++ b/messages/tests/safety.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { getRegisteredToolNames } from "../src/index.js";
+
+describe("safety flags", () => {
+  test("default mode registers read and write tools", () => {
+    expect(getRegisteredToolNames({ readOnly: false, confirmDestructive: false })).toEqual([
+      "list_chats",
+      "get_chat_messages",
+      "search_messages",
+      "get_chat_participants",
+      "send_message",
+    ]);
+  });
+
+  test("read-only mode removes send_message", () => {
+    expect(getRegisteredToolNames({ readOnly: true, confirmDestructive: false })).toEqual([
+      "list_chats",
+      "get_chat_messages",
+      "search_messages",
+      "get_chat_participants",
+    ]);
+  });
+});

--- a/notes/src/index.ts
+++ b/notes/src/index.ts
@@ -4,250 +4,300 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import * as applescript from "./applescript.js";
 
-const readOnly = process.argv.includes("--read-only");
-const confirmDestructive = process.argv.includes("--confirm-destructive");
-
-const server = new McpServer({
-  name: "apple-notes",
-  version: "1.0.0",
-});
-
-// ---- list_folders ----
-server.registerTool(
-  "list_folders",
-  {
-    description: "List all folders in Apple Notes",
-    inputSchema: z.object({}),
-  },
-  async () => {
-    try {
-      const folders = await applescript.listFolders();
-      return { content: [{ type: "text", text: JSON.stringify(folders, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- create_folder ----
-server.registerTool(
-  "create_folder",
-  {
-    description: "Create a new folder in Apple Notes",
-    inputSchema: z.object({
-      name: z.string().describe("Name of the folder to create"),
-    }),
-  },
-  async ({ name }) => {
-    try {
-      const result = await applescript.createFolder(name);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- list_notes ----
-server.registerTool(
-  "list_notes",
-  {
-    description: "List all notes in a specified Apple Notes folder",
-    inputSchema: z.object({
-      folder: z.string().describe("Name of the folder to list notes from"),
-    }),
-  },
-  async ({ folder }) => {
-    try {
-      const notes = await applescript.listNotes(folder);
-      return { content: [{ type: "text", text: JSON.stringify(notes, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- get_note ----
-server.registerTool(
-  "get_note",
-  {
-    description: "Get the full content of a specific note by title",
-    inputSchema: z.object({
-      title: z.string().describe("Title of the note to retrieve"),
-      folder: z.string().optional().describe("Folder to search in (searches all folders if omitted)"),
-    }),
-  },
-  async ({ title, folder }) => {
-    try {
-      const note = await applescript.getNote(title, folder);
-      return { content: [{ type: "text", text: JSON.stringify(note, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- create_note ----
-server.registerTool(
-  "create_note",
-  {
-    description: "Create a new note in a specified Apple Notes folder",
-    inputSchema: z.object({
-      title: z.string().describe("Title of the new note"),
-      body: z.string().describe("HTML body content of the note"),
-      folder: z.string().describe("Folder to create the note in"),
-    }),
-  },
-  async ({ title, body, folder }) => {
-    try {
-      const result = await applescript.createNote(title, body, folder);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- update_note ----
-server.registerTool(
-  "update_note",
-  {
-    description: "Update the body of an existing note",
-    inputSchema: z.object({
-      title: z.string().describe("Title of the note to update"),
-      body: z.string().describe("New HTML body content for the note"),
-      folder: z.string().optional().describe("Folder the note is in (searches all folders if omitted)"),
-    }),
-  },
-  async ({ title, body, folder }) => {
-    try {
-      const result = await applescript.updateNote(title, body, folder);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-if (!readOnly) {
-  // ---- delete_note ----
-  server.registerTool(
-    "delete_note",
-    {
-      description: "Delete a note from Apple Notes",
-      inputSchema: z.object({
-        title: z.string().describe("Title of the note to delete"),
-        folder: z.string().optional().describe("Folder the note is in (searches all folders if omitted)"),
-        ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
-      }),
-    },
-    async ({ title, folder, confirm }: { title: string; folder?: string; confirm?: unknown }) => {
-      if (confirmDestructive && !confirm) {
-        return { content: [{ type: "text", text: "This will permanently delete the note. Please confirm with the user, then call again with confirm: true." }] };
-      }
-      try {
-        const result = await applescript.deleteNote(title, folder);
-        return { content: [{ type: "text", text: result }] };
-      } catch (err) {
-        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-      }
-    }
-  );
-
-  // ---- delete_folder ----
-  server.registerTool(
-    "delete_folder",
-    {
-      description: "Delete a folder and all its notes from Apple Notes",
-      inputSchema: z.object({
-        name: z.string().describe("Name of the folder to delete"),
-        ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
-      }),
-    },
-    async ({ name, confirm }: { name: string; confirm?: unknown }) => {
-      if (confirmDestructive && !confirm) {
-        return { content: [{ type: "text", text: "This will permanently delete the folder and all notes inside it. Please confirm with the user, then call again with confirm: true." }] };
-      }
-      try {
-        const result = await applescript.deleteFolder(name);
-        return { content: [{ type: "text", text: result }] };
-      } catch (err) {
-        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-      }
-    }
-  );
+export interface SafetyFlags {
+  readOnly: boolean;
+  confirmDestructive: boolean;
 }
 
-// ---- move_note ----
-server.registerTool(
-  "move_note",
-  {
-    description: "Move a note from one folder to another",
-    inputSchema: z.object({
-      title: z.string().describe("Title of the note to move"),
-      from_folder: z.string().describe("Source folder name"),
-      to_folder: z.string().describe("Destination folder name"),
-    }),
-  },
-  async ({ title, from_folder, to_folder }) => {
-    try {
-      const result = await applescript.moveNote(title, from_folder, to_folder);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- append_to_note ----
-server.registerTool(
-  "append_to_note",
-  {
-    description: "Append HTML content to an existing note without replacing its body",
-    inputSchema: z.object({
-      title: z.string().describe("Title of the note to append to"),
-      content: z.string().describe("HTML content to append to the note"),
-      folder: z.string().optional().describe("Folder the note is in (searches all folders if omitted)"),
-    }),
-  },
-  async ({ title, content, folder }) => {
-    try {
-      const result = await applescript.appendToNote(title, content, folder);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- search_notes ----
-server.registerTool(
+const READ_TOOL_NAMES = [
+  "list_folders",
+  "list_notes",
+  "get_note",
   "search_notes",
-  {
-    description: "Search notes by keyword across all folders or within a specific folder. Searches both titles and body content.",
-    inputSchema: z.object({
-      query: z.string().describe("Search keyword to match against note titles and body content"),
-      folder: z.string().optional().describe("Folder to search in (searches all folders if omitted)"),
-    }),
-  },
-  async ({ query, folder }) => {
-    try {
-      const results = await applescript.searchNotes(query, folder);
-      return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+] as const;
+
+const WRITE_TOOL_NAMES = [
+  "create_folder",
+  "create_note",
+  "update_note",
+  "move_note",
+  "append_to_note",
+] as const;
+
+const DESTRUCTIVE_TOOL_NAMES = [
+  "delete_note",
+  "delete_folder",
+] as const;
+
+export function parseSafetyFlags(argv: string[] = process.argv): SafetyFlags {
+  return {
+    readOnly: argv.includes("--read-only"),
+    confirmDestructive: argv.includes("--confirm-destructive"),
+  };
+}
+
+export function getRegisteredToolNames(flags: SafetyFlags = parseSafetyFlags()): string[] {
+  return [
+    ...READ_TOOL_NAMES,
+    ...(flags.readOnly ? [] : WRITE_TOOL_NAMES),
+    ...(flags.readOnly ? [] : DESTRUCTIVE_TOOL_NAMES),
+  ];
+}
+
+export function requiresDestructiveConfirmation(flags: SafetyFlags = parseSafetyFlags()): boolean {
+  return !flags.readOnly && flags.confirmDestructive;
+}
+
+export function createServer(flags: SafetyFlags = parseSafetyFlags()): McpServer {
+  const { readOnly, confirmDestructive } = flags;
+  const server = new McpServer({
+    name: "apple-notes",
+    version: "1.0.0",
+  });
+
+  // ---- list_folders ----
+  server.registerTool(
+    "list_folders",
+    {
+      description: "List all folders in Apple Notes",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      try {
+        const folders = await applescript.listFolders();
+        return { content: [{ type: "text", text: JSON.stringify(folders, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
     }
+  );
+
+  if (!readOnly) {
+    // ---- create_folder ----
+    server.registerTool(
+      "create_folder",
+      {
+        description: "Create a new folder in Apple Notes",
+        inputSchema: z.object({
+          name: z.string().describe("Name of the folder to create"),
+        }),
+      },
+      async ({ name }) => {
+        try {
+          const result = await applescript.createFolder(name);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
   }
-);
+
+  // ---- list_notes ----
+  server.registerTool(
+    "list_notes",
+    {
+      description: "List all notes in a specified Apple Notes folder",
+      inputSchema: z.object({
+        folder: z.string().describe("Name of the folder to list notes from"),
+      }),
+    },
+    async ({ folder }) => {
+      try {
+        const notes = await applescript.listNotes(folder);
+        return { content: [{ type: "text", text: JSON.stringify(notes, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  // ---- get_note ----
+  server.registerTool(
+    "get_note",
+    {
+      description: "Get the full content of a specific note by title",
+      inputSchema: z.object({
+        title: z.string().describe("Title of the note to retrieve"),
+        folder: z.string().optional().describe("Folder to search in (searches all folders if omitted)"),
+      }),
+    },
+    async ({ title, folder }) => {
+      try {
+        const note = await applescript.getNote(title, folder);
+        return { content: [{ type: "text", text: JSON.stringify(note, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  if (!readOnly) {
+    // ---- create_note ----
+    server.registerTool(
+      "create_note",
+      {
+        description: "Create a new note in a specified Apple Notes folder",
+        inputSchema: z.object({
+          title: z.string().describe("Title of the new note"),
+          body: z.string().describe("HTML body content of the note"),
+          folder: z.string().describe("Folder to create the note in"),
+        }),
+      },
+      async ({ title, body, folder }) => {
+        try {
+          const result = await applescript.createNote(title, body, folder);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- update_note ----
+    server.registerTool(
+      "update_note",
+      {
+        description: "Update the body of an existing note",
+        inputSchema: z.object({
+          title: z.string().describe("Title of the note to update"),
+          body: z.string().describe("New HTML body content for the note"),
+          folder: z.string().optional().describe("Folder the note is in (searches all folders if omitted)"),
+        }),
+      },
+      async ({ title, body, folder }) => {
+        try {
+          const result = await applescript.updateNote(title, body, folder);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- delete_note ----
+    server.registerTool(
+      "delete_note",
+      {
+        description: "Delete a note from Apple Notes",
+        inputSchema: z.object({
+          title: z.string().describe("Title of the note to delete"),
+          folder: z.string().optional().describe("Folder the note is in (searches all folders if omitted)"),
+          ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
+        }),
+      },
+      async ({ title, folder, confirm }: { title: string; folder?: string; confirm?: unknown }) => {
+        if (confirmDestructive && !confirm) {
+          return { content: [{ type: "text", text: "This will permanently delete the note. Please confirm with the user, then call again with confirm: true." }] };
+        }
+        try {
+          const result = await applescript.deleteNote(title, folder);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- delete_folder ----
+    server.registerTool(
+      "delete_folder",
+      {
+        description: "Delete a folder and all its notes from Apple Notes",
+        inputSchema: z.object({
+          name: z.string().describe("Name of the folder to delete"),
+          ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
+        }),
+      },
+      async ({ name, confirm }: { name: string; confirm?: unknown }) => {
+        if (confirmDestructive && !confirm) {
+          return { content: [{ type: "text", text: "This will permanently delete the folder and all notes inside it. Please confirm with the user, then call again with confirm: true." }] };
+        }
+        try {
+          const result = await applescript.deleteFolder(name);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- move_note ----
+    server.registerTool(
+      "move_note",
+      {
+        description: "Move a note from one folder to another",
+        inputSchema: z.object({
+          title: z.string().describe("Title of the note to move"),
+          from_folder: z.string().describe("Source folder name"),
+          to_folder: z.string().describe("Destination folder name"),
+        }),
+      },
+      async ({ title, from_folder, to_folder }) => {
+        try {
+          const result = await applescript.moveNote(title, from_folder, to_folder);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- append_to_note ----
+    server.registerTool(
+      "append_to_note",
+      {
+        description: "Append HTML content to an existing note without replacing its body",
+        inputSchema: z.object({
+          title: z.string().describe("Title of the note to append to"),
+          content: z.string().describe("HTML content to append to the note"),
+          folder: z.string().optional().describe("Folder the note is in (searches all folders if omitted)"),
+        }),
+      },
+      async ({ title, content, folder }) => {
+        try {
+          const result = await applescript.appendToNote(title, content, folder);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+  }
+
+  // ---- search_notes ----
+  server.registerTool(
+    "search_notes",
+    {
+      description: "Search notes by keyword across all folders or within a specific folder. Searches both titles and body content.",
+      inputSchema: z.object({
+        query: z.string().describe("Search keyword to match against note titles and body content"),
+        folder: z.string().optional().describe("Folder to search in (searches all folders if omitted)"),
+      }),
+    },
+    async ({ query, folder }) => {
+      try {
+        const results = await applescript.searchNotes(query, folder);
+        return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  return server;
+}
 
 // ---- Start server ----
 async function main() {
   const transport = new StdioServerTransport();
-  await server.connect(transport);
+  await createServer().connect(transport);
   console.error("Apple Notes MCP server running on stdio");
 }
 
-main().catch((err) => {
-  console.error("Fatal error:", err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/notes/tests/safety.test.ts
+++ b/notes/tests/safety.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { getRegisteredToolNames, requiresDestructiveConfirmation } from "../src/index.js";
+
+describe("safety flags", () => {
+  test("default mode registers all tools", () => {
+    expect(getRegisteredToolNames({ readOnly: false, confirmDestructive: false })).toEqual([
+      "list_folders",
+      "list_notes",
+      "get_note",
+      "search_notes",
+      "create_folder",
+      "create_note",
+      "update_note",
+      "move_note",
+      "append_to_note",
+      "delete_note",
+      "delete_folder",
+    ]);
+  });
+
+  test("read-only mode keeps only read tools", () => {
+    expect(getRegisteredToolNames({ readOnly: true, confirmDestructive: false })).toEqual([
+      "list_folders",
+      "list_notes",
+      "get_note",
+      "search_notes",
+    ]);
+  });
+
+  test("confirm-destructive only affects destructive tools", () => {
+    expect(getRegisteredToolNames({ readOnly: false, confirmDestructive: true })).toEqual([
+      "list_folders",
+      "list_notes",
+      "get_note",
+      "search_notes",
+      "create_folder",
+      "create_note",
+      "update_note",
+      "move_note",
+      "append_to_note",
+      "delete_note",
+      "delete_folder",
+    ]);
+    expect(requiresDestructiveConfirmation({ readOnly: false, confirmDestructive: true })).toBe(true);
+  });
+});

--- a/reminders/src/index.ts
+++ b/reminders/src/index.ts
@@ -2,261 +2,311 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import * as applescript from "./applescript.js";
+import * as eventkit from "./eventkit.js";
 
-const readOnly = process.argv.includes("--read-only");
-const confirmDestructive = process.argv.includes("--confirm-destructive");
-
-const server = new McpServer({
-  name: "apple-reminders",
-  version: "1.0.0",
-});
-
-// ---- list_lists ----
-server.registerTool(
-  "list_lists",
-  {
-    description: "List all reminder lists in Apple Reminders",
-    inputSchema: z.object({}),
-  },
-  async () => {
-    try {
-      const lists = await applescript.listLists();
-      return { content: [{ type: "text", text: JSON.stringify(lists, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- create_list ----
-server.registerTool(
-  "create_list",
-  {
-    description: "Create a new reminder list",
-    inputSchema: z.object({
-      name: z.string().describe("Name of the list to create"),
-    }),
-  },
-  async ({ name }) => {
-    try {
-      const result = await applescript.createList(name);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- list_reminders ----
-server.registerTool(
-  "list_reminders",
-  {
-    description: "List reminders in a specific list",
-    inputSchema: z.object({
-      list: z.string().describe("Name of the reminder list"),
-      include_completed: z.boolean().optional().describe("Include completed reminders (default false)"),
-    }),
-  },
-  async ({ list, include_completed }) => {
-    try {
-      const reminders = await applescript.listReminders(list, include_completed);
-      return { content: [{ type: "text", text: JSON.stringify(reminders, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- get_reminder ----
-server.registerTool(
-  "get_reminder",
-  {
-    description: "Get full details of a reminder by name",
-    inputSchema: z.object({
-      name: z.string().describe("Name of the reminder to retrieve"),
-      list: z.string().optional().describe("List to search in (searches all lists if omitted)"),
-    }),
-  },
-  async ({ name, list }) => {
-    try {
-      const reminder = await applescript.getReminder(name, list);
-      return { content: [{ type: "text", text: JSON.stringify(reminder, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- create_reminder ----
-server.registerTool(
-  "create_reminder",
-  {
-    description: "Create a new reminder in a list",
-    inputSchema: z.object({
-      name: z.string().describe("Name of the reminder"),
-      list: z.string().describe("List to add the reminder to"),
-      body: z.string().optional().describe("Notes/body text for the reminder"),
-      due_date: z.string().optional().describe("Due date (e.g. 'March 15, 2025 at 2:00 PM')"),
-      priority: z.number().optional().describe("Priority: 0 (none), 1 (high), 5 (medium), 9 (low)"),
-    }),
-  },
-  async ({ name, list, body, due_date, priority }) => {
-    try {
-      const result = await applescript.createReminder(name, list, { body, dueDate: due_date, priority });
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- update_reminder ----
-server.registerTool(
-  "update_reminder",
-  {
-    description: "Update an existing reminder's details",
-    inputSchema: z.object({
-      name: z.string().describe("Name of the reminder to update"),
-      list: z.string().optional().describe("List the reminder is in (searches all lists if omitted)"),
-      new_name: z.string().optional().describe("New name for the reminder"),
-      body: z.string().optional().describe("New notes/body text"),
-      due_date: z.string().optional().describe("New due date (e.g. 'March 15, 2025 at 2:00 PM')"),
-      priority: z.number().optional().describe("New priority: 0 (none), 1 (high), 5 (medium), 9 (low)"),
-    }),
-  },
-  async ({ name, list, new_name, body, due_date, priority }) => {
-    try {
-      const result = await applescript.updateReminder(name, list, {
-        newName: new_name,
-        body,
-        dueDate: due_date,
-        priority,
-      });
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- complete_reminder ----
-server.registerTool(
-  "complete_reminder",
-  {
-    description: "Mark a reminder as completed",
-    inputSchema: z.object({
-      name: z.string().describe("Name of the reminder to complete"),
-      list: z.string().optional().describe("List the reminder is in (searches all lists if omitted)"),
-    }),
-  },
-  async ({ name, list }) => {
-    try {
-      const result = await applescript.completeReminder(name, list);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-// ---- uncomplete_reminder ----
-server.registerTool(
-  "uncomplete_reminder",
-  {
-    description: "Mark a completed reminder as incomplete",
-    inputSchema: z.object({
-      name: z.string().describe("Name of the reminder to uncomplete"),
-      list: z.string().optional().describe("List the reminder is in (searches all lists if omitted)"),
-    }),
-  },
-  async ({ name, list }) => {
-    try {
-      const result = await applescript.uncompleteReminder(name, list);
-      return { content: [{ type: "text", text: result }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-    }
-  }
-);
-
-if (!readOnly) {
-  // ---- delete_reminder ----
-  server.registerTool(
-    "delete_reminder",
-    {
-      description: "Delete a reminder",
-      inputSchema: z.object({
-        name: z.string().describe("Name of the reminder to delete"),
-        list: z.string().optional().describe("List the reminder is in (searches all lists if omitted)"),
-        ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
-      }),
-    },
-    async ({ name, list, confirm }: { name: string; list?: string; confirm?: unknown }) => {
-      if (confirmDestructive && !confirm) {
-        return { content: [{ type: "text", text: "This will permanently delete the reminder. Please confirm with the user, then call again with confirm: true." }] };
-      }
-      try {
-        const result = await applescript.deleteReminder(name, list);
-        return { content: [{ type: "text", text: result }] };
-      } catch (err) {
-        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-      }
-    }
-  );
-
-  // ---- delete_list ----
-  server.registerTool(
-    "delete_list",
-    {
-      description: "Delete a reminder list and all its reminders",
-      inputSchema: z.object({
-        name: z.string().describe("Name of the list to delete"),
-        ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
-      }),
-    },
-    async ({ name, confirm }: { name: string; confirm?: unknown }) => {
-      if (confirmDestructive && !confirm) {
-        return { content: [{ type: "text", text: "This will permanently delete the reminder list and all its reminders. Please confirm with the user, then call again with confirm: true." }] };
-      }
-      try {
-        const result = await applescript.deleteList(name);
-        return { content: [{ type: "text", text: result }] };
-      } catch (err) {
-        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
-      }
-    }
-  );
+export interface SafetyFlags {
+  readOnly: boolean;
+  confirmDestructive: boolean;
 }
 
-// ---- search_reminders ----
-server.registerTool(
+const READ_TOOL_NAMES = [
+  "list_lists",
+  "list_reminders",
+  "get_reminder",
   "search_reminders",
-  {
-    description: "Search reminders by name across all lists or within a specific list",
-    inputSchema: z.object({
-      query: z.string().describe("Text to search for in reminder names"),
-      list: z.string().optional().describe("List to search in (searches all lists if omitted)"),
-    }),
-  },
-  async ({ query, list }) => {
-    try {
-      const results = await applescript.searchReminders(query, list);
-      return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
-    } catch (err) {
-      return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+] as const;
+
+const WRITE_TOOL_NAMES = [
+  "create_list",
+  "create_reminder",
+  "update_reminder",
+  "complete_reminder",
+  "uncomplete_reminder",
+] as const;
+
+const DESTRUCTIVE_TOOL_NAMES = [
+  "delete_reminder",
+  "delete_list",
+] as const;
+
+export function parseSafetyFlags(argv: string[] = process.argv): SafetyFlags {
+  return {
+    readOnly: argv.includes("--read-only"),
+    confirmDestructive: argv.includes("--confirm-destructive"),
+  };
+}
+
+export function getRegisteredToolNames(flags: SafetyFlags = parseSafetyFlags()): string[] {
+  return [
+    ...READ_TOOL_NAMES,
+    ...(flags.readOnly ? [] : WRITE_TOOL_NAMES),
+    ...(flags.readOnly ? [] : DESTRUCTIVE_TOOL_NAMES),
+  ];
+}
+
+export function requiresDestructiveConfirmation(flags: SafetyFlags = parseSafetyFlags()): boolean {
+  return !flags.readOnly && flags.confirmDestructive;
+}
+
+export function createServer(flags: SafetyFlags = parseSafetyFlags()): McpServer {
+  const { readOnly, confirmDestructive } = flags;
+  const server = new McpServer({
+    name: "apple-reminders",
+    version: "1.0.0",
+  });
+
+  // ---- list_lists ----
+  server.registerTool(
+    "list_lists",
+    {
+      description: "List all reminder lists in Apple Reminders",
+      inputSchema: z.object({}),
+    },
+    async () => {
+      try {
+        const lists = await eventkit.listLists();
+        return { content: [{ type: "text", text: JSON.stringify(lists, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
     }
+  );
+
+  if (!readOnly) {
+    // ---- create_list ----
+    server.registerTool(
+      "create_list",
+      {
+        description: "Create a new reminder list",
+        inputSchema: z.object({
+          name: z.string().describe("Name of the list to create"),
+        }),
+      },
+      async ({ name }) => {
+        try {
+          const result = await eventkit.createList(name);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
   }
-);
+
+  // ---- list_reminders ----
+  server.registerTool(
+    "list_reminders",
+    {
+      description: "List reminders in a specific list",
+      inputSchema: z.object({
+        list: z.string().describe("Name of the reminder list"),
+        include_completed: z.boolean().optional().describe("Include completed reminders (default false)"),
+      }),
+    },
+    async ({ list, include_completed }) => {
+      try {
+        const reminders = await eventkit.listReminders(list, include_completed);
+        return { content: [{ type: "text", text: JSON.stringify(reminders, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  // ---- get_reminder ----
+  server.registerTool(
+    "get_reminder",
+    {
+      description: "Get full details of a reminder by name",
+      inputSchema: z.object({
+        name: z.string().describe("Name of the reminder to retrieve"),
+        list: z.string().optional().describe("List to search in (searches all lists if omitted)"),
+      }),
+    },
+    async ({ name, list }) => {
+      try {
+        const reminder = await eventkit.getReminder(name, list);
+        return { content: [{ type: "text", text: JSON.stringify(reminder, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  if (!readOnly) {
+    // ---- create_reminder ----
+    server.registerTool(
+      "create_reminder",
+      {
+        description: "Create a new reminder in a list",
+        inputSchema: z.object({
+          name: z.string().describe("Name of the reminder"),
+          list: z.string().describe("List to add the reminder to"),
+          body: z.string().optional().describe("Notes/body text for the reminder"),
+          due_date: z.string().optional().describe("Due date (e.g. 'March 15, 2025 at 2:00 PM')"),
+          priority: z.number().optional().describe("Priority: 0 (none), 1 (high), 5 (medium), 9 (low)"),
+        }),
+      },
+      async ({ name, list, body, due_date, priority }) => {
+        try {
+          const result = await eventkit.createReminder(name, list, { body, dueDate: due_date, priority });
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- update_reminder ----
+    server.registerTool(
+      "update_reminder",
+      {
+        description: "Update an existing reminder's details",
+        inputSchema: z.object({
+          name: z.string().describe("Name of the reminder to update"),
+          list: z.string().optional().describe("List the reminder is in (searches all lists if omitted)"),
+          new_name: z.string().optional().describe("New name for the reminder"),
+          body: z.string().optional().describe("New notes/body text"),
+          due_date: z.string().optional().describe("New due date (e.g. 'March 15, 2025 at 2:00 PM')"),
+          priority: z.number().optional().describe("New priority: 0 (none), 1 (high), 5 (medium), 9 (low)"),
+        }),
+      },
+      async ({ name, list, new_name, body, due_date, priority }) => {
+        try {
+          const result = await eventkit.updateReminder(name, list, {
+            newName: new_name,
+            body,
+            dueDate: due_date,
+            priority,
+          });
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- complete_reminder ----
+    server.registerTool(
+      "complete_reminder",
+      {
+        description: "Mark a reminder as completed",
+        inputSchema: z.object({
+          name: z.string().describe("Name of the reminder to complete"),
+          list: z.string().optional().describe("List the reminder is in (searches all lists if omitted)"),
+        }),
+      },
+      async ({ name, list }) => {
+        try {
+          const result = await eventkit.completeReminder(name, list);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- uncomplete_reminder ----
+    server.registerTool(
+      "uncomplete_reminder",
+      {
+        description: "Mark a completed reminder as incomplete",
+        inputSchema: z.object({
+          name: z.string().describe("Name of the reminder to uncomplete"),
+          list: z.string().optional().describe("List the reminder is in (searches all lists if omitted)"),
+        }),
+      },
+      async ({ name, list }) => {
+        try {
+          const result = await eventkit.uncompleteReminder(name, list);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- delete_reminder ----
+    server.registerTool(
+      "delete_reminder",
+      {
+        description: "Delete a reminder",
+        inputSchema: z.object({
+          name: z.string().describe("Name of the reminder to delete"),
+          list: z.string().optional().describe("List the reminder is in (searches all lists if omitted)"),
+          ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
+        }),
+      },
+      async ({ name, list, confirm }: { name: string; list?: string; confirm?: unknown }) => {
+        if (confirmDestructive && !confirm) {
+          return { content: [{ type: "text", text: "This will permanently delete the reminder. Please confirm with the user, then call again with confirm: true." }] };
+        }
+        try {
+          const result = await eventkit.deleteReminder(name, list);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+
+    // ---- delete_list ----
+    server.registerTool(
+      "delete_list",
+      {
+        description: "Delete a reminder list and all its reminders",
+        inputSchema: z.object({
+          name: z.string().describe("Name of the list to delete"),
+          ...(confirmDestructive ? { confirm: z.boolean().optional().describe("Set to true to confirm this destructive action") } : {}),
+        }),
+      },
+      async ({ name, confirm }: { name: string; confirm?: unknown }) => {
+        if (confirmDestructive && !confirm) {
+          return { content: [{ type: "text", text: "This will permanently delete the reminder list and all its reminders. Please confirm with the user, then call again with confirm: true." }] };
+        }
+        try {
+          const result = await eventkit.deleteList(name);
+          return { content: [{ type: "text", text: result }] };
+        } catch (err) {
+          return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+        }
+      }
+    );
+  }
+
+  // ---- search_reminders ----
+  server.registerTool(
+    "search_reminders",
+    {
+      description: "Search reminders by name across all lists or within a specific list",
+      inputSchema: z.object({
+        query: z.string().describe("Text to search for in reminder names"),
+        list: z.string().optional().describe("List to search in (searches all lists if omitted)"),
+      }),
+    },
+    async ({ query, list }) => {
+      try {
+        const results = await eventkit.searchReminders(query, list);
+        return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${(err as Error).message}` }], isError: true };
+      }
+    }
+  );
+
+  return server;
+}
 
 // ---- Start server ----
 async function main() {
   const transport = new StdioServerTransport();
-  await server.connect(transport);
+  await createServer().connect(transport);
   console.error("Apple Reminders MCP server running on stdio");
 }
 
-main().catch((err) => {
-  console.error("Fatal error:", err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/reminders/tests/safety.test.ts
+++ b/reminders/tests/safety.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { getRegisteredToolNames, requiresDestructiveConfirmation } from "../src/index.js";
+
+describe("safety flags", () => {
+  test("default mode registers all tools", () => {
+    expect(getRegisteredToolNames({ readOnly: false, confirmDestructive: false })).toEqual([
+      "list_lists",
+      "list_reminders",
+      "get_reminder",
+      "search_reminders",
+      "create_list",
+      "create_reminder",
+      "update_reminder",
+      "complete_reminder",
+      "uncomplete_reminder",
+      "delete_reminder",
+      "delete_list",
+    ]);
+  });
+
+  test("read-only mode removes all mutating tools", () => {
+    expect(getRegisteredToolNames({ readOnly: true, confirmDestructive: false })).toEqual([
+      "list_lists",
+      "list_reminders",
+      "get_reminder",
+      "search_reminders",
+    ]);
+  });
+
+  test("confirm-destructive still exposes non-destructive writes", () => {
+    expect(getRegisteredToolNames({ readOnly: false, confirmDestructive: true })).toEqual([
+      "list_lists",
+      "list_reminders",
+      "get_reminder",
+      "search_reminders",
+      "create_list",
+      "create_reminder",
+      "update_reminder",
+      "complete_reminder",
+      "uncomplete_reminder",
+      "delete_reminder",
+      "delete_list",
+    ]);
+    expect(requiresDestructiveConfirmation({ readOnly: false, confirmDestructive: true })).toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed
  This PR makes the documented safety-flag behavior consistent across the Apple MCP servers that support mutating operations.

  It aligns `mail`, `messages`, `notes`, `contacts`, `reminders`, and `calendar` so that:
  - `--read-only` registers only read tools and removes all mutating tools
  - `--confirm-destructive` adds a `confirm: true` gate only to destructive tools
  - `mail` and `messages` now participate in the same safety model as the other servers

  It also updates the root README so the public safety-mode contract matches the implementation, including Mail's destructive tool coverage.

  ## Why it changed
  The repo README advertised a repo-wide safety model, but the implementation was inconsistent:
  - `mail` and `messages` did not parse the safety flags at all
  - several other servers still exposed non-destructive write tools in `--read-only` mode

  That mismatch creates a real trust problem because users can believe a server is read-only when it still exposes mutating tools.

  ## Impact
  Users can now rely on a consistent safety model across the touched servers.

  This is especially useful for agents operating over personal data, where `--read-only` should genuinely remove write capability and `--confirm-destructive` should behave predictably.

  ## Root cause
  The safety behavior had evolved independently in each server package, and the implementations drifted away from the README contract.

  ## Validation
  I validated the change with:
  - `npm run build` in `mail`
  - `npm run build` in `messages`
  - `npm run build` in `notes`
  - `npm run build` in `contacts`
  - `npm run build` in `reminders`
  - `npm run build` in `calendar`
  - a Node-based runtime check against the built modules to confirm default mode, `--read-only`, and destructive confirmation behavior across all six packages

  I also added focused safety tests for each touched server package.

  ## Notes
  `bun test` was not run in this environment because `bun` is not installed on this machine.