### PR TITLE
fix(notes): preserve the note title when updating body content

### DIFF
--- a/notes/src/applescript.ts
+++ b/notes/src/applescript.ts
@@ -137,9 +137,39 @@ end tell`;
   return runAppleScript(script);
 }
 
+/**
+ * Apple Notes derives a note's NAME from the first line of its BODY, so
+ * `set body of n to <content>` does not merely replace content -- it silently
+ * RENAMES the note whenever the new body does not lead with the existing title.
+ *
+ * createNote is unaffected: it sets `name` explicitly alongside `body`.
+ * updateNote sets only `body`, so a caller that sends new content without
+ * repeating the title as the first line loses the title. Observed against a
+ * note called "Grocery List" whose name was replaced by whatever text happened
+ * to lead the updated body.
+ *
+ * tests/applescript.test.ts already documents the coupling -- its fixtures keep
+ * the title in an <h1> "to preserve it after updates" -- but that only protects
+ * callers who remember to do it. This moves the guarantee into updateNote.
+ *
+ * Prepending the title when it is absent keeps name and body consistent the way
+ * Notes itself models them. Setting `name` after the body would instead let the
+ * name and the visible first line diverge.
+ *
+ * Exported because it is pure, so it can be unit-tested without touching a real
+ * Notes database.
+ */
+export function bodyPreservingTitle(title: string, body: string): string {
+  const leadingText = body.replace(/<[^>]*>/g, "").trimStart();
+  if (leadingText.startsWith(title.trim())) {
+    return body;
+  }
+  return `<h1>${title}</h1>${body}`;
+}
+
 export async function updateNote(title: string, body: string, folder?: string): Promise<string> {
   const safeTitle = sanitize(title);
-  const safeBody = sanitize(body);
+  const safeBody = sanitize(bodyPreservingTitle(title, body));
   let scope: string;
   if (folder) {
     const safeFolder = sanitize(folder);


### PR DESCRIPTION
### The problem

Apple Notes derives a note's **name from the first line of its body**. `updateNote` sets only the body:

```applescript
set body of n to "${safeBody}"
```

so it does not merely replace content — it silently **renames the note** whenever the new body does not lead with the existing title.

`createNote` is unaffected, because it sets `name` explicitly alongside `body`:

```applescript
make new note at theFolder with properties {name:"${safeTitle}", body:"${safeBody}"}
```

I hit this repeatedly against a note called "Grocery List": routine content updates renamed it to whatever text happened to lead the new body, and the title had to be repaired by hand afterwards.

### Why the tests don't catch it

`tests/applescript.test.ts` already documents the coupling, and works around it in its fixtures:

```ts
// Apple Notes derives the note name from the body's first line,
// so we keep the title as an <h1> to preserve it after updates.
const updatedBody = `<h1>${title}</h1><p>Updated content</p>`;
```

That protects callers who remember to do it. Any caller who sends content alone loses the title.

### The change

A small pure helper that prepends the title when the body does not already lead with it, applied in `updateNote`:

```ts
const safeBody = sanitize(bodyPreservingTitle(title, body));
```

A body that already carries its title — the `<h1>` shape the tests use, or plain text — is returned untouched, so existing callers see no behaviour change.

I chose prepending over `set name of n to ...` after the body deliberately: setting the name keeps name and visible first line able to diverge, which looks fixed while reading wrong. Prepending keeps the two consistent the way Notes itself models them.

`bodyPreservingTitle` is exported because it is pure, so it can be unit-tested without touching a real Notes database.

### Testing

Verified against the compiled output: a content-only update prepends the title; an already-titled body is returned byte-identical; the result leads with the title in every branch, including an empty body and a body whose leading text belongs to a different note.

I did not run the integration suite in `tests/`, since it creates and deletes notes in a real Notes folder on the machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHDtMo5h9oAUMrYjfRL5ae
